### PR TITLE
Improve cel_perceive tool description for Glama TDQS A grade

### DIFF
--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -283,24 +283,41 @@ export function createCelMcpServer(cel?: Cel): McpServer {
     {
       title: "CEL Perceive",
       description:
-        "Always-on perception engine (Cortex). Maintains a continuously-updated " +
-        "mental model via background event streams with periodic accessibility tree refreshes " +
-        "on significant changes, and vision/screenshots when flagged as needed.\n\n" +
-        "IMPORTANT: Singleton — only one perception session can be active at a time. " +
-        "cel_see 'watch' mode is unavailable during an active session.\n\n" +
+        "Stateful perception engine (Cortex). Replaces repeated cel_see polling with a warm, " +
+        "continuously-updated mental model that ingests accessibility events in the background " +
+        "and surfaces diffs, anomalies, and stability signals on demand.\n\n" +
+        "When to use: any task that takes more than 3 observations OR that needs to detect " +
+        "side effects between actions (modals appearing, focus shifts, stale state). For one-shot " +
+        "reads or simple act→verify cycles, prefer cel_see — it's lighter and doesn't require a session.\n\n" +
+        "Lifecycle: start → (read | feed | checkpoint | configure | status)* → stop. The session is " +
+        "a singleton — only one cortex can run at a time, and cel_see 'watch' mode is unavailable " +
+        "while active. Always pair start with stop to flush the run summary and free the cortex.\n\n" +
         "Modes:\n" +
-        "- start: Boot the cortex with a goal. Set enable_suggestions=true (default) " +
-        "for LLM-powered next-action recommendations on each read.\n" +
-        "- read: Get the mental model snapshot (instant — model is kept warm by background events).\n" +
-        "- feed: Report an action you took (action, target, expected outcome). " +
-        "Cortex waits for screen to settle, diffs against current model, returns verification.\n" +
-        "- checkpoint: Summarize completed work and reset action history. Use between phases of multi-step tasks.\n" +
-        "- configure: Update goal or enable_suggestions mid-session.\n" +
-        "- status: Cortex health — confidence score, uptime, cycle count, " +
-        "element counts (stable vs volatile), temporal state (loading, errors, focus trail).\n" +
-        "- stop: Shutdown the cortex and get a summary.\n\n" +
-        "The model includes temporal awareness (loading states, error persistence, " +
-        "focus trail) and element stability classification (stable vs volatile targets).",
+        "- start: Open a session with a natural-language goal. Cortex parses constraints from the " +
+        "goal (factual / action / navigation / verification), boots its event listeners, and primes " +
+        "the model. Optional enable_suggestions=true (default) generates LLM next-action hints on " +
+        "each read; disable for passive observation to save tokens.\n" +
+        "- read: Return the current mental-model snapshot. Instant — the model is kept warm by " +
+        "background events. Output: stable elements, volatile elements, focus trail, recent diffs, " +
+        "anomalies, optional next-action suggestions, constraint-satisfaction state.\n" +
+        "- feed: Report an action you just executed (action verb, target id/description, expected " +
+        "outcome). Cortex waits for the screen to settle, diffs against the prior model, and returns " +
+        "{landed, anomalies, side_effects} so the host can decide whether to retry or proceed.\n" +
+        "- checkpoint: Record a one-paragraph progress summary and reset the recent-actions log. " +
+        "Use at natural phase boundaries — login complete, form filled, file saved — so subsequent " +
+        "reads anchor on the right context window.\n" +
+        "- configure: Mid-session adjustments. Replace goal (re-extracts constraints, preserves " +
+        "satisfied ones by text match) or toggle enable_suggestions without dropping the session.\n" +
+        "- status: Cortex telemetry — confidence score, uptime, cycle count, stable/volatile " +
+        "element counts, temporal flags (is_loading, has_errors), focus trail. Use for health " +
+        "checks or to inspect why suggestions look off.\n" +
+        "- stop: End the session and emit a run summary (actions taken, checkpoints, final " +
+        "constraint satisfaction). Idempotent — safe to call from cleanup paths.\n\n" +
+        "Cost model: read is free (memoized); feed pays one a11y diff (~50ms); start/configure pay " +
+        "one LLM call to extract constraints when enable_suggestions=true; stop is free.\n\n" +
+        "Cross-tool rules: cel_see 'watch' mode is blocked during an active session — use perceive " +
+        "read instead. cel_act calls do NOT auto-feed Cortex; you must explicitly call feed after " +
+        "each action group for diff tracking to work.",
       inputSchema: celPerceiveSchema,
     },
     degraded ? stubHandler : async (args) => handleCelPerceive(instance, args),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3876,7 +3876,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.9.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4252,7 +4252,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
## Summary

cel_perceive was the weakest of the 4 tools on Glama's Tool Definition Quality scoring (lowest 2.4/5 vs avg 4.1/5 → grade B). Its top-level description was a mode list with a brief opening, missing the structural elements the other 3 tools all had.

## Rewrite covers the 6 TDQS dimensions

- **purpose_clarity** — opening sentence states what it IS (stateful perception engine, replaces polling) not just what it does
- **usage_guidelines** — explicit when-to-use rule vs cel_see (>3 observations OR side-effect detection)
- **behavioral_transparency** — per-mode block describes purpose + behavior + output structure
- **parameter_semantics** — already addressed in the prior cel-perceive.ts schema rewrite
- **conciseness_structure** — sectioned: When to use / Lifecycle / Modes / Cost / Cross-tool
- **contextual_completeness** — explicit cross-tool rules (watch-mode collision, feed-not-auto)

Plus a cost model section so callers can predict latency / token spend.

## Math

Currently `0.6 × mean(4.1) + 0.4 × min(2.4) = 3.42` → B (threshold A ≥ 3.5).
Pulling the floor from 2.4 → ~4.0 with similar mean → `0.6 × 4.5 + 0.4 × 4.0 = 4.3` → A.

## Verified

`preflight-cellar-oss.sh` clean: Rust Linux + CodeQL no new alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)