### PR TITLE
feat(mcp): expose screenshots as resources

### DIFF
--- a/agent/src/cel-bindings.ts
+++ b/agent/src/cel-bindings.ts
@@ -116,8 +116,10 @@ export interface CelNative {
   axRequestPermission(): boolean;
   getContext(): string;
   captureScreen(): Buffer;
+  captureWindow(windowId: number): Buffer;
   listMonitors(): string;
   listWindows(): string;
+  listCaptureWindows(): string;
   mouseMove(x: number, y: number): void;
   click(x: number, y: number): void;
   rightClick(x: number, y: number): void;
@@ -573,6 +575,14 @@ export class Cel implements
     return this.native.captureScreen();
   }
 
+  /** Capture a specific window as PNG buffer. */
+  captureWindow(windowId: number): Buffer {
+    if (!this.native) {
+      throw new Error("Native module not available");
+    }
+    return this.native.captureWindow(windowId);
+  }
+
   /** List available monitors. */
   listMonitors(): MonitorInfo[] {
     if (!this.native) return [];
@@ -583,6 +593,12 @@ export class Cel implements
   listWindows(): WindowInfo[] {
     if (!this.native) return [];
     return JSON.parse(this.native.listWindows());
+  }
+
+  /** List windows with IDs compatible with captureWindow(). */
+  listCaptureWindows(): WindowInfo[] {
+    if (!this.native) return [];
+    return JSON.parse(this.native.listCaptureWindows());
   }
 
   // --- Input ---

--- a/cel/cel-napi/src/context.rs
+++ b/cel/cel-napi/src/context.rs
@@ -32,6 +32,18 @@ pub fn capture_screen() -> napi::Result<napi::bindgen_prelude::Buffer> {
     Ok(png.into())
 }
 
+/// Capture a window by platform capture ID and return as PNG bytes.
+#[napi]
+pub fn capture_window(window_id: u32) -> napi::Result<napi::bindgen_prelude::Buffer> {
+    let mut capture = cel_display::create_capture();
+    let frame = capture
+        .capture_window(window_id)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    let png =
+        cel_display::encode_png(&frame).map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    Ok(png.into())
+}
+
 /// List available monitors. Returns JSON string.
 #[napi]
 pub fn list_monitors() -> napi::Result<String> {
@@ -49,6 +61,18 @@ pub fn list_windows() -> napi::Result<String> {
     let bus = cel_signals::create_signal_bus();
     let snap = bus.snapshot();
     serde_json::to_string(&snap.window_list).map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+/// List windows from the capture backend. Returns JSON string.
+///
+/// This exposes the same platform capture IDs that `capture_window` expects.
+#[napi]
+pub fn list_capture_windows() -> napi::Result<String> {
+    let capture = cel_display::create_capture();
+    let windows = capture
+        .list_windows()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    serde_json::to_string(&windows).map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
 /// Create a resilient ContextReference from a ContextElement JSON.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -57,6 +57,29 @@ CEL uses four tools organized by intent:
 
 Plus 5 [**prompts**](#prompts--reusable-quick-start-templates) — quick-start templates the host surfaces as commands (`cellar/setup-task`, `cellar/inspect-app`, `cellar/debug-hung-action`, `cellar/extract-table`, `cellar/run-numbers-write`).
 
+The server can also expose screenshots as MCP resources. Screenshot resources
+are disabled by default because any connected MCP client can read them once they
+are enabled. Only turn them on for trusted local clients and sessions:
+
+```bash
+CELLAR_ENABLE_SCREEN_RESOURCES=1 cellar mcp
+```
+
+| Resource | Contents |
+|----------|----------|
+| `cellar://screen/current` | Fresh PNG screenshot of the primary display |
+| `cellar://screen/{app_name}` | Fresh PNG screenshot for a visible app window |
+
+Use resources when your MCP client can display or subscribe to resource content directly.
+Use `cel_see` `screenshot` when you specifically need the screenshot inside a tool call result.
+
+Resource reads are uncached and capture a fresh PNG on each request. PNG payloads
+can be multiple MB over stdio, so prefer targeted reads and avoid polling unless
+your client handles large resource payloads well. `cellar://screen/current`
+captures the primary display. App resources use window IDs from the native
+capture backend (`listCaptureWindows`) and do not fall back to accessibility
+window IDs or a full-screen screenshot if a matching window cannot be captured.
+
 ---
 
 ## cel_see — Read the Screen

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -1,0 +1,212 @@
+import {
+  ResourceTemplate,
+  type McpServer,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type {
+  ListResourcesResult,
+  ReadResourceResult,
+  Resource,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Cel, WindowInfo } from "@cellar/agent";
+
+export const CURRENT_SCREEN_RESOURCE_URI = "cellar://screen/current";
+export const APP_SCREEN_RESOURCE_TEMPLATE = "cellar://screen/{app_name}";
+export const SCREENSHOT_MIME_TYPE = "image/png";
+export const SCREENSHOT_TRANSPORT_NOTE =
+  "PNG screenshots are captured on demand and can be multiple MB over stdio.";
+
+type ScreenResourceCel = Pick<
+  Cel,
+  "captureScreen" | "captureWindow" | "listCaptureWindows"
+>;
+
+function assertScreenResourceSupport(
+  cel: Partial<ScreenResourceCel>,
+): asserts cel is ScreenResourceCel {
+  if (
+    typeof cel.captureScreen !== "function" ||
+    typeof cel.captureWindow !== "function" ||
+    typeof cel.listCaptureWindows !== "function"
+  ) {
+    throw new Error(
+      "Screen resources require cel-napi support for captureScreen, " +
+        "captureWindow, and listCaptureWindows.",
+    );
+  }
+}
+
+function normalizeAppName(appName: string): string {
+  return appName.trim().toLowerCase();
+}
+
+function isVisibleWindow(window: WindowInfo): boolean {
+  return (
+    Boolean(window.app_name?.trim()) &&
+    !window.is_minimized &&
+    window.width > 0 &&
+    window.height > 0
+  );
+}
+
+function getCaptureWindows(cel: ScreenResourceCel): WindowInfo[] {
+  assertScreenResourceSupport(cel);
+
+  try {
+    return cel.listCaptureWindows();
+  } catch {
+    return [];
+  }
+}
+
+function findWindowForApp(
+  cel: ScreenResourceCel,
+  appName: string,
+): WindowInfo | undefined {
+  const normalized = normalizeAppName(appName);
+  return getCaptureWindows(cel)
+    .filter(isVisibleWindow)
+    .sort((a, b) => (a.title || a.app_name).localeCompare(b.title || b.app_name))
+    .find((window) => normalizeAppName(window.app_name) === normalized);
+}
+
+export function screenResourceUriForApp(appName: string): string {
+  return `cellar://screen/${encodeURIComponent(appName)}`;
+}
+
+export function appNameFromScreenResourceUri(uri: URL): string {
+  if (uri.protocol !== "cellar:" || uri.hostname !== "screen") {
+    throw new Error(`Unsupported screen resource URI: ${uri.toString()}`);
+  }
+
+  const encodedAppName = uri.pathname.replace(/^\/+/, "");
+  if (!encodedAppName || encodedAppName === "current") {
+    throw new Error(`Expected app screen resource URI: ${APP_SCREEN_RESOURCE_TEMPLATE}`);
+  }
+  return decodeURIComponent(encodedAppName);
+}
+
+export function listScreenResources(cel: ScreenResourceCel): Resource[] {
+  assertScreenResourceSupport(cel);
+
+  const resources: Resource[] = [
+    {
+      uri: CURRENT_SCREEN_RESOURCE_URI,
+      name: "current-screen",
+      title: "Current screen",
+      description: "Latest PNG screenshot of the primary display.",
+      mimeType: SCREENSHOT_MIME_TYPE,
+      _meta: {
+        capture_scope: "primary_display",
+        freshness: "uncached",
+        size_note: SCREENSHOT_TRANSPORT_NOTE,
+      },
+    },
+  ];
+
+  const seenApps = new Set<string>();
+  const appResources = getCaptureWindows(cel)
+    .filter(isVisibleWindow)
+    .filter((window) => {
+      const key = normalizeAppName(window.app_name);
+      if (seenApps.has(key)) return false;
+      seenApps.add(key);
+      return true;
+    })
+    .sort((a, b) => a.app_name.localeCompare(b.app_name))
+    .map<Resource>((window) => ({
+      uri: screenResourceUriForApp(window.app_name),
+      name: `screen-${normalizeAppName(window.app_name).replace(/[^a-z0-9_-]+/g, "-")}`,
+      title: `${window.app_name} screen`,
+      description: `Latest PNG screenshot for the visible ${window.app_name} window.`,
+      mimeType: SCREENSHOT_MIME_TYPE,
+      _meta: {
+        capture_scope: "visible_app_window",
+        freshness: "uncached",
+        size_note: SCREENSHOT_TRANSPORT_NOTE,
+        id_source: "listCaptureWindows",
+        app_name: window.app_name,
+        window_id: window.id,
+        window_title: window.title,
+        bounds: {
+          x: window.x,
+          y: window.y,
+          width: window.width,
+          height: window.height,
+        },
+      },
+    }));
+
+  resources.push(...appResources);
+  return resources;
+}
+
+export function readCurrentScreenResource(
+  cel: Pick<Cel, "captureScreen">,
+  uri = CURRENT_SCREEN_RESOURCE_URI,
+): ReadResourceResult {
+  const buffer = cel.captureScreen();
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: SCREENSHOT_MIME_TYPE,
+        blob: buffer.toString("base64"),
+      },
+    ],
+  };
+}
+
+export function readAppScreenResource(
+  cel: ScreenResourceCel,
+  uri: URL,
+): ReadResourceResult {
+  assertScreenResourceSupport(cel);
+
+  const appName = appNameFromScreenResourceUri(uri);
+  const window = findWindowForApp(cel, appName);
+  if (!window) {
+    throw new Error(`No visible window found for app "${appName}"`);
+  }
+
+  const buffer = cel.captureWindow(window.id);
+  return {
+    contents: [
+      {
+        uri: uri.toString(),
+        mimeType: SCREENSHOT_MIME_TYPE,
+        blob: buffer.toString("base64"),
+      },
+    ],
+  };
+}
+
+export function registerScreenResources(server: McpServer, cel: Cel): void {
+  server.registerResource(
+    "current-screen",
+    CURRENT_SCREEN_RESOURCE_URI,
+    {
+      title: "Current screen",
+      description: "Latest PNG screenshot of the primary display.",
+      mimeType: SCREENSHOT_MIME_TYPE,
+    },
+    async (uri): Promise<ReadResourceResult> =>
+      readCurrentScreenResource(cel, uri.toString()),
+  );
+
+  server.registerResource(
+    "app-screen",
+    new ResourceTemplate(APP_SCREEN_RESOURCE_TEMPLATE, {
+      list: async (): Promise<ListResourcesResult> => ({
+        resources: listScreenResources(cel).filter(
+          (resource) => resource.uri !== CURRENT_SCREEN_RESOURCE_URI,
+        ),
+      }),
+    }),
+    {
+      title: "App screen",
+      description: "Latest PNG screenshot for a visible app window.",
+      mimeType: SCREENSHOT_MIME_TYPE,
+    },
+    async (uri): Promise<ReadResourceResult> => readAppScreenResource(cel, uri),
+  );
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { celActSchema, handleCelAct } from "./tools/cel-act.js";
 import { celThinkSchema, handleCelThink } from "./tools/cel-think.js";
 import { celPerceiveSchema, handleCelPerceive } from "./tools/cel-perceive.js";
 import { registerPrompts } from "./prompts.js";
+import { registerScreenResources } from "./resources.js";
 
 type CdpTargetLike = {
   app_name?: string;
@@ -33,9 +34,17 @@ export function filterBrowserCdpTargets<T extends CdpTargetLike>(targets: T[]): 
   return targets.filter((target) => isBrowserCdpTarget(target));
 }
 
+export function screenResourcesEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env.CELLAR_ENABLE_SCREEN_RESOURCES;
+  return raw === "1" || raw?.toLowerCase() === "true" || raw?.toLowerCase() === "yes";
+}
+
 export function createCelMcpServer(cel?: Cel): McpServer {
   const instance = cel ?? new Cel();
   const degraded = !instance.isNativeAvailable;
+  const enableScreenResources = screenResourcesEnabled();
 
   if (degraded) {
     console.warn(
@@ -189,6 +198,15 @@ export function createCelMcpServer(cel?: Cel): McpServer {
       ].join("\n"),
     },
   );
+
+  if (enableScreenResources && !degraded) {
+    registerScreenResources(server, instance);
+  } else if (enableScreenResources) {
+    console.warn(
+      "[cellar-mcp] CELLAR_ENABLE_SCREEN_RESOURCES is set, but cel-napi is not available. " +
+        "Screenshot resources are disabled in schema-only mode.",
+    );
+  }
 
   server.registerTool(
     "cel_see",

--- a/mcp-server/test/resources.test.ts
+++ b/mcp-server/test/resources.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CURRENT_SCREEN_RESOURCE_URI,
+  appNameFromScreenResourceUri,
+  listScreenResources,
+  readAppScreenResource,
+  readCurrentScreenResource,
+  screenResourceUriForApp,
+} from "../src/resources.js";
+import { screenResourcesEnabled } from "../src/server.js";
+import type { WindowInfo } from "@cellar/agent";
+
+function window(overrides: Partial<WindowInfo>): WindowInfo {
+  return {
+    id: 1,
+    app_name: "Finder",
+    title: "Documents",
+    x: 0,
+    y: 0,
+    width: 800,
+    height: 600,
+    is_minimized: false,
+    ...overrides,
+  };
+}
+
+describe("screen resources", () => {
+  it("lists the current screen plus one visible resource per app", () => {
+    const cel = {
+      captureScreen: vi.fn(),
+      captureWindow: vi.fn(),
+      listCaptureWindows: vi.fn(() => [
+        window({ id: 10, app_name: "Finder", title: "Downloads" }),
+        window({ id: 11, app_name: "Finder", title: "Documents" }),
+        window({ id: 12, app_name: "Notes", title: "Todo" }),
+        window({ id: 13, app_name: "Hidden", is_minimized: true }),
+        window({ id: 14, app_name: "", title: "Untitled" }),
+      ]),
+    };
+
+    const resources = listScreenResources(cel);
+
+    expect(resources.map((resource) => resource.uri)).toEqual([
+      CURRENT_SCREEN_RESOURCE_URI,
+      "cellar://screen/Finder",
+      "cellar://screen/Notes",
+    ]);
+    expect(resources[1]?._meta).toMatchObject({
+      app_name: "Finder",
+      window_id: 10,
+      window_title: "Downloads",
+      capture_scope: "visible_app_window",
+      freshness: "uncached",
+      id_source: "listCaptureWindows",
+    });
+  });
+
+  it("encodes app names as URI-safe path segments", () => {
+    const uri = screenResourceUriForApp("Foo/Bar Beta");
+
+    expect(uri).toBe("cellar://screen/Foo%2FBar%20Beta");
+    expect(appNameFromScreenResourceUri(new URL(uri))).toBe("Foo/Bar Beta");
+  });
+
+  it("reads the current screen as a PNG blob resource", () => {
+    const cel = {
+      captureScreen: vi.fn(() => Buffer.from("screen")),
+    };
+
+    expect(readCurrentScreenResource(cel)).toEqual({
+      contents: [
+        {
+          uri: CURRENT_SCREEN_RESOURCE_URI,
+          mimeType: "image/png",
+          blob: Buffer.from("screen").toString("base64"),
+        },
+      ],
+    });
+  });
+
+  it("captures the matching app window when reading an app resource", () => {
+    const cel = {
+      captureScreen: vi.fn(() => Buffer.from("full-screen")),
+      captureWindow: vi.fn(() => Buffer.from("window-shot")),
+      listCaptureWindows: vi.fn(() => [
+        window({ id: 21, app_name: "Calendar", title: "May" }),
+        window({ id: 22, app_name: "Notes", title: "Todo" }),
+      ]),
+    };
+
+    const result = readAppScreenResource(cel, new URL("cellar://screen/Notes"));
+
+    expect(cel.captureWindow).toHaveBeenCalledWith(22);
+    expect(cel.captureScreen).not.toHaveBeenCalled();
+    expect(result.contents[0]).toMatchObject({
+      uri: "cellar://screen/Notes",
+      mimeType: "image/png",
+      blob: Buffer.from("window-shot").toString("base64"),
+    });
+  });
+
+  it("rejects app resources when no visible matching window exists", () => {
+    const cel = {
+      captureScreen: vi.fn(() => Buffer.from("screen")),
+      captureWindow: vi.fn(() => Buffer.from("window-shot")),
+      listCaptureWindows: vi.fn(() => [window({ id: 21, app_name: "Calendar" })]),
+    };
+
+    expect(() => readAppScreenResource(cel, new URL("cellar://screen/Notes"))).toThrow(
+      'No visible window found for app "Notes"',
+    );
+  });
+
+  it("requires capture-backend window ids for app resources", () => {
+    const cel = {
+      captureScreen: vi.fn(() => Buffer.from("full-screen")),
+      listCaptureWindows: vi.fn(() => [window({ id: 22, app_name: "Notes" })]),
+    };
+
+    expect(() =>
+      readAppScreenResource(cel as never, new URL("cellar://screen/Notes")),
+    ).toThrow("Screen resources require cel-napi support");
+    expect(cel.captureScreen).not.toHaveBeenCalled();
+  });
+
+  it("gates resource registration behind an explicit environment opt-in", () => {
+    expect(screenResourcesEnabled({})).toBe(false);
+    expect(screenResourcesEnabled({ CELLAR_ENABLE_SCREEN_RESOURCES: "0" })).toBe(false);
+    expect(screenResourcesEnabled({ CELLAR_ENABLE_SCREEN_RESOURCES: "1" })).toBe(true);
+    expect(screenResourcesEnabled({ CELLAR_ENABLE_SCREEN_RESOURCES: "true" })).toBe(true);
+    expect(screenResourcesEnabled({ CELLAR_ENABLE_SCREEN_RESOURCES: "yes" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- registers `cellar://screen/current` and `cellar://screen/{app_name}` MCP resources that return PNG blobs
- exposes capture-backend window IDs through N-API/TypeScript so app resources can capture the matching visible window
- documents the new MCP resource surface and adds focused unit coverage for URI encoding, resource listing, and app-window reads

Fixes #5.

## Validation

- `pnpm exec vitest run mcp-server/test/resources.test.ts`
- `pnpm --filter @cellar/agent build && pnpm --filter @cellar/adapter-browser build && pnpm --filter @dpagk/cellar-mcp lint`
- `pnpm --filter @dpagk/cellar-mcp build`
- `cargo check -p cel-napi`
- `cargo test -p cel-display`
- `cargo fmt -p cel-napi --check`
- `git diff --check`

Note: repo-wide `cargo fmt --check` currently reports formatting drift in unrelated Rust files, so I kept the format check scoped to the touched Rust package.
