### PR TITLE
Fix duplicate shebang in mcp-server bundle.cjs (Glama deploy)

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { startStdioServer } from "./server.js";
 
 function printHelp(): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3876,7 +3876,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.9.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4252,7 +4252,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
## Summary

Glama's deploy of the schema-only Docker image was crashing at runtime with:
```
/app/mcp-server/dist/bundle.cjs:2
#!/usr/bin/env node
^
SyntaxError: Invalid or unexpected token
```

Cause: `src/index.ts` had a `#!/usr/bin/env node` shebang AND `esbuild.config.mjs` prepended one via `banner.js`. esbuild preserved both. Node strips line 1 as a shebang (special-cased) but then sees `#` on line 2 as an actual token → SyntaxError.

## Fix

Remove the shebang from `src/index.ts`. esbuild's banner remains the single source of truth for the bundled bin entry's shebang. Effect on `dist/bundle.cjs`:

Before:
```
#!/usr/bin/env node
#!/usr/bin/env node
"use strict";
```

After:
```
#!/usr/bin/env node
"use strict";
var __create = ...
```

## Verified

- `pnpm build` produces a clean bundle.cjs (3.5MB, same as before)
- Stdio MCP smoke test: `initialize` returns `serverInfo.name="cel"`, `tools/list` returns all 4 tools
- preflight-cellar-oss.sh remains green (Rust Linux + CodeQL no new alerts)

## Glama deploy form values (unchanged from PR #29 description)

- **Node.js version**: `22`
- **Build steps**: `["pnpm install --frozen-lockfile --ignore-scripts", "pnpm --filter @dpagk/cellar-mcp build"]`
- **CMD args**: `["node", "mcp-server/dist/bundle.cjs"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)