### PR TITLE
ci: overhaul GitHub Actions for correctness and speed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,65 @@
+# Path-based auto-labeling for PRs (used by .github/workflows/label.yml)
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cel/**'
+          - 'adapters/adapter-common/**'
+          - 'adapters/excel/**'
+          - 'adapters/sap-gui/**'
+          - 'adapters/bloomberg/**'
+          - 'adapters/metatrader/**'
+          - 'Cargo.toml'
+          - 'Cargo.lock'
+
+typescript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'agent/**'
+          - 'mcp-server/**'
+          - 'cli/**'
+          - 'adapters/browser/**'
+          - 'live-view/**'
+          - 'recorder/**'
+          - 'registry/**'
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'tsconfig.base.json'
+
+cortex:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cel/cel-cortex/**'
+          - 'cel/cel-napi/**'
+          - 'tests/cortex/**'
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'mcp-server/**'
+
+adapters:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'adapters/**'
+
+e2e:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+
+app:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       ts: ${{ steps.filter.outputs.ts }}
-      e2e: ${{ steps.filter.outputs.e2e }}
       napi: ${{ steps.filter.outputs.napi }}
     steps:
       - uses: actions/checkout@v6
@@ -57,14 +56,6 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'tsconfig.base.json'
-              - '.github/workflows/ci.yml'
-            e2e:
-              - 'e2e/**'
-              - 'agent/**'
-              - 'mcp-server/**'
-              - 'adapters/browser/**'
-              - 'live-view/**'
-              - 'recorder/**'
               - '.github/workflows/ci.yml'
             napi:
               - 'cel/cel-napi/**'
@@ -204,43 +195,6 @@ jobs:
       - run: make test-ts
 
   # -------------------------------------------------------------------------
-  # E2E — Playwright (selective projects, excludes real-extraction)
-  # -------------------------------------------------------------------------
-  e2e:
-    name: 'E2E: Playwright'
-    needs: [changes, ts-build]
-    if: needs.changes.outputs.e2e == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - run: make build-ts
-
-      - name: Install Playwright browsers
-        working-directory: e2e
-        run: npx playwright install --with-deps chromium
-
-      - run: make test-e2e
-
-      - name: Upload report
-        uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: e2e/playwright-report/
-          retention-days: 7
-
-  # -------------------------------------------------------------------------
   # Cortex + NAPI — integration tests (macOS only; needs accessibility APIs)
   # -------------------------------------------------------------------------
   cortex:
@@ -278,7 +232,7 @@ jobs:
   ci-ok:
     name: CI ✓
     if: always()
-    needs: [rust-fmt, rust-clippy, rust-test, ts-build, ts-test, e2e, cortex]
+    needs: [rust-fmt, rust-clippy, rust-test, ts-build, ts-test, cortex]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed
@@ -289,7 +243,6 @@ jobs:
             "${{ needs.rust-test.result }}"
             "${{ needs.ts-build.result }}"
             "${{ needs.ts-test.result }}"
-            "${{ needs.e2e.result }}"
             "${{ needs.cortex.result }}"
           )
           for r in "${results[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,165 +4,298 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# ---------------------------------------------------------------------------
+# Change detection — skip jobs when their source files haven't changed
+# ---------------------------------------------------------------------------
 jobs:
-  rust-check:
-    name: Rust ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      ts: ${{ steps.filter.outputs.ts }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      napi: ${{ steps.filter.outputs.napi }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
         with:
-          components: clippy, rustfmt
-      - name: Cache cargo registry & build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-      - name: Check workspace
-        run: cargo check --workspace
-      - name: Run tests
-        run: cargo test --workspace
-      - name: Clippy
-        run: cargo clippy --workspace
-        continue-on-error: true
-      - name: Format check
-        run: cargo fmt --all -- --check
-        continue-on-error: true
+          filters: |
+            rust:
+              - 'cel/**'
+              - 'adapters/adapter-common/**'
+              - 'adapters/excel/**'
+              - 'adapters/sap-gui/**'
+              - 'adapters/bloomberg/**'
+              - 'adapters/metatrader/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+            ts:
+              - 'agent/**'
+              - 'mcp-server/**'
+              - 'cli/**'
+              - 'adapters/browser/**'
+              - 'live-view/**'
+              - 'recorder/**'
+              - 'registry/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig.base.json'
+              - '.github/workflows/ci.yml'
+            e2e:
+              - 'e2e/**'
+              - 'agent/**'
+              - 'mcp-server/**'
+              - 'adapters/browser/**'
+              - 'live-view/**'
+              - 'recorder/**'
+              - '.github/workflows/ci.yml'
+            napi:
+              - 'cel/cel-napi/**'
+              - 'cel/cel-cortex/**'
+              - 'cel/cel-context/**'
+              - 'cel/cel-planner/**'
+              - 'cel/cel-goal-runner/**'
+              - 'cel/cel-store/**'
+              - 'cel/cel-cdp/**'
+              - 'cel/cel-signals/**'
+              - 'tests/cortex/**'
+              - '.github/workflows/ci.yml'
 
-  typescript-check:
-    name: TypeScript ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
-      - name: Lint
-        run: pnpm lint
-        continue-on-error: true
-
-  rust-linux:
-    name: Rust Linux
+  # -------------------------------------------------------------------------
+  # Rust — format (fast-fail), clippy, tests on Linux + macOS
+  # -------------------------------------------------------------------------
+  rust-fmt:
+    name: 'Rust: format'
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: make lint-rust-fmt
+
+  rust-clippy:
+    name: 'Rust: clippy (${{ matrix.os }})'
+    needs: [changes, rust-fmt]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+          - os: macos
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system deps (Linux)
+        if: matrix.os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev at-spi2-core \
             libwayland-dev libpipewire-0.3-dev \
             libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libasound2-dev \
-            libgbm-dev
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: linux-cargo-
-      - name: Run tests
-        run: cargo check --workspace --lib --bins --tests
-      - name: Clippy
-        run: cargo clippy --workspace --lib --bins --tests
-        continue-on-error: true
+            libjavascriptcoregtk-4.1-dev
 
-  napi-build:
-    name: NAPI ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: clippy-${{ matrix.os }}
+
+      - run: make lint-rust-clippy
+
+  rust-test:
+    name: 'Rust: test (${{ matrix.os }})'
+    needs: [changes, rust-fmt]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-    needs: [rust-check, typescript-check]
+        include:
+          - os: linux
+            runner: ubuntu-latest
+          - os: macos
+            runner: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build NAPI bindings
-        run: cargo build -p cel-napi --release
-      - name: Verify .node artifact
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            ls -la target/release/cel_napi.dll || echo "DLL not found (expected for napi)"
-          else
-            ls -la target/release/libcel_napi.dylib || echo "dylib not found (expected for napi)"
-          fi
+      - uses: actions/checkout@v6
 
-  cortex-tests:
-    name: Cortex Tests
-    runs-on: macos-latest
-    needs: [rust-check]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: macos-cortex-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: macos-cortex-
-      - name: Rust Cortex unit tests
-        run: cargo test -p cel-cortex
-      - name: Build NAPI binary with Cortex
+      - name: Install system deps (Linux)
+        if: matrix.os == 'linux'
         run: |
-          cargo build --release -p cel-napi
-          cp target/release/libcel_napi.dylib cel/cel-napi/cel-napi.darwin-arm64.node
-      - name: Build TypeScript
-        run: pnpm install --frozen-lockfile && pnpm -r build
-      - name: NAPI smoke test
-        run: node tests/cortex/napi-smoke.mjs
-      - name: MCP protocol test
-        run: node tests/cortex/mcp-protocol.mjs
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev at-spi2-core \
+            libwayland-dev libpipewire-0.3-dev \
+            libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test-${{ matrix.os }}
+
+      - run: make test-rust
+
+  # -------------------------------------------------------------------------
+  # TypeScript — build, typecheck, unit tests (Linux only; no platform code)
+  # -------------------------------------------------------------------------
+  ts-build:
+    name: 'TS: build + lint'
+    needs: changes
+    if: needs.changes.outputs.ts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: make build-ts
+      - run: make lint-ts
+
+  ts-test:
+    name: 'TS: unit tests'
+    needs: [changes, ts-build]
+    if: needs.changes.outputs.ts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: make build-ts
+      - run: make test-ts
+
+  # -------------------------------------------------------------------------
+  # E2E — Playwright (selective projects, excludes real-extraction)
+  # -------------------------------------------------------------------------
+  e2e:
+    name: 'E2E: Playwright'
+    needs: [changes, ts-build]
+    if: needs.changes.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: make build-ts
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - run: make test-e2e
+
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+  # -------------------------------------------------------------------------
+  # Cortex + NAPI — integration tests (macOS only; needs accessibility APIs)
+  # -------------------------------------------------------------------------
+  cortex:
+    name: 'Cortex: integration (macOS)'
+    needs: changes
+    if: needs.changes.outputs.napi == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cortex-macos
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: make test-cortex
+      - run: make build-napi
+      - run: make build-ts
+      - run: make test-cortex-napi
+      - run: make test-cortex-mcp
+
+  # -------------------------------------------------------------------------
+  # Gate — single required status check for branch protection
+  # -------------------------------------------------------------------------
+  ci-ok:
+    name: CI ✓
+    if: always()
+    needs: [rust-fmt, rust-clippy, rust-test, ts-build, ts-test, e2e, cortex]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          results=(
+            "${{ needs.rust-fmt.result }}"
+            "${{ needs.rust-clippy.result }}"
+            "${{ needs.rust-test.result }}"
+            "${{ needs.ts-build.result }}"
+            "${{ needs.ts-test.result }}"
+            "${{ needs.e2e.result }}"
+            "${{ needs.cortex.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "::error::Required check failed or was cancelled ($r)"
+              exit 1
+            fi
+          done
+          echo "All required checks passed (or were skipped due to path filtering)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
           sudo apt-get install -y libdbus-1-dev at-spi2-core \
             libwayland-dev libpipewire-0.3-dev \
             libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev
+            libjavascriptcoregtk-4.1-dev \
+            libasound2-dev libgbm-dev
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -142,7 +143,8 @@ jobs:
           sudo apt-get install -y libdbus-1-dev at-spi2-core \
             libwayland-dev libpipewire-0.3-dev \
             libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev
+            libjavascriptcoregtk-4.1-dev \
+            libasound2-dev libgbm-dev
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,18 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Auto-label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-rust build-ts build-cortex build-napi build-mcp-sidecar test test-all test-rust test-ts test-cortex test-cortex-napi test-cortex-mcp test-e2e test-real-extraction lint lint-rust lint-rust-fmt lint-rust-clippy lint-ts clean dev-tauri build-tauri
+.PHONY: build build-rust build-ts build-cortex build-napi build-mcp-sidecar test test-all test-rust test-ts test-cortex test-cortex-napi test-cortex-mcp test-e2e test-real-extraction lint lint-rust lint-rust-fmt lint-rust-clippy lint-ts fmt fmt-rust clean dev-tauri build-tauri
 
 build: build-rust build-ts
 
@@ -43,6 +43,12 @@ lint-rust-clippy:
 
 lint-ts:
 	pnpm lint
+
+# Auto-fix formatting (companion to lint-rust-fmt)
+fmt: fmt-rust
+
+fmt-rust:
+	cargo fmt --all
 
 build-cortex:
 	cargo build -p cel-cortex

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-rust build-ts build-cortex build-napi build-mcp-sidecar test test-all test-rust test-ts test-cortex test-cortex-napi test-cortex-mcp test-e2e test-real-extraction lint lint-rust lint-ts clean dev-tauri build-tauri
+.PHONY: build build-rust build-ts build-cortex build-napi build-mcp-sidecar test test-all test-rust test-ts test-cortex test-cortex-napi test-cortex-mcp test-e2e test-real-extraction lint lint-rust lint-rust-fmt lint-rust-clippy lint-ts clean dev-tauri build-tauri
 
 build: build-rust build-ts
 
@@ -6,7 +6,11 @@ build-rust:
 	cargo build --workspace
 
 build-ts:
+ifdef CI
+	pnpm install --frozen-lockfile
+else
 	pnpm install
+endif
 	pnpm build
 
 test: test-rust test-ts
@@ -29,9 +33,13 @@ test-e2e-ui:
 
 lint: lint-rust lint-ts
 
-lint-rust:
-	cargo clippy --workspace -- -D warnings
+lint-rust: lint-rust-fmt lint-rust-clippy
+
+lint-rust-fmt:
 	cargo fmt --all -- --check
+
+lint-rust-clippy:
+	cargo clippy --workspace -- -D warnings
 
 lint-ts:
 	pnpm lint

--- a/adapters/adapter-common/src/lib.rs
+++ b/adapters/adapter-common/src/lib.rs
@@ -84,7 +84,10 @@ mod tests {
 
     #[test]
     fn test_adapter_error_display() {
-        assert_eq!(AdapterError::AppNotFound.to_string(), "App not running or not found");
+        assert_eq!(
+            AdapterError::AppNotFound.to_string(),
+            "App not running or not found"
+        );
         assert_eq!(AdapterError::ConnectionLost.to_string(), "Connection lost");
         assert_eq!(
             AdapterError::Unavailable("no COM".into()).to_string(),

--- a/adapters/browser/package.json
+++ b/adapters/browser/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
+    "test": "vitest run --exclude '**/integration.test.ts' --exclude '**/node_modules/**'",
+    "test:integration": "vitest run src/__tests__/integration.test.ts",
     "lint": "tsc --noEmit"
   },
   "dependencies": {

--- a/adapters/numbers/src/lib.rs
+++ b/adapters/numbers/src/lib.rs
@@ -24,11 +24,11 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use cel_accessibility::ElementState;
 use cel_context::{ContentRole, ContextElement, ContextSource};
+use cel_cortex::adapter::{LifecycleDeclaration, VerificationDeclaration};
 use cel_cortex::{
     ActionDeclaration, ActionResult, AdapterDriver, AdapterError, AdapterManifest,
     ContextDeclaration,
 };
-use cel_cortex::adapter::{LifecycleDeclaration, VerificationDeclaration};
 #[cfg(target_os = "macos")]
 use cel_input::CellWrite;
 use serde_json::{json, Value};
@@ -106,7 +106,11 @@ impl NumbersAdapter {
                 (String::from("app"), String::from("Numbers")),
                 (
                     String::from("preview_range"),
-                    format!("A1:{}{}", column_label(NUMBERS_PREVIEW_COLS - 1), NUMBERS_PREVIEW_ROWS),
+                    format!(
+                        "A1:{}{}",
+                        column_label(NUMBERS_PREVIEW_COLS - 1),
+                        NUMBERS_PREVIEW_ROWS
+                    ),
                 ),
             ]),
         }];
@@ -205,13 +209,9 @@ impl NumbersAdapter {
             .and_then(Value::as_bool)
             .unwrap_or(true);
         let writes = parse_cell_writes(params)?;
-        let readbacks = cel_input::write_numbers_cells(
-            sheet.as_deref(),
-            table.as_deref(),
-            &writes,
-            verify,
-        )
-        .map_err(|err| AdapterError::ExecutionFailed(err.to_string()))?;
+        let readbacks =
+            cel_input::write_numbers_cells(sheet.as_deref(), table.as_deref(), &writes, verify)
+                .map_err(|err| AdapterError::ExecutionFailed(err.to_string()))?;
         Ok(json!({
             "app": "Numbers",
             "writes": writes
@@ -487,14 +487,11 @@ fn parse_cell_writes(params: &Value) -> Result<Vec<CellWrite>, AdapterError> {
                     "write_cells expects each entry to include non-empty `cell_ref`".into(),
                 )
             })?;
-        let cell_value = value
-            .get("value")
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                AdapterError::ExecutionFailed(
-                    "write_cells expects each entry to include string `value`".into(),
-                )
-            })?;
+        let cell_value = value.get("value").and_then(Value::as_str).ok_or_else(|| {
+            AdapterError::ExecutionFailed(
+                "write_cells expects each entry to include string `value`".into(),
+            )
+        })?;
         parsed.push(CellWrite {
             cell_ref: cell_ref.to_string(),
             value: cell_value.to_string(),
@@ -578,7 +575,10 @@ mod tests {
     fn manifest_declares_document_model_truth_and_actions() {
         let adapter = NumbersAdapter::new();
         assert_eq!(adapter.manifest.context.truth_surface, "document_model");
-        assert_eq!(adapter.manifest.verification.truth_surface, "document_model");
+        assert_eq!(
+            adapter.manifest.verification.truth_surface,
+            "document_model"
+        );
         assert_eq!(
             adapter.manifest.verification.readback_action.as_deref(),
             Some("read_cells")

--- a/adapters/numbers/src/lib.rs
+++ b/adapters/numbers/src/lib.rs
@@ -19,6 +19,9 @@
 //! packaging convention as `adapters/browser`, per the adapter-sdk
 //! pivot in April 2026 (see `docs/adapter-roadmap.md` P0).
 
+// AppleScript-only — entire adapter compiles to a no-op on non-macOS.
+#![cfg(target_os = "macos")]
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/cel/cel-accessibility/Cargo.toml
+++ b/cel/cel-accessibility/Cargo.toml
@@ -19,3 +19,20 @@ tokio = { workspace = true }
 core-foundation = "0.10"
 core-graphics = "0.24"
 rayon = "1.10"
+
+# macOS-only examples — gated behind a feature so cargo skips them on
+# Linux. Enable via `cargo build --features macos-examples --example …`.
+[features]
+macos-examples = []
+
+[[example]]
+name = "dump_deep"
+required-features = ["macos-examples"]
+
+[[example]]
+name = "dump_page_content"
+required-features = ["macos-examples"]
+
+[[example]]
+name = "dump_text"
+required-features = ["macos-examples"]

--- a/cel/cel-accessibility/examples/dump_deep.rs
+++ b/cel/cel-accessibility/examples/dump_deep.rs
@@ -2,6 +2,7 @@
 //!
 //! Usage: cargo run -p cel-accessibility --example dump_deep
 
+
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;

--- a/cel/cel-accessibility/examples/dump_deep.rs
+++ b/cel/cel-accessibility/examples/dump_deep.rs
@@ -2,7 +2,6 @@
 //!
 //! Usage: cargo run -p cel-accessibility --example dump_deep
 
-
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;
@@ -23,10 +22,7 @@ extern "C" {
         attr: CFStringRef,
         value: *mut CFTypeRef,
     ) -> AXError;
-    fn AXUIElementCopyAttributeNames(
-        el: AXUIElementRef,
-        names: *mut CFTypeRef,
-    ) -> AXError;
+    fn AXUIElementCopyAttributeNames(el: AXUIElementRef, names: *mut CFTypeRef) -> AXError;
     fn CFRelease(cf: *const c_void);
 }
 
@@ -84,7 +80,13 @@ fn main() {
     unsafe { CFRelease(app as *const c_void) };
 }
 
-fn dump_children(el: AXUIElementRef, depth: usize, count: &mut usize, max_depth: usize, max_count: usize) {
+fn dump_children(
+    el: AXUIElementRef,
+    depth: usize,
+    count: &mut usize,
+    max_depth: usize,
+    max_count: usize,
+) {
     if depth >= max_depth || *count >= max_count {
         return;
     }
@@ -139,7 +141,13 @@ fn dump_children(el: AXUIElementRef, depth: usize, count: &mut usize, max_depth:
                     break;
                 }
                 if let Some(child) = arr.get(i) {
-                    dump_children(child.as_CFTypeRef() as AXUIElementRef, depth + 1, count, max_depth, max_count);
+                    dump_children(
+                        child.as_CFTypeRef() as AXUIElementRef,
+                        depth + 1,
+                        count,
+                        max_depth,
+                        max_count,
+                    );
                 }
             }
         }
@@ -154,9 +162,8 @@ fn dump_attributes(el: AXUIElementRef, _depth: usize) {
         return;
     }
 
-    let arr: CFArray<CFType> = unsafe {
-        CFArray::wrap_under_create_rule(names_ref as core_foundation::array::CFArrayRef)
-    };
+    let arr: CFArray<CFType> =
+        unsafe { CFArray::wrap_under_create_rule(names_ref as core_foundation::array::CFArrayRef) };
 
     for i in 0..arr.len() {
         if let Some(item) = arr.get(i) {
@@ -180,7 +187,8 @@ fn dump_attributes(el: AXUIElementRef, _depth: usize) {
 fn get_attr(el: AXUIElementRef, attr: &str) -> Option<CFType> {
     let attr_cf = CFString::new(attr);
     let mut value: CFTypeRef = ptr::null();
-    let err = unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
+    let err =
+        unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
     if err != 0 || value.is_null() {
         return None;
     }
@@ -195,7 +203,11 @@ fn get_string(el: AXUIElementRef, attr: &str) -> Option<String> {
     {
         let s: CFString = unsafe { CFString::wrap_under_get_rule(cf_ref as CFStringRef) };
         let r = s.to_string();
-        if r.is_empty() { None } else { Some(r) }
+        if r.is_empty() {
+            None
+        } else {
+            Some(r)
+        }
     } else {
         None
     }

--- a/cel/cel-accessibility/examples/dump_deep.rs
+++ b/cel/cel-accessibility/examples/dump_deep.rs
@@ -2,9 +2,6 @@
 //!
 //! Usage: cargo run -p cel-accessibility --example dump_deep
 
-
-#![cfg(target_os = "macos")]
-
 use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::string::{CFString, CFStringRef};

--- a/cel/cel-accessibility/examples/dump_page_content.rs
+++ b/cel/cel-accessibility/examples/dump_page_content.rs
@@ -1,8 +1,5 @@
 //! Dump the web page content area — skip Chrome UI, focus on AXWebArea children.
 
-
-#![cfg(target_os = "macos")]
-
 use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::string::{CFString, CFStringRef};

--- a/cel/cel-accessibility/examples/dump_page_content.rs
+++ b/cel/cel-accessibility/examples/dump_page_content.rs
@@ -1,6 +1,5 @@
 //! Dump the web page content area — skip Chrome UI, focus on AXWebArea children.
 
-
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;
@@ -15,7 +14,11 @@ use core_foundation::base::CFTypeRef;
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
     fn AXUIElementCreateApplication(pid: i32) -> AXUIElementRef;
-    fn AXUIElementCopyAttributeValue(el: AXUIElementRef, attr: CFStringRef, value: *mut CFTypeRef) -> i32;
+    fn AXUIElementCopyAttributeValue(
+        el: AXUIElementRef,
+        attr: CFStringRef,
+        value: *mut CFTypeRef,
+    ) -> i32;
     fn CFRelease(cf: *const c_void);
 }
 
@@ -23,11 +26,17 @@ fn main() {
     let output = std::process::Command::new("osascript")
         .args(["-e", "tell application \"System Events\" to unix id of first process whose frontmost is true"])
         .output().expect("osascript failed");
-    let pid: i32 = String::from_utf8_lossy(&output.stdout).trim().parse().expect("bad pid");
+    let pid: i32 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .expect("bad pid");
 
     let app = unsafe { AXUIElementCreateApplication(pid) };
     let window = get_attr(app, "AXFocusedWindow");
-    let win_ref = window.as_ref().map(|w| w.as_CFTypeRef() as AXUIElementRef).unwrap_or(app);
+    let win_ref = window
+        .as_ref()
+        .map(|w| w.as_CFTypeRef() as AXUIElementRef)
+        .unwrap_or(app);
 
     // Find AXWebArea elements (the page content boundary)
     println!("=== Searching for AXWebArea (page content) ===\n");
@@ -42,7 +51,9 @@ fn main() {
         let title = get_string(*wa, "AXTitle").unwrap_or_else(|| "(untitled)".into());
         let url = get_string(*wa, "AXURL");
         println!("--- WebArea #{}: \"{}\" ---", i + 1, title);
-        if let Some(u) = &url { println!("    URL: {}", u); }
+        if let Some(u) = &url {
+            println!("    URL: {}", u);
+        }
         println!();
 
         // Dump ALL children of this web area with full text
@@ -54,8 +65,15 @@ fn main() {
     unsafe { CFRelease(app as *const c_void) };
 }
 
-fn find_web_areas(el: AXUIElementRef, depth: usize, results: &mut Vec<AXUIElementRef>, max_depth: usize) {
-    if depth >= max_depth { return; }
+fn find_web_areas(
+    el: AXUIElementRef,
+    depth: usize,
+    results: &mut Vec<AXUIElementRef>,
+    max_depth: usize,
+) {
+    if depth >= max_depth {
+        return;
+    }
     let role = get_string(el, "AXRole").unwrap_or_default();
     if role == "AXWebArea" {
         results.push(el);
@@ -63,19 +81,36 @@ fn find_web_areas(el: AXUIElementRef, depth: usize, results: &mut Vec<AXUIElemen
     }
     if let Some(kids) = get_attr(el, "AXChildren") {
         let kids_ref = kids.as_CFTypeRef();
-        if unsafe { core_foundation::array::CFArrayGetTypeID() } == unsafe { core_foundation::base::CFGetTypeID(kids_ref) } {
-            let arr: CFArray<CFType> = unsafe { CFArray::wrap_under_get_rule(kids_ref as core_foundation::array::CFArrayRef) };
+        if unsafe { core_foundation::array::CFArrayGetTypeID() }
+            == unsafe { core_foundation::base::CFGetTypeID(kids_ref) }
+        {
+            let arr: CFArray<CFType> = unsafe {
+                CFArray::wrap_under_get_rule(kids_ref as core_foundation::array::CFArrayRef)
+            };
             for i in 0..arr.len() {
                 if let Some(child) = arr.get(i) {
-                    find_web_areas(child.as_CFTypeRef() as AXUIElementRef, depth + 1, results, max_depth);
+                    find_web_areas(
+                        child.as_CFTypeRef() as AXUIElementRef,
+                        depth + 1,
+                        results,
+                        max_depth,
+                    );
                 }
             }
         }
     }
 }
 
-fn dump_web_content(el: AXUIElementRef, depth: usize, count: &mut usize, max_depth: usize, max_count: usize) {
-    if depth >= max_depth || *count >= max_count { return; }
+fn dump_web_content(
+    el: AXUIElementRef,
+    depth: usize,
+    count: &mut usize,
+    max_depth: usize,
+    max_count: usize,
+) {
+    if depth >= max_depth || *count >= max_count {
+        return;
+    }
     *count += 1;
 
     let role = get_string(el, "AXRole").unwrap_or_default();
@@ -84,26 +119,55 @@ fn dump_web_content(el: AXUIElementRef, depth: usize, count: &mut usize, max_dep
     let value = get_string(el, "AXValue").unwrap_or_default();
     let role_desc = get_string(el, "AXRoleDescription").unwrap_or_default();
 
-    let text = if !title.is_empty() { &title }
-        else if !value.is_empty() { &value }
-        else if !desc.is_empty() { &desc }
-        else { "" };
+    let text = if !title.is_empty() {
+        &title
+    } else if !value.is_empty() {
+        &value
+    } else if !desc.is_empty() {
+        &desc
+    } else {
+        ""
+    };
 
     // Only print elements that have content
-    if !text.is_empty() || matches!(role.as_str(), "AXLink" | "AXButton" | "AXTextField" | "AXTextArea" | "AXImage" | "AXHeading") {
+    if !text.is_empty()
+        || matches!(
+            role.as_str(),
+            "AXLink" | "AXButton" | "AXTextField" | "AXTextArea" | "AXImage" | "AXHeading"
+        )
+    {
         let indent = "  ".repeat(depth.min(10));
-        let display_text = if text.len() > 120 { format!("{}...", &text[..117]) } else { text.to_string() };
-        println!("{}[{}] {} \"{}\" (rdesc={})", indent, count, role, display_text, role_desc);
+        let display_text = if text.len() > 120 {
+            format!("{}...", &text[..117])
+        } else {
+            text.to_string()
+        };
+        println!(
+            "{}[{}] {} \"{}\" (rdesc={})",
+            indent, count, role, display_text, role_desc
+        );
     }
 
     if let Some(kids) = get_attr(el, "AXChildren") {
         let kids_ref = kids.as_CFTypeRef();
-        if unsafe { core_foundation::array::CFArrayGetTypeID() } == unsafe { core_foundation::base::CFGetTypeID(kids_ref) } {
-            let arr: CFArray<CFType> = unsafe { CFArray::wrap_under_get_rule(kids_ref as core_foundation::array::CFArrayRef) };
+        if unsafe { core_foundation::array::CFArrayGetTypeID() }
+            == unsafe { core_foundation::base::CFGetTypeID(kids_ref) }
+        {
+            let arr: CFArray<CFType> = unsafe {
+                CFArray::wrap_under_get_rule(kids_ref as core_foundation::array::CFArrayRef)
+            };
             for i in 0..arr.len() {
-                if *count >= max_count { break; }
+                if *count >= max_count {
+                    break;
+                }
                 if let Some(child) = arr.get(i) {
-                    dump_web_content(child.as_CFTypeRef() as AXUIElementRef, depth + 1, count, max_depth, max_count);
+                    dump_web_content(
+                        child.as_CFTypeRef() as AXUIElementRef,
+                        depth + 1,
+                        count,
+                        max_depth,
+                        max_count,
+                    );
                 }
             }
         }
@@ -113,17 +177,28 @@ fn dump_web_content(el: AXUIElementRef, depth: usize, count: &mut usize, max_dep
 fn get_attr(el: AXUIElementRef, attr: &str) -> Option<CFType> {
     let attr_cf = CFString::new(attr);
     let mut value: CFTypeRef = ptr::null();
-    let err = unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
-    if err != 0 || value.is_null() { return None; }
+    let err =
+        unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
+    if err != 0 || value.is_null() {
+        return None;
+    }
     Some(unsafe { CFType::wrap_under_create_rule(value) })
 }
 
 fn get_string(el: AXUIElementRef, attr: &str) -> Option<String> {
     let cf = get_attr(el, attr)?;
     let cf_ref = cf.as_CFTypeRef();
-    if unsafe { core_foundation::string::CFStringGetTypeID() } == unsafe { core_foundation::base::CFGetTypeID(cf_ref) } {
+    if unsafe { core_foundation::string::CFStringGetTypeID() }
+        == unsafe { core_foundation::base::CFGetTypeID(cf_ref) }
+    {
         let s: CFString = unsafe { CFString::wrap_under_get_rule(cf_ref as CFStringRef) };
         let r = s.to_string();
-        if r.is_empty() { None } else { Some(r) }
-    } else { None }
+        if r.is_empty() {
+            None
+        } else {
+            Some(r)
+        }
+    } else {
+        None
+    }
 }

--- a/cel/cel-accessibility/examples/dump_page_content.rs
+++ b/cel/cel-accessibility/examples/dump_page_content.rs
@@ -1,5 +1,6 @@
 //! Dump the web page content area — skip Chrome UI, focus on AXWebArea children.
 
+
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;

--- a/cel/cel-accessibility/examples/dump_text.rs
+++ b/cel/cel-accessibility/examples/dump_text.rs
@@ -1,6 +1,7 @@
 //! Dump ALL elements with text content — check what AX actually gives us for web views.
 //! Focuses on: AXValue, AXTitle, AXDescription, AXRoleDescription, AXHelp
 
+
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;

--- a/cel/cel-accessibility/examples/dump_text.rs
+++ b/cel/cel-accessibility/examples/dump_text.rs
@@ -1,7 +1,6 @@
 //! Dump ALL elements with text content — check what AX actually gives us for web views.
 //! Focuses on: AXValue, AXTitle, AXDescription, AXRoleDescription, AXHelp
 
-
 #![cfg(target_os = "macos")]
 
 use core_foundation::array::CFArray;
@@ -30,23 +29,41 @@ fn main() {
         .args(["-e", "tell application \"System Events\" to unix id of first process whose frontmost is true"])
         .output()
         .expect("osascript failed");
-    let pid: i32 = String::from_utf8_lossy(&output.stdout).trim().parse().expect("bad pid");
+    let pid: i32 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .expect("bad pid");
 
     let app = unsafe { AXUIElementCreateApplication(pid) };
     let window = get_attr(app, "AXFocusedWindow");
-    let win_ref = window.as_ref().map(|w| w.as_CFTypeRef() as AXUIElementRef).unwrap_or(app);
+    let win_ref = window
+        .as_ref()
+        .map(|w| w.as_CFTypeRef() as AXUIElementRef)
+        .unwrap_or(app);
 
     println!("=== Elements with text content (AXValue, AXTitle, AXDescription) ===\n");
     let mut count = 0;
     let mut text_count = 0;
     dump_text_elements(win_ref, 0, &mut count, &mut text_count, 25, 500);
-    println!("\n--- Total: {} elements scanned, {} with text content ---", count, text_count);
+    println!(
+        "\n--- Total: {} elements scanned, {} with text content ---",
+        count, text_count
+    );
 
     unsafe { CFRelease(app as *const c_void) };
 }
 
-fn dump_text_elements(el: AXUIElementRef, depth: usize, count: &mut usize, text_count: &mut usize, max_depth: usize, max_count: usize) {
-    if depth >= max_depth || *count >= max_count { return; }
+fn dump_text_elements(
+    el: AXUIElementRef,
+    depth: usize,
+    count: &mut usize,
+    text_count: &mut usize,
+    max_depth: usize,
+    max_count: usize,
+) {
+    if depth >= max_depth || *count >= max_count {
+        return;
+    }
     *count += 1;
 
     let role = get_string(el, "AXRole").unwrap_or_default();
@@ -63,19 +80,35 @@ fn dump_text_elements(el: AXUIElementRef, depth: usize, count: &mut usize, text_
         let indent = "  ".repeat(depth.min(8));
         println!("{}[{}] {}", indent, count, role);
         if let Some(t) = &title {
-            let t = if t.len() > 100 { format!("{}...", &t[..97]) } else { t.clone() };
+            let t = if t.len() > 100 {
+                format!("{}...", &t[..97])
+            } else {
+                t.clone()
+            };
             println!("{}  title: \"{}\"", indent, t);
         }
         if let Some(d) = &desc {
-            let d = if d.len() > 100 { format!("{}...", &d[..97]) } else { d.clone() };
+            let d = if d.len() > 100 {
+                format!("{}...", &d[..97])
+            } else {
+                d.clone()
+            };
             println!("{}  desc:  \"{}\"", indent, d);
         }
         if let Some(v) = &value {
-            let v = if v.len() > 200 { format!("{}...", &v[..197]) } else { v.clone() };
+            let v = if v.len() > 200 {
+                format!("{}...", &v[..197])
+            } else {
+                v.clone()
+            };
             println!("{}  value: \"{}\"", indent, v);
         }
         if let Some(h) = &help {
-            let h = if h.len() > 100 { format!("{}...", &h[..97]) } else { h.clone() };
+            let h = if h.len() > 100 {
+                format!("{}...", &h[..97])
+            } else {
+                h.clone()
+            };
             println!("{}  help:  \"{}\"", indent, h);
         }
         if let Some(r) = &role_desc {
@@ -93,9 +126,18 @@ fn dump_text_elements(el: AXUIElementRef, depth: usize, count: &mut usize, text_
                 CFArray::wrap_under_get_rule(kids_ref as core_foundation::array::CFArrayRef)
             };
             for i in 0..arr.len() {
-                if *count >= max_count { break; }
+                if *count >= max_count {
+                    break;
+                }
                 if let Some(child) = arr.get(i) {
-                    dump_text_elements(child.as_CFTypeRef() as AXUIElementRef, depth + 1, count, text_count, max_depth, max_count);
+                    dump_text_elements(
+                        child.as_CFTypeRef() as AXUIElementRef,
+                        depth + 1,
+                        count,
+                        text_count,
+                        max_depth,
+                        max_count,
+                    );
                 }
             }
         }
@@ -105,8 +147,11 @@ fn dump_text_elements(el: AXUIElementRef, depth: usize, count: &mut usize, text_
 fn get_attr(el: AXUIElementRef, attr: &str) -> Option<CFType> {
     let attr_cf = CFString::new(attr);
     let mut value: CFTypeRef = ptr::null();
-    let err = unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
-    if err != 0 || value.is_null() { return None; }
+    let err =
+        unsafe { AXUIElementCopyAttributeValue(el, attr_cf.as_concrete_TypeRef(), &mut value) };
+    if err != 0 || value.is_null() {
+        return None;
+    }
     Some(unsafe { CFType::wrap_under_create_rule(value) })
 }
 
@@ -118,7 +163,11 @@ fn get_string(el: AXUIElementRef, attr: &str) -> Option<String> {
     {
         let s: CFString = unsafe { CFString::wrap_under_get_rule(cf_ref as CFStringRef) };
         let r = s.to_string();
-        if r.is_empty() { None } else { Some(r) }
+        if r.is_empty() {
+            None
+        } else {
+            Some(r)
+        }
     } else {
         None
     }

--- a/cel/cel-accessibility/examples/dump_text.rs
+++ b/cel/cel-accessibility/examples/dump_text.rs
@@ -1,9 +1,6 @@
 //! Dump ALL elements with text content — check what AX actually gives us for web views.
 //! Focuses on: AXValue, AXTitle, AXDescription, AXRoleDescription, AXHelp
 
-
-#![cfg(target_os = "macos")]
-
 use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::string::{CFString, CFStringRef};

--- a/cel/cel-accessibility/examples/dump_tree.rs
+++ b/cel/cel-accessibility/examples/dump_tree.rs
@@ -5,7 +5,6 @@
 //! Requires Accessibility permission in System Settings.
 //! If denied, prints instructions.
 
-
 #![cfg(target_os = "macos")]
 
 fn main() {

--- a/cel/cel-accessibility/examples/dump_tree.rs
+++ b/cel/cel-accessibility/examples/dump_tree.rs
@@ -5,6 +5,7 @@
 //! Requires Accessibility permission in System Settings.
 //! If denied, prints instructions.
 
+
 #![cfg(target_os = "macos")]
 
 fn main() {

--- a/cel/cel-accessibility/examples/dump_tree.rs
+++ b/cel/cel-accessibility/examples/dump_tree.rs
@@ -5,9 +5,6 @@
 //! Requires Accessibility permission in System Settings.
 //! If denied, prints instructions.
 
-
-#![cfg(target_os = "macos")]
-
 fn main() {
     let tree = cel_accessibility::create_tree();
 

--- a/cel/cel-accessibility/src/budget.rs
+++ b/cel/cel-accessibility/src/budget.rs
@@ -111,12 +111,13 @@ impl AppCost {
     }
 
     fn maybe_decay(&mut self) {
-        if self.last_walk.elapsed() > DECAY_IDLE_THRESHOLD && self.tier != WalkTier::Light {
-            if self.durations.len() > 2 {
-                self.durations.drain(..self.durations.len() / 2);
-                self.truncation_count = self.truncation_count.saturating_sub(2);
-                self.tier = self.compute_tier();
-            }
+        if self.last_walk.elapsed() > DECAY_IDLE_THRESHOLD
+            && self.tier != WalkTier::Light
+            && self.durations.len() > 2
+        {
+            self.durations.drain(..self.durations.len() / 2);
+            self.truncation_count = self.truncation_count.saturating_sub(2);
+            self.tier = self.compute_tier();
         }
     }
 }

--- a/cel/cel-accessibility/src/lib.rs
+++ b/cel/cel-accessibility/src/lib.rs
@@ -123,7 +123,9 @@ mod tests {
     #[test]
     fn test_stub_find_elements_returns_empty() {
         let stub = StubAccessibility;
-        let results = stub.find_elements(Some(&ElementRole::Button), None).unwrap();
+        let results = stub
+            .find_elements(Some(&ElementRole::Button), None)
+            .unwrap();
         assert!(results.is_empty());
     }
 
@@ -145,15 +147,33 @@ mod tests {
     #[test]
     fn test_element_role_all_variants() {
         let roles = vec![
-            ElementRole::Window, ElementRole::Button, ElementRole::Input,
-            ElementRole::Text, ElementRole::List, ElementRole::ListItem,
-            ElementRole::Menu, ElementRole::MenuItem, ElementRole::Tab,
-            ElementRole::TabItem, ElementRole::Table, ElementRole::TableRow,
-            ElementRole::TableCell, ElementRole::Checkbox, ElementRole::RadioButton,
-            ElementRole::ComboBox, ElementRole::Slider, ElementRole::ScrollBar,
-            ElementRole::TreeView, ElementRole::TreeItem, ElementRole::Toolbar,
-            ElementRole::StatusBar, ElementRole::Dialog, ElementRole::Group,
-            ElementRole::Image, ElementRole::Link, ElementRole::Custom("custom".into()),
+            ElementRole::Window,
+            ElementRole::Button,
+            ElementRole::Input,
+            ElementRole::Text,
+            ElementRole::List,
+            ElementRole::ListItem,
+            ElementRole::Menu,
+            ElementRole::MenuItem,
+            ElementRole::Tab,
+            ElementRole::TabItem,
+            ElementRole::Table,
+            ElementRole::TableRow,
+            ElementRole::TableCell,
+            ElementRole::Checkbox,
+            ElementRole::RadioButton,
+            ElementRole::ComboBox,
+            ElementRole::Slider,
+            ElementRole::ScrollBar,
+            ElementRole::TreeView,
+            ElementRole::TreeItem,
+            ElementRole::Toolbar,
+            ElementRole::StatusBar,
+            ElementRole::Dialog,
+            ElementRole::Group,
+            ElementRole::Image,
+            ElementRole::Link,
+            ElementRole::Custom("custom".into()),
         ];
         assert_eq!(roles.len(), 27);
         for role in &roles {
@@ -196,7 +216,12 @@ mod tests {
 
     #[test]
     fn test_bounds_serialization() {
-        let bounds = Bounds { x: 10, y: 20, width: 100, height: 50 };
+        let bounds = Bounds {
+            x: 10,
+            y: 20,
+            width: 100,
+            height: 50,
+        };
         let json = serde_json::to_string(&bounds).unwrap();
         let back: Bounds = serde_json::from_str(&json).unwrap();
         assert_eq!(back.x, 10);
@@ -212,10 +237,19 @@ mod tests {
             role: ElementRole::Button,
             label: Some("OK".into()),
             value: None,
-            bounds: Some(Bounds { x: 100, y: 200, width: 80, height: 30 }),
+            bounds: Some(Bounds {
+                x: 100,
+                y: 200,
+                width: 80,
+                height: 30,
+            }),
             state: ElementState {
-                focused: false, enabled: true, visible: true,
-                selected: false, expanded: None, checked: None,
+                focused: false,
+                enabled: true,
+                visible: true,
+                selected: false,
+                expanded: None,
+                checked: None,
             },
             description: None,
             parent_id: None,
@@ -229,10 +263,19 @@ mod tests {
             role: ElementRole::Dialog,
             label: Some("Confirm".into()),
             value: None,
-            bounds: Some(Bounds { x: 50, y: 50, width: 300, height: 200 }),
+            bounds: Some(Bounds {
+                x: 50,
+                y: 50,
+                width: 300,
+                height: 200,
+            }),
             state: ElementState {
-                focused: true, enabled: true, visible: true,
-                selected: false, expanded: None, checked: None,
+                focused: true,
+                enabled: true,
+                visible: true,
+                selected: false,
+                expanded: None,
+                checked: None,
             },
             description: None,
             parent_id: None,
@@ -253,10 +296,19 @@ mod tests {
             role: ElementRole::Input,
             label: Some("Username".into()),
             value: Some("admin".into()),
-            bounds: Some(Bounds { x: 0, y: 0, width: 200, height: 30 }),
+            bounds: Some(Bounds {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 30,
+            }),
             state: ElementState {
-                focused: true, enabled: true, visible: true,
-                selected: false, expanded: None, checked: None,
+                focused: true,
+                enabled: true,
+                visible: true,
+                selected: false,
+                expanded: None,
+                checked: None,
             },
             description: None,
             parent_id: None,

--- a/cel/cel-accessibility/src/linux.rs
+++ b/cel/cel-accessibility/src/linux.rs
@@ -97,6 +97,13 @@ impl LinuxAccessibility {
                 ))
             })?;
 
+        // tokio::net::UnixStream::from_std panics if called outside a Tokio
+        // runtime (e.g. plain `cargo test` without #[tokio::test]). Treat that
+        // as Unavailable so the caller falls back to StubAccessibility.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(AccessibilityError::Unavailable);
+        }
+
         let std_stream = UnixStream::connect(socket_path).map_err(|e| {
             AccessibilityError::QueryFailed(format!("Connect AT-SPI2 socket: {}", e))
         })?;
@@ -389,6 +396,7 @@ impl LinuxAccessibility {
     }
 
     /// Recursively build an AccessibilityElement tree from a D-Bus accessible.
+    #[allow(clippy::too_many_arguments)]
     fn build_element(
         &self,
         dest: &str,
@@ -732,12 +740,10 @@ fn collect_matching(
     label: Option<&str>,
     out: &mut Vec<AccessibilityElement>,
 ) {
-    let role_matches = role.map_or(true, |r| {
-        std::mem::discriminant(&node.role) == std::mem::discriminant(r)
-    });
-    let label_matches = label.map_or(true, |l| {
-        node.label.as_deref().map_or(false, |nl| nl.contains(l))
-    });
+    let role_matches =
+        role.is_none_or(|r| std::mem::discriminant(&node.role) == std::mem::discriminant(r));
+    let label_matches =
+        label.is_none_or(|l| node.label.as_deref().is_some_and(|nl| nl.contains(l)));
 
     if role_matches && label_matches {
         out.push(node.clone());

--- a/cel/cel-accessibility/src/linux.rs
+++ b/cel/cel-accessibility/src/linux.rs
@@ -76,9 +76,9 @@ impl LinuxAccessibility {
         )
         .map_err(|e| AccessibilityError::QueryFailed(format!("a11y bus proxy: {}", e)))?;
 
-        let address: String = proxy.call("GetAddress", &()).map_err(|e| {
-            AccessibilityError::QueryFailed(format!("GetAddress: {}", e))
-        })?;
+        let address: String = proxy
+            .call("GetAddress", &())
+            .map_err(|e| AccessibilityError::QueryFailed(format!("GetAddress: {}", e)))?;
 
         if address.is_empty() {
             return Err(AccessibilityError::Unavailable);
@@ -100,26 +100,22 @@ impl LinuxAccessibility {
         let std_stream = UnixStream::connect(socket_path).map_err(|e| {
             AccessibilityError::QueryFailed(format!("Connect AT-SPI2 socket: {}", e))
         })?;
-        std_stream.set_nonblocking(true).map_err(|e| {
-            AccessibilityError::QueryFailed(format!("Set non-blocking: {}", e))
-        })?;
-        let stream = tokio::net::UnixStream::from_std(std_stream).map_err(|e| {
-            AccessibilityError::QueryFailed(format!("Tokio UnixStream: {}", e))
-        })?;
+        std_stream
+            .set_nonblocking(true)
+            .map_err(|e| AccessibilityError::QueryFailed(format!("Set non-blocking: {}", e)))?;
+        let stream = tokio::net::UnixStream::from_std(std_stream)
+            .map_err(|e| AccessibilityError::QueryFailed(format!("Tokio UnixStream: {}", e)))?;
 
         zbus::blocking::connection::Builder::unix_stream(stream)
             .method_timeout(DBUS_TIMEOUT)
             .build()
-            .map_err(|e| {
-                AccessibilityError::QueryFailed(format!("AT-SPI2 bus auth: {}", e))
-            })
+            .map_err(|e| AccessibilityError::QueryFailed(format!("AT-SPI2 bus auth: {}", e)))
     }
 
     /// Query the Name property of an accessible object.
     fn get_name(&self, dest: &str, path: &str) -> Option<String> {
-        let proxy = zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Accessible",
-        ).ok()?;
+        let proxy =
+            zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Accessible").ok()?;
         let value: OwnedValue = proxy.get_property("Name").ok()?;
         let name: &str = value.downcast_ref().ok()?;
         if name.is_empty() {
@@ -131,11 +127,11 @@ impl LinuxAccessibility {
 
     /// Query the Role of an accessible object via GetRoleName.
     fn get_role(&self, dest: &str, path: &str) -> ElementRole {
-        let proxy = match zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Accessible") {
-            Ok(p) => p,
-            Err(_) => return ElementRole::Custom("unknown".into()),
-        };
+        let proxy =
+            match zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Accessible") {
+                Ok(p) => p,
+                Err(_) => return ElementRole::Custom("unknown".into()),
+            };
 
         let result: Result<String, _> = proxy.call("GetRoleName", &());
         match result {
@@ -146,8 +142,8 @@ impl LinuxAccessibility {
 
     /// Query the bounding box via the Component interface's GetExtents method.
     fn get_bounds(&self, dest: &str, path: &str) -> Option<Bounds> {
-        let proxy = zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Component").ok()?;
+        let proxy =
+            zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Component").ok()?;
 
         // GetExtents(coord_type: u32) -> (x, y, width, height)
         // coord_type 0 = screen coordinates
@@ -165,8 +161,8 @@ impl LinuxAccessibility {
 
     /// Get the Value property (for inputs, sliders, etc.).
     fn get_value(&self, dest: &str, path: &str) -> Option<String> {
-        let proxy = zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Value").ok()?;
+        let proxy =
+            zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Value").ok()?;
         let value: OwnedValue = proxy.get_property("CurrentValue").ok()?;
         if let Ok(v) = value.downcast_ref::<f64>() {
             return Some(v.to_string());
@@ -176,8 +172,8 @@ impl LinuxAccessibility {
 
     /// Get the Description property (secondary label / tooltip).
     fn get_description(&self, dest: &str, path: &str) -> Option<String> {
-        let proxy = zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Accessible").ok()?;
+        let proxy =
+            zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Accessible").ok()?;
         let value: OwnedValue = proxy.get_property("Description").ok()?;
         let desc: &str = value.downcast_ref().ok()?;
         if desc.is_empty() {
@@ -200,11 +196,11 @@ impl LinuxAccessibility {
     ///   30 = visible,     31 = manages_descendants
     ///   41 = checkable    (in second u32, bit 9)
     fn get_state(&self, dest: &str, path: &str) -> ElementState {
-        let proxy = match zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Accessible") {
-            Ok(p) => p,
-            Err(_) => return ElementState::default_visible(),
-        };
+        let proxy =
+            match zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Accessible") {
+                Ok(p) => p,
+                Err(_) => return ElementState::default_visible(),
+            };
 
         // GetState returns (u32, u32) — two halves of a 64-bit bitfield
         let result: Result<Vec<u32>, _> = proxy.call("GetState", &());
@@ -212,17 +208,19 @@ impl LinuxAccessibility {
             Ok(state_vec) if state_vec.len() >= 2 => {
                 let bits: u64 = (state_vec[0] as u64) | ((state_vec[1] as u64) << 32);
                 ElementState {
-                    focused:  bits & (1 << 12) != 0,  // ATSPI_STATE_FOCUSED = 12
-                    enabled:  bits & (1 << 8) != 0,    // ATSPI_STATE_ENABLED = 8
-                    visible:  bits & (1 << 30) != 0,   // ATSPI_STATE_VISIBLE = 30
-                    selected: bits & (1 << 23) != 0,   // ATSPI_STATE_SELECTED = 23
-                    expanded: if bits & (1 << 9) != 0 { // ATSPI_STATE_EXPANDABLE = 9
-                        Some(bits & (1 << 10) != 0)     // ATSPI_STATE_EXPANDED = 10
+                    focused: bits & (1 << 12) != 0,  // ATSPI_STATE_FOCUSED = 12
+                    enabled: bits & (1 << 8) != 0,   // ATSPI_STATE_ENABLED = 8
+                    visible: bits & (1 << 30) != 0,  // ATSPI_STATE_VISIBLE = 30
+                    selected: bits & (1 << 23) != 0, // ATSPI_STATE_SELECTED = 23
+                    expanded: if bits & (1 << 9) != 0 {
+                        // ATSPI_STATE_EXPANDABLE = 9
+                        Some(bits & (1 << 10) != 0) // ATSPI_STATE_EXPANDED = 10
                     } else {
                         None
                     },
-                    checked: if bits & (1u64 << 41) != 0 { // ATSPI_STATE_CHECKABLE = 41
-                        Some(bits & (1 << 4) != 0)          // ATSPI_STATE_CHECKED = 4
+                    checked: if bits & (1u64 << 41) != 0 {
+                        // ATSPI_STATE_CHECKABLE = 41
+                        Some(bits & (1 << 4) != 0) // ATSPI_STATE_CHECKED = 4
                     } else {
                         None
                     },
@@ -231,9 +229,9 @@ impl LinuxAccessibility {
             Ok(state_vec) if state_vec.len() == 1 => {
                 let bits: u64 = state_vec[0] as u64;
                 ElementState {
-                    focused:  bits & (1 << 12) != 0,
-                    enabled:  bits & (1 << 8) != 0,
-                    visible:  bits & (1 << 30) != 0,
+                    focused: bits & (1 << 12) != 0,
+                    enabled: bits & (1 << 8) != 0,
+                    visible: bits & (1 << 30) != 0,
                     selected: bits & (1 << 23) != 0,
                     expanded: None,
                     checked: None,
@@ -248,8 +246,8 @@ impl LinuxAccessibility {
 
     /// Get text content from the Text interface.
     fn get_text(&self, dest: &str, path: &str) -> Option<String> {
-        let proxy = zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Text").ok()?;
+        let proxy =
+            zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Text").ok()?;
 
         // GetText(start_offset, end_offset) — use 0, -1 for full text
         let result: Result<String, _> = proxy.call("GetText", &(0i32, -1i32));
@@ -262,11 +260,11 @@ impl LinuxAccessibility {
     /// Get the count of selected children via the Selection interface.
     /// Returns the number of selected children, or 0 if not a selection container.
     fn get_selected_count(&self, dest: &str, path: &str) -> usize {
-        let proxy = match zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Selection") {
-            Ok(p) => p,
-            Err(_) => return 0,
-        };
+        let proxy =
+            match zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Selection") {
+                Ok(p) => p,
+                Err(_) => return 0,
+            };
 
         let result: Result<i32, _> = proxy.get_property("NSelectedChildren");
         match result {
@@ -278,11 +276,11 @@ impl LinuxAccessibility {
     /// Get available actions from the Action interface.
     /// Returns action names like "click", "press", "activate", "expand or contract".
     fn get_actions(&self, dest: &str, path: &str) -> Vec<String> {
-        let proxy = match zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Action") {
-            Ok(p) => p,
-            Err(_) => return vec![],
-        };
+        let proxy =
+            match zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Action") {
+                Ok(p) => p,
+                Err(_) => return vec![],
+            };
 
         // Get the number of actions
         let n_actions: Result<i32, _> = proxy.get_property("NActions");
@@ -322,13 +320,17 @@ impl LinuxAccessibility {
         let state = self.get_state(dest, path);
         let mut found_here = if state.focused {
             let role = self.get_role(dest, path);
-            let label = self.get_name(dest, path).or_else(|| self.get_description(dest, path));
+            let label = self
+                .get_name(dest, path)
+                .or_else(|| self.get_description(dest, path));
             Some(AccessibilityElement {
                 id: format!("focused-{}", depth),
                 role,
                 label,
                 description: self.get_description(dest, path),
-                value: self.get_text(dest, path).or_else(|| self.get_value(dest, path)),
+                value: self
+                    .get_text(dest, path)
+                    .or_else(|| self.get_value(dest, path)),
                 bounds: self.get_bounds(dest, path),
                 state: state.clone(),
                 parent_id: None,
@@ -347,7 +349,11 @@ impl LinuxAccessibility {
             if i >= MAX_FOCUSED_ELEMENTS {
                 break;
             }
-            let child_dest = if child_bus.is_empty() { dest } else { child_bus.as_str() };
+            let child_dest = if child_bus.is_empty() {
+                dest
+            } else {
+                child_bus.as_str()
+            };
             if let Some(deeper) = self.find_focused_in_tree(child_dest, child_path, depth + 1) {
                 // Prefer the deepest focused element (most specific)
                 found_here = Some(deeper);
@@ -359,14 +365,14 @@ impl LinuxAccessibility {
 
     /// Get children of an accessible object as (bus_name, object_path) pairs.
     fn get_children(&self, dest: &str, path: &str) -> Vec<(String, String)> {
-        let proxy = match zbus::blocking::Proxy::new(
-            &self.conn, dest, path, "org.a11y.atspi.Accessible") {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::trace!("get_children proxy failed for {} {}: {}", dest, path, e);
-                return vec![];
-            }
-        };
+        let proxy =
+            match zbus::blocking::Proxy::new(&self.conn, dest, path, "org.a11y.atspi.Accessible") {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::trace!("get_children proxy failed for {} {}: {}", dest, path, e);
+                    return vec![];
+                }
+            };
 
         // GetChildren returns array of (bus_name, object_path) D-Bus structs: a(so)
         let result: Result<Vec<(String, OwnedObjectPath)>, _> = proxy.call("GetChildren", &());
@@ -404,7 +410,9 @@ impl LinuxAccessibility {
         let label = name.or_else(|| description.clone());
 
         // Try to get value — first from Text interface, then Value interface
-        let value = self.get_text(dest, path).or_else(|| self.get_value(dest, path));
+        let value = self
+            .get_text(dest, path)
+            .or_else(|| self.get_value(dest, path));
 
         // Get available actions (click, press, activate, etc.)
         let actions = self.get_actions(dest, path);
@@ -418,7 +426,10 @@ impl LinuxAccessibility {
 
         // For list/tree containers, check if this element has selected children
         // (enriches the selected state beyond just the state bitfield)
-        if matches!(role, ElementRole::List | ElementRole::TreeView | ElementRole::Table) {
+        if matches!(
+            role,
+            ElementRole::List | ElementRole::TreeView | ElementRole::Table
+        ) {
             let n_selected = self.get_selected_count(dest, path);
             if n_selected > 0 {
                 state.selected = true;
@@ -435,7 +446,11 @@ impl LinuxAccessibility {
                 if *element_count >= max_elements {
                     break;
                 }
-                let child_dest = if child_bus.is_empty() { dest } else { child_bus.as_str() };
+                let child_dest = if child_bus.is_empty() {
+                    dest
+                } else {
+                    child_bus.as_str()
+                };
                 children.push(self.build_element(
                     child_dest,
                     child_path,
@@ -473,9 +488,17 @@ impl LinuxAccessibility {
 fn collect_element_text(elem: &AccessibilityElement) -> String {
     let mut buf = String::new();
     fn recurse(e: &AccessibilityElement, b: &mut String) {
-        if let Some(ref l) = e.label { b.push_str(l); b.push(' '); }
-        if let Some(ref v) = e.value { b.push_str(v); b.push(' '); }
-        for child in &e.children { recurse(child, b); }
+        if let Some(ref l) = e.label {
+            b.push_str(l);
+            b.push(' ');
+        }
+        if let Some(ref v) = e.value {
+            b.push_str(v);
+            b.push(' ');
+        }
+        for child in &e.children {
+            recurse(child, b);
+        }
     }
     recurse(elem, &mut buf);
     buf
@@ -495,7 +518,8 @@ impl AccessibilityTree for LinuxAccessibility {
 
         for (idx, (bus_name, _obj_path)) in children_refs.iter().enumerate() {
             // Derive app name for budget/cache keying
-            let app_name = self.get_name(bus_name, app_root_path)
+            let app_name = self
+                .get_name(bus_name, app_root_path)
                 .filter(|n| !n.is_empty())
                 .unwrap_or_else(|| bus_name.clone());
 
@@ -508,7 +532,9 @@ impl AccessibilityTree for LinuxAccessibility {
             }
 
             // Per-app budget check
-            let decision = self.budget.lock()
+            let decision = self
+                .budget
+                .lock()
                 .map(|mut b| b.should_walk(&app_name))
                 .unwrap_or(crate::budget::WalkDecision {
                     walk: true,
@@ -836,20 +862,59 @@ mod tests {
 
     #[test]
     fn test_atspi_role_mapping() {
-        assert!(matches!(atspi_role_to_element_role("push button"), ElementRole::Button));
-        assert!(matches!(atspi_role_to_element_role("entry"), ElementRole::Input));
-        assert!(matches!(atspi_role_to_element_role("check box"), ElementRole::Checkbox));
-        assert!(matches!(atspi_role_to_element_role("combo box"), ElementRole::ComboBox));
-        assert!(matches!(atspi_role_to_element_role("menu bar"), ElementRole::Menu));
-        assert!(matches!(atspi_role_to_element_role("page tab"), ElementRole::TabItem));
-        assert!(matches!(atspi_role_to_element_role("table"), ElementRole::Table));
-        assert!(matches!(atspi_role_to_element_role("tree"), ElementRole::TreeView));
-        assert!(matches!(atspi_role_to_element_role("link"), ElementRole::Link));
-        assert!(matches!(atspi_role_to_element_role("slider"), ElementRole::Slider));
-        assert!(matches!(atspi_role_to_element_role("panel"), ElementRole::Group));
-        assert!(matches!(atspi_role_to_element_role("image"), ElementRole::Image));
+        assert!(matches!(
+            atspi_role_to_element_role("push button"),
+            ElementRole::Button
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("entry"),
+            ElementRole::Input
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("check box"),
+            ElementRole::Checkbox
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("combo box"),
+            ElementRole::ComboBox
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("menu bar"),
+            ElementRole::Menu
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("page tab"),
+            ElementRole::TabItem
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("table"),
+            ElementRole::Table
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("tree"),
+            ElementRole::TreeView
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("link"),
+            ElementRole::Link
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("slider"),
+            ElementRole::Slider
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("panel"),
+            ElementRole::Group
+        ));
+        assert!(matches!(
+            atspi_role_to_element_role("image"),
+            ElementRole::Image
+        ));
         // Unknown roles become Custom
-        assert!(matches!(atspi_role_to_element_role("weird-widget"), ElementRole::Custom(_)));
+        assert!(matches!(
+            atspi_role_to_element_role("weird-widget"),
+            ElementRole::Custom(_)
+        ));
     }
 
     #[test]

--- a/cel/cel-accessibility/src/macos.rs
+++ b/cel/cel-accessibility/src/macos.rs
@@ -36,11 +36,20 @@ type CGDirectDisplayID = u32;
 
 // CGRect in points (not pixels) for monitor geometry.
 #[repr(C)]
-struct CGPointF { x: f64, y: f64 }
+struct CGPointF {
+    x: f64,
+    y: f64,
+}
 #[repr(C)]
-struct CGSizeF { width: f64, height: f64 }
+struct CGSizeF {
+    width: f64,
+    height: f64,
+}
 #[repr(C)]
-struct CGRectF { origin: CGPointF, size: CGSizeF }
+struct CGRectF {
+    origin: CGPointF,
+    size: CGSizeF,
+}
 
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
@@ -57,17 +66,19 @@ extern "C" {
 fn get_display_scale_factor() -> f64 {
     use std::sync::OnceLock;
     static SCALE: OnceLock<f64> = OnceLock::new();
-    *SCALE.get_or_init(|| {
-        unsafe {
-            let display = CGMainDisplayID();
-            let mode = CGDisplayCopyDisplayMode(display);
-            if mode.is_null() {
-                return 1.0;
-            }
-            let pixel_w = CGDisplayModeGetPixelWidth(mode) as f64;
-            let point_w = CGDisplayModeGetWidth(mode) as f64;
-            CGDisplayModeRelease(mode);
-            if point_w > 0.0 { pixel_w / point_w } else { 1.0 }
+    *SCALE.get_or_init(|| unsafe {
+        let display = CGMainDisplayID();
+        let mode = CGDisplayCopyDisplayMode(display);
+        if mode.is_null() {
+            return 1.0;
+        }
+        let pixel_w = CGDisplayModeGetPixelWidth(mode) as f64;
+        let point_w = CGDisplayModeGetWidth(mode) as f64;
+        CGDisplayModeRelease(mode);
+        if point_w > 0.0 {
+            pixel_w / point_w
+        } else {
+            1.0
         }
     })
 }
@@ -77,7 +88,12 @@ fn get_main_monitor_bounds() -> (f64, f64, f64, f64) {
     unsafe {
         let display = CGMainDisplayID();
         let rect = CGDisplayBounds(display);
-        (rect.origin.x, rect.origin.y, rect.size.width, rect.size.height)
+        (
+            rect.origin.x,
+            rect.origin.y,
+            rect.size.width,
+            rect.size.height,
+        )
     }
 }
 
@@ -111,10 +127,7 @@ extern "C" {
         attribute: CFStringRef,
         value: *mut CFTypeRef,
     ) -> AXError;
-    fn AXUIElementCopyActionNames(
-        element: AXUIElementRef,
-        names: *mut CFTypeRef,
-    ) -> AXError;
+    fn AXUIElementCopyActionNames(element: AXUIElementRef, names: *mut CFTypeRef) -> AXError;
     fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut i32) -> AXError;
     fn AXUIElementPerformAction(element: AXUIElementRef, action: CFStringRef) -> AXError;
     fn AXUIElementSetAttributeValue(
@@ -134,10 +147,7 @@ extern "C" {
         element: *mut AXUIElementRef,
     ) -> AXError;
     #[allow(dead_code)]
-    fn AXUIElementCopyAttributeNames(
-        element: AXUIElementRef,
-        names: *mut CFTypeRef,
-    ) -> AXError;
+    fn AXUIElementCopyAttributeNames(element: AXUIElementRef, names: *mut CFTypeRef) -> AXError;
     fn AXIsProcessTrusted() -> bool;
     fn AXIsProcessTrustedWithOptions(options: *const c_void) -> bool;
     fn CFRelease(cf: *const c_void);
@@ -167,9 +177,7 @@ extern "C" {
         notification: CFStringRef,
         refcon: *mut c_void,
     ) -> AXError;
-    fn AXObserverGetRunLoopSource(
-        observer: AXObserverRef,
-    ) -> *const c_void; // CFRunLoopSourceRef
+    fn AXObserverGetRunLoopSource(observer: AXObserverRef) -> *const c_void; // CFRunLoopSourceRef
 }
 
 // CFRunLoop FFI
@@ -180,7 +188,11 @@ type CFRunLoopSourceRef = *const c_void;
 extern "C" {
     fn CFRunLoopGetCurrent() -> CFRunLoopRef;
     fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
-    fn CFRunLoopRunInMode(mode: CFStringRef, seconds: f64, return_after_source_handled: bool) -> i32;
+    fn CFRunLoopRunInMode(
+        mode: CFStringRef,
+        seconds: f64,
+        return_after_source_handled: bool,
+    ) -> i32;
     fn CFRunLoopStop(rl: CFRunLoopRef);
 }
 
@@ -250,7 +262,9 @@ unsafe extern "C" fn ax_observer_callback(
         "AXWindowResized" => AccessibilityEvent::WindowResized,
         "AXWindowMiniaturized" => AccessibilityEvent::WindowMinimized,
         "AXWindowDeminiaturized" => AccessibilityEvent::WindowRestored,
-        "AXSelectedTextChanged" | "AXSelectedChildrenChanged" => AccessibilityEvent::SelectionChanged,
+        "AXSelectedTextChanged" | "AXSelectedChildrenChanged" => {
+            AccessibilityEvent::SelectionChanged
+        }
         "AXRowCountChanged" => AccessibilityEvent::RowCountChanged,
         "AXRowExpanded" | "AXRowCollapsed" | "AXSelectedRowsChanged" | "AXSelectedCellsChanged" => {
             AccessibilityEvent::LayoutChanged
@@ -265,15 +279,14 @@ unsafe extern "C" fn ax_observer_callback(
             let app_name = get_ax_string(element, "AXTitle");
             AccessibilityEvent::AppShown { app_name }
         }
-        "AXAnnouncementRequested" => {
-            AccessibilityEvent::AnnouncementRequested { text: None }
-        }
+        "AXAnnouncementRequested" => AccessibilityEvent::AnnouncementRequested { text: None },
         "AXHelpTagCreated" => AccessibilityEvent::HelpTagShown,
         _ => return, // Ignore unknown notifications
     };
 
     if let Ok(mut events) = buffer.lock() {
-        if events.len() < 200 { // Cap buffer to prevent unbounded growth
+        if events.len() < 200 {
+            // Cap buffer to prevent unbounded growth
             events.push(event);
         }
     }
@@ -342,8 +355,7 @@ pub fn request_process_trust() -> bool {
 
     let key = CFString::from_static_string("AXTrustedCheckOptionPrompt");
     let value = CFBoolean::true_value();
-    let pairs: Vec<(CFString, CFType)> =
-        vec![(key, value.as_CFType())];
+    let pairs: Vec<(CFString, CFType)> = vec![(key, value.as_CFType())];
     let options = CFDictionary::from_CFType_pairs(&pairs);
 
     unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef() as *const c_void) }
@@ -446,11 +458,7 @@ impl MacAccessibility {
 
                     // Run the loop — blocks until CFRunLoopStop is called
                     loop {
-                        let result = CFRunLoopRunInMode(
-                            kCFRunLoopDefaultMode,
-                            1.0,
-                            false,
-                        );
+                        let result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0, false);
                         // result == 1 means the run loop was stopped via CFRunLoopStop
                         if result == 1 {
                             break;
@@ -458,13 +466,17 @@ impl MacAccessibility {
                     }
 
                     // Reconstruct the Arc to drop it properly
-                    let _ = std::sync::Arc::from_raw(refcon as *const std::sync::Mutex<Vec<AccessibilityEvent>>);
+                    let _ = std::sync::Arc::from_raw(
+                        refcon as *const std::sync::Mutex<Vec<AccessibilityEvent>>,
+                    );
 
                     CFRelease(app as *const c_void);
                     CFRelease(observer);
                 }
             })
-            .map_err(|e| AccessibilityError::QueryFailed(format!("Failed to spawn observer thread: {}", e)))?;
+            .map_err(|e| {
+                AccessibilityError::QueryFailed(format!("Failed to spawn observer thread: {}", e))
+            })?;
 
         // Wait for the thread to send us its CFRunLoopRef
         let run_loop_addr = rl_rx.recv_timeout(Duration::from_secs(2)).unwrap_or(0);
@@ -540,14 +552,13 @@ impl MacAccessibility {
                 other => other, // Pass through raw AX action names
             };
             let action_cf = CFString::new(ax_action);
-            let err = unsafe {
-                AXUIElementPerformAction(element, action_cf.as_concrete_TypeRef())
-            };
+            let err = unsafe { AXUIElementPerformAction(element, action_cf.as_concrete_TypeRef()) };
             return if err == K_AX_ERROR_SUCCESS {
                 Ok(true)
             } else {
                 Err(AccessibilityError::OperationFailed(format!(
-                    "AXPerformAction '{}' failed with error {}", action, err
+                    "AXPerformAction '{}' failed with error {}",
+                    action, err
                 )))
             };
         }
@@ -565,8 +576,15 @@ impl MacAccessibility {
                     if *count >= MAX_ELEMENTS {
                         break;
                     }
-                    if let Some(child_ref) = arr.get(i).map(|c| c.as_CFTypeRef() as AXUIElementRef) {
-                        match self.find_and_perform_action(child_ref, target_id, action, depth + 1, count) {
+                    if let Some(child_ref) = arr.get(i).map(|c| c.as_CFTypeRef() as AXUIElementRef)
+                    {
+                        match self.find_and_perform_action(
+                            child_ref,
+                            target_id,
+                            action,
+                            depth + 1,
+                            count,
+                        ) {
                             Ok(true) => return Ok(true),
                             Err(e) => return Err(e),
                             Ok(false) => {} // Keep searching
@@ -636,7 +654,11 @@ impl MacAccessibility {
         }
         // Timeout check — only check every 10 elements to reduce clock overhead
         if current_count % 10 == 0 && std::time::Instant::now() > *deadline {
-            tracing::debug!("AX tree traversal hit timeout at depth {}, count {}", depth, current_count);
+            tracing::debug!(
+                "AX tree traversal hit timeout at depth {}, count {}",
+                depth,
+                current_count
+            );
             return None;
         }
 
@@ -667,9 +689,7 @@ impl MacAccessibility {
             .or_else(|| get_ax_string(element, "AXDescription"));
 
         // Filter out empty text elements and spacers early
-        if role_str == "AXStaticText"
-            && label.as_deref().map_or(true, |l| l.trim().is_empty())
-        {
+        if role_str == "AXStaticText" && label.as_deref().map_or(true, |l| l.trim().is_empty()) {
             let value_check = get_ax_string(element, "AXValue");
             if value_check.as_deref().map_or(true, |v| v.trim().is_empty()) {
                 return None;
@@ -709,7 +729,9 @@ impl MacAccessibility {
             properties.insert("required".into(), "true".into());
         }
         if let Some(v) = get_ax_string(element, "AXInvalid") {
-            if v != "false" { properties.insert("invalid".into(), v); }
+            if v != "false" {
+                properties.insert("invalid".into(), v);
+            }
         }
         // Slider bounds
         if role_str == "AXSlider" || role_str == "AXValueIndicator" {
@@ -770,7 +792,8 @@ impl MacAccessibility {
                     // Collect child refs
                     let child_refs: Vec<SendableAXRef> = (0..arr.len())
                         .filter_map(|i| {
-                            arr.get(i).map(|c| SendableAXRef(c.as_CFTypeRef() as AXUIElementRef))
+                            arr.get(i)
+                                .map(|c| SendableAXRef(c.as_CFTypeRef() as AXUIElementRef))
                         })
                         .collect();
 
@@ -782,7 +805,14 @@ impl MacAccessibility {
                                 if count.load(Ordering::Relaxed) >= max_nodes {
                                     return None;
                                 }
-                                self.build_element(child.0, Some(&id), depth + 1, count, deadline, max_nodes)
+                                self.build_element(
+                                    child.0,
+                                    Some(&id),
+                                    depth + 1,
+                                    count,
+                                    deadline,
+                                    max_nodes,
+                                )
                             })
                             .collect()
                     } else {
@@ -792,7 +822,14 @@ impl MacAccessibility {
                             if count.load(Ordering::Relaxed) >= max_nodes {
                                 break;
                             }
-                            if let Some(child_elem) = self.build_element(child.0, Some(&id), depth + 1, count, deadline, max_nodes) {
+                            if let Some(child_elem) = self.build_element(
+                                child.0,
+                                Some(&id),
+                                depth + 1,
+                                count,
+                                deadline,
+                                max_nodes,
+                            ) {
                                 kids.push(child_elem);
                             }
                         }
@@ -849,7 +886,9 @@ impl MacAccessibility {
     ) -> Result<(AccessibilityElement, TruncationReason), AccessibilityError> {
         let app = unsafe { AXUIElementCreateApplication(pid) };
         if app.is_null() {
-            return Err(AccessibilityError::QueryFailed("Failed to create app element".into()));
+            return Err(AccessibilityError::QueryFailed(
+                "Failed to create app element".into(),
+            ));
         }
 
         let app_label = get_ax_string(app, "AXTitle");
@@ -916,7 +955,9 @@ impl MacAccessibility {
     /// Get the display name of an app by PID (cheap — single AX attribute read).
     fn get_app_name_for_pid(&self, pid: i32) -> String {
         let app = unsafe { AXUIElementCreateApplication(pid) };
-        if app.is_null() { return pid.to_string(); }
+        if app.is_null() {
+            return pid.to_string();
+        }
         let name = get_ax_string(app, "AXTitle").unwrap_or_else(|| pid.to_string());
         unsafe { CFRelease(app as *const c_void) };
         name
@@ -927,9 +968,17 @@ impl MacAccessibility {
 fn collect_element_text(elem: &AccessibilityElement) -> String {
     let mut buf = String::new();
     fn recurse(e: &AccessibilityElement, b: &mut String) {
-        if let Some(ref l) = e.label { b.push_str(l); b.push(' '); }
-        if let Some(ref v) = e.value { b.push_str(v); b.push(' '); }
-        for child in &e.children { recurse(child, b); }
+        if let Some(ref l) = e.label {
+            b.push_str(l);
+            b.push(' ');
+        }
+        if let Some(ref v) = e.value {
+            b.push_str(v);
+            b.push(' ');
+        }
+        for child in &e.children {
+            recurse(child, b);
+        }
     }
     recurse(elem, &mut buf);
     buf
@@ -960,7 +1009,9 @@ impl AccessibilityTree for MacAccessibility {
         let app_name = self.get_app_name_for_pid(pid);
 
         // ── BUDGET CHECK: may throttle walk for heavy apps ──
-        let decision = self.budget.lock()
+        let decision = self
+            .budget
+            .lock()
             .map(|mut b| b.should_walk(&app_name))
             .unwrap_or(crate::budget::WalkDecision {
                 walk: true,
@@ -993,7 +1044,11 @@ impl AccessibilityTree for MacAccessibility {
                     && current_event_count == cached_event_count
                     && age_ms < CACHE_MAX_AGE_MS
                 {
-                    tracing::debug!("AX tree cache hit (age: {}ms, events: {})", age_ms, current_event_count);
+                    tracing::debug!(
+                        "AX tree cache hit (age: {}ms, events: {})",
+                        age_ms,
+                        current_event_count
+                    );
                     return Ok(cached.tree.clone());
                 }
             }
@@ -1001,22 +1056,33 @@ impl AccessibilityTree for MacAccessibility {
 
         // ── FULL TREE WALK ──
         let walk_start = std::time::Instant::now();
-        let (mut elem, truncation) = self.build_tree_for_pid(pid, decision.max_nodes, decision.timeout)?;
+        let (mut elem, truncation) =
+            self.build_tree_for_pid(pid, decision.max_nodes, decision.timeout)?;
         let walk_duration = walk_start.elapsed();
 
         // Record walk outcome in budget
         if let Ok(mut b) = self.budget.lock() {
-            b.record_walk(&app_name, walk_duration, truncation != TruncationReason::None);
+            b.record_walk(
+                &app_name,
+                walk_duration,
+                truncation != TruncationReason::None,
+            );
         }
 
         // Chromium warmup retry
         let actionable = count_actionable(&elem);
         if actionable < 5 {
             std::thread::sleep(std::time::Duration::from_millis(150));
-            if let Ok((retry, retry_trunc)) = self.build_tree_for_pid(pid, decision.max_nodes, decision.timeout) {
+            if let Ok((retry, retry_trunc)) =
+                self.build_tree_for_pid(pid, decision.max_nodes, decision.timeout)
+            {
                 if count_actionable(&retry) > actionable {
                     if let Ok(mut b) = self.budget.lock() {
-                        b.record_walk(&app_name, walk_duration, retry_trunc != TruncationReason::None);
+                        b.record_walk(
+                            &app_name,
+                            walk_duration,
+                            retry_trunc != TruncationReason::None,
+                        );
                     }
                     elem = retry;
                 }
@@ -1033,7 +1099,8 @@ impl AccessibilityTree for MacAccessibility {
             } else {
                 tracing::debug!(
                     "AX snapshot dedup: near-identical content (app={}, window={})",
-                    app_name, window_title
+                    app_name,
+                    window_title
                 );
             }
         }
@@ -1046,7 +1113,8 @@ impl AccessibilityTree for MacAccessibility {
                 created_at: std::time::Instant::now(),
             });
         }
-        self.cache_event_count.store(current_event_count, Ordering::Relaxed);
+        self.cache_event_count
+            .store(current_event_count, Ordering::Relaxed);
 
         Ok(elem)
     }
@@ -1105,7 +1173,9 @@ impl AccessibilityTree for MacAccessibility {
         let pid = self.get_focused_app_pid()?;
         let app = unsafe { AXUIElementCreateApplication(pid) };
         if app.is_null() {
-            return Err(AccessibilityError::QueryFailed("Failed to create app element".into()));
+            return Err(AccessibilityError::QueryFailed(
+                "Failed to create app element".into(),
+            ));
         }
 
         // Get the target element — prefer focused window, fall back to app
@@ -1125,11 +1195,10 @@ impl AccessibilityTree for MacAccessibility {
                 tracing::info!("AXPerformAction '{}' on element '{}'", action, element_id);
                 Ok(true)
             }
-            Ok(false) => {
-                Err(AccessibilityError::NotFound(format!(
-                    "Element '{}' not found in accessibility tree", element_id
-                )))
-            }
+            Ok(false) => Err(AccessibilityError::NotFound(format!(
+                "Element '{}' not found in accessibility tree",
+                element_id
+            ))),
             Err(e) => Err(e),
         }
     }
@@ -1138,7 +1207,9 @@ impl AccessibilityTree for MacAccessibility {
         let pid = self.get_focused_app_pid()?;
         let app = unsafe { AXUIElementCreateApplication(pid) };
         if app.is_null() {
-            return Err(AccessibilityError::QueryFailed("Failed to create app element".into()));
+            return Err(AccessibilityError::QueryFailed(
+                "Failed to create app element".into(),
+            ));
         }
 
         let window_cf = get_ax_attribute(app, "AXFocusedWindow");
@@ -1154,14 +1225,17 @@ impl AccessibilityTree for MacAccessibility {
 
         match result {
             Ok(true) => {
-                tracing::info!("AXSetAttributeValue on element '{}' = '{}'", element_id, value);
+                tracing::info!(
+                    "AXSetAttributeValue on element '{}' = '{}'",
+                    element_id,
+                    value
+                );
                 Ok(true)
             }
-            Ok(false) => {
-                Err(AccessibilityError::NotFound(format!(
-                    "Element '{}' not found in accessibility tree", element_id
-                )))
-            }
+            Ok(false) => Err(AccessibilityError::NotFound(format!(
+                "Element '{}' not found in accessibility tree",
+                element_id
+            ))),
             Err(e) => Err(e),
         }
     }
@@ -1190,16 +1264,18 @@ impl AccessibilityTree for MacAccessibility {
         result.unwrap_or(false)
     }
 
-    fn element_at_position(&self, x: f32, y: f32) -> Result<Option<AccessibilityElement>, AccessibilityError> {
+    fn element_at_position(
+        &self,
+        x: f32,
+        y: f32,
+    ) -> Result<Option<AccessibilityElement>, AccessibilityError> {
         let system_wide = unsafe { AXUIElementCreateSystemWide() };
         if system_wide.is_null() {
             return Ok(None);
         }
 
         let mut element_ref: AXUIElementRef = ptr::null();
-        let err = unsafe {
-            AXUIElementCopyElementAtPosition(system_wide, x, y, &mut element_ref)
-        };
+        let err = unsafe { AXUIElementCopyElementAtPosition(system_wide, x, y, &mut element_ref) };
         unsafe { CFRelease(system_wide as *const c_void) };
 
         if err != K_AX_ERROR_SUCCESS || element_ref.is_null() {
@@ -1231,7 +1307,9 @@ impl AccessibilityTree for MacAccessibility {
                     == unsafe { core_foundation::base::CFGetTypeID(children_ref) }
                 {
                     let arr: CFArray<CFType> = unsafe {
-                        CFArray::wrap_under_get_rule(children_ref as core_foundation::array::CFArrayRef)
+                        CFArray::wrap_under_get_rule(
+                            children_ref as core_foundation::array::CFArrayRef,
+                        )
                     };
                     for i in 0..arr.len() {
                         if let Some(top_menu) = arr.get(i) {
@@ -1271,8 +1349,11 @@ impl AccessibilityTree for MacAccessibility {
                         let win_ref = win.as_CFTypeRef() as AXUIElementRef;
                         let count = AtomicUsize::new(0);
                         // Shallow tree (depth 2) for each window — just enough for title/bounds
-                        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-                        if let Some(elem) = self.build_element(win_ref, None, 0, &count, &deadline, MAX_ELEMENTS) {
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_millis(500);
+                        if let Some(elem) =
+                            self.build_element(win_ref, None, 0, &count, &deadline, MAX_ELEMENTS)
+                        {
                             windows.push(elem);
                         }
                     }
@@ -1319,8 +1400,8 @@ fn extract_menu_items(
                             continue; // Skip separators
                         }
                         let enabled = get_ax_bool(child_ref, "AXEnabled").unwrap_or(true);
-                        let shortcut = get_ax_string(child_ref, "AXMenuItemCmdChar")
-                            .and_then(|key| {
+                        let shortcut =
+                            get_ax_string(child_ref, "AXMenuItemCmdChar").and_then(|key| {
                                 if key.is_empty() {
                                     return None;
                                 }
@@ -1352,13 +1433,21 @@ fn extract_menu_items(
                                 == unsafe { core_foundation::base::CFGetTypeID(sub_ref) }
                             {
                                 let sub_arr: CFArray<CFType> = unsafe {
-                                    CFArray::wrap_under_get_rule(sub_ref as core_foundation::array::CFArrayRef)
+                                    CFArray::wrap_under_get_rule(
+                                        sub_ref as core_foundation::array::CFArrayRef,
+                                    )
                                 };
                                 for j in 0..sub_arr.len() {
                                     if let Some(sub_child) = sub_arr.get(j) {
-                                        let sub_child_ref = sub_child.as_CFTypeRef() as AXUIElementRef;
+                                        let sub_child_ref =
+                                            sub_child.as_CFTypeRef() as AXUIElementRef;
                                         let sub_path = format!("{} > {}", path_prefix, label);
-                                        extract_menu_items(sub_child_ref, &sub_path, items, depth + 1);
+                                        extract_menu_items(
+                                            sub_child_ref,
+                                            &sub_path,
+                                            items,
+                                            depth + 1,
+                                        );
                                     }
                                 }
                             }
@@ -1425,7 +1514,8 @@ fn find_and_set_value(
                 "false" | "0" => false,
                 _ => {
                     return Err(AccessibilityError::OperationFailed(format!(
-                        "Invalid boolean value '{}' for checkbox/radio", value
+                        "Invalid boolean value '{}' for checkbox/radio",
+                        value
                     )));
                 }
             };
@@ -1443,7 +1533,10 @@ fn find_and_set_value(
             }
         } else if let Ok(num) = value.parse::<f64>() {
             // Try numeric for sliders, progress indicators, etc.
-            if matches!(role_str.as_str(), "AXSlider" | "AXScrollBar" | "AXValueIndicator") {
+            if matches!(
+                role_str.as_str(),
+                "AXSlider" | "AXScrollBar" | "AXValueIndicator"
+            ) {
                 let cf_num = CFNumber::from(num);
                 unsafe {
                     AXUIElementSetAttributeValue(
@@ -1479,7 +1572,8 @@ fn find_and_set_value(
             Ok(true)
         } else {
             Err(AccessibilityError::OperationFailed(format!(
-                "AXUIElementSetAttributeValue failed with error {}", set_err
+                "AXUIElementSetAttributeValue failed with error {}",
+                set_err
             )))
         };
     }
@@ -1564,7 +1658,9 @@ fn find_and_check_settable(
                     break;
                 }
                 if let Some(child_ref) = arr.get(i).map(|c| c.as_CFTypeRef() as AXUIElementRef) {
-                    if let Some(result) = find_and_check_settable(child_ref, target_id, depth + 1, count) {
+                    if let Some(result) =
+                        find_and_check_settable(child_ref, target_id, depth + 1, count)
+                    {
                         return Some(result);
                     }
                 }
@@ -1646,9 +1742,8 @@ fn get_ax_array_len(element: AXUIElementRef, attr: &str) -> Option<usize> {
     if unsafe { core_foundation::array::CFArrayGetTypeID() }
         == unsafe { core_foundation::base::CFGetTypeID(cf_ref) }
     {
-        let arr: CFArray<CFType> = unsafe {
-            CFArray::wrap_under_get_rule(cf_ref as core_foundation::array::CFArrayRef)
-        };
+        let arr: CFArray<CFType> =
+            unsafe { CFArray::wrap_under_get_rule(cf_ref as core_foundation::array::CFArrayRef) };
         Some(arr.len() as usize)
     } else {
         None
@@ -1700,7 +1795,10 @@ fn get_ax_state_fast(element: AXUIElementRef, role: &str) -> ElementState {
     let focused = get_ax_bool(element, "AXFocused").unwrap_or(false);
 
     // Only query selected for roles that support selection
-    let selected = if matches!(role, "AXRow" | "AXCell" | "AXMenuItem" | "AXListItem" | "AXTabButton" | "AXRadioButton") {
+    let selected = if matches!(
+        role,
+        "AXRow" | "AXCell" | "AXMenuItem" | "AXListItem" | "AXTabButton" | "AXRadioButton"
+    ) {
         get_ax_bool(element, "AXSelected").unwrap_or(false)
     } else {
         false
@@ -1736,13 +1834,34 @@ fn get_ax_state_fast(element: AXUIElementRef, role: &str) -> ElementState {
 
 /// Check if a role is interactive (worth querying actions for).
 fn is_interactive_role(role: &str) -> bool {
-    matches!(role,
-        "AXButton" | "AXLink" | "AXTextField" | "AXTextArea" | "AXSearchField"
-        | "AXSecureTextField" | "AXCheckBox" | "AXRadioButton" | "AXPopUpButton"
-        | "AXComboBox" | "AXSlider" | "AXMenuItem" | "AXMenuBarItem" | "AXMenuButton"
-        | "AXTab" | "AXTabButton" | "AXDisclosureTriangle" | "AXIncrementor"
-        | "AXColorWell" | "AXDateField" | "AXToolbar" | "AXStepper"
-        | "AXSplitGroup" | "AXImage" | "AXRow" | "AXCell"
+    matches!(
+        role,
+        "AXButton"
+            | "AXLink"
+            | "AXTextField"
+            | "AXTextArea"
+            | "AXSearchField"
+            | "AXSecureTextField"
+            | "AXCheckBox"
+            | "AXRadioButton"
+            | "AXPopUpButton"
+            | "AXComboBox"
+            | "AXSlider"
+            | "AXMenuItem"
+            | "AXMenuBarItem"
+            | "AXMenuButton"
+            | "AXTab"
+            | "AXTabButton"
+            | "AXDisclosureTriangle"
+            | "AXIncrementor"
+            | "AXColorWell"
+            | "AXDateField"
+            | "AXToolbar"
+            | "AXStepper"
+            | "AXSplitGroup"
+            | "AXImage"
+            | "AXRow"
+            | "AXCell"
     )
 }
 
@@ -1754,9 +1873,8 @@ fn get_ax_actions(element: AXUIElementRef) -> Vec<String> {
         return vec![];
     }
 
-    let arr: CFArray<CFType> = unsafe {
-        CFArray::wrap_under_create_rule(names_ref as core_foundation::array::CFArrayRef)
-    };
+    let arr: CFArray<CFType> =
+        unsafe { CFArray::wrap_under_create_rule(names_ref as core_foundation::array::CFArrayRef) };
 
     let mut actions = Vec::new();
     for i in 0..arr.len() {
@@ -1842,9 +1960,14 @@ fn find_in_tree(
     label: Option<&str>,
     results: &mut Vec<AccessibilityElement>,
 ) {
-    let role_match = role.map_or(true, |r| std::mem::discriminant(&element.role) == std::mem::discriminant(r));
+    let role_match = role.map_or(true, |r| {
+        std::mem::discriminant(&element.role) == std::mem::discriminant(r)
+    });
     let label_match = label.map_or(true, |l| {
-        element.label.as_deref().map_or(false, |el| el.to_lowercase().contains(&l.to_lowercase()))
+        element
+            .label
+            .as_deref()
+            .map_or(false, |el| el.to_lowercase().contains(&l.to_lowercase()))
     });
 
     if role_match && label_match {
@@ -1880,8 +2003,14 @@ mod tests {
         assert!(matches!(map_role("AXTextArea", None), ElementRole::Input));
         assert!(matches!(map_role("AXStaticText", None), ElementRole::Text));
         assert!(matches!(map_role("AXWindow", None), ElementRole::Window));
-        assert!(matches!(map_role("AXCheckBox", None), ElementRole::Checkbox));
-        assert!(matches!(map_role("AXRadioButton", None), ElementRole::RadioButton));
+        assert!(matches!(
+            map_role("AXCheckBox", None),
+            ElementRole::Checkbox
+        ));
+        assert!(matches!(
+            map_role("AXRadioButton", None),
+            ElementRole::RadioButton
+        ));
         assert!(matches!(map_role("AXSlider", None), ElementRole::Slider));
         assert!(matches!(map_role("AXLink", None), ElementRole::Link));
         assert!(matches!(map_role("AXImage", None), ElementRole::Image));
@@ -1893,8 +2022,14 @@ mod tests {
 
     #[test]
     fn test_map_role_with_subrole() {
-        assert!(matches!(map_role("AXGroup", Some("AXTabPanel")), ElementRole::TabItem));
-        assert!(matches!(map_role("AXGroup", Some("AXContentList")), ElementRole::List));
+        assert!(matches!(
+            map_role("AXGroup", Some("AXTabPanel")),
+            ElementRole::TabItem
+        ));
+        assert!(matches!(
+            map_role("AXGroup", Some("AXContentList")),
+            ElementRole::List
+        ));
         assert!(matches!(map_role("AXGroup", None), ElementRole::Group));
     }
 
@@ -1910,7 +2045,10 @@ mod tests {
     fn test_map_role_table_and_dialog_variants() {
         assert!(matches!(map_role("AXRow", None), ElementRole::TableRow));
         assert!(matches!(map_role("AXCell", None), ElementRole::TableCell));
-        assert!(matches!(map_role("AXTabButton", None), ElementRole::TabItem));
+        assert!(matches!(
+            map_role("AXTabButton", None),
+            ElementRole::TabItem
+        ));
         assert!(matches!(map_role("AXDialog", None), ElementRole::Dialog));
     }
 
@@ -1979,10 +2117,7 @@ mod tests {
         // Should have some children from the focused window
         println!("Root: {:?} - children: {}", tree.label, tree.children.len());
         for child in &tree.children {
-            println!(
-                "  {:?} {:?} {:?}",
-                child.role, child.label, child.bounds
-            );
+            println!("  {:?} {:?} {:?}", child.role, child.label, child.bounds);
         }
     }
 }

--- a/cel/cel-accessibility/src/macos.rs
+++ b/cel/cel-accessibility/src/macos.rs
@@ -653,7 +653,7 @@ impl MacAccessibility {
             return None;
         }
         // Timeout check — only check every 10 elements to reduce clock overhead
-        if current_count % 10 == 0 && std::time::Instant::now() > *deadline {
+        if current_count.is_multiple_of(10) && std::time::Instant::now() > *deadline {
             tracing::debug!(
                 "AX tree traversal hit timeout at depth {}, count {}",
                 depth,
@@ -689,9 +689,9 @@ impl MacAccessibility {
             .or_else(|| get_ax_string(element, "AXDescription"));
 
         // Filter out empty text elements and spacers early
-        if role_str == "AXStaticText" && label.as_deref().map_or(true, |l| l.trim().is_empty()) {
+        if role_str == "AXStaticText" && label.as_deref().is_none_or(|l| l.trim().is_empty()) {
             let value_check = get_ax_string(element, "AXValue");
-            if value_check.as_deref().map_or(true, |v| v.trim().is_empty()) {
+            if value_check.as_deref().is_none_or(|v| v.trim().is_empty()) {
                 return None;
             }
         }
@@ -1960,14 +1960,13 @@ fn find_in_tree(
     label: Option<&str>,
     results: &mut Vec<AccessibilityElement>,
 ) {
-    let role_match = role.map_or(true, |r| {
-        std::mem::discriminant(&element.role) == std::mem::discriminant(r)
-    });
-    let label_match = label.map_or(true, |l| {
+    let role_match =
+        role.is_none_or(|r| std::mem::discriminant(&element.role) == std::mem::discriminant(r));
+    let label_match = label.is_none_or(|l| {
         element
             .label
             .as_deref()
-            .map_or(false, |el| el.to_lowercase().contains(&l.to_lowercase()))
+            .is_some_and(|el| el.to_lowercase().contains(&l.to_lowercase()))
     });
 
     if role_match && label_match {

--- a/cel/cel-accessibility/src/tree.rs
+++ b/cel/cel-accessibility/src/tree.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::collections::HashMap;
 
 #[derive(Debug, thiserror::Error)]
@@ -66,8 +65,10 @@ impl NormalizedBounds {
 /// [`crate::budget::AppWalkBudget`] for adaptive throttling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum TruncationReason {
     /// Walk completed naturally — visited all reachable nodes.
+    #[default]
     None,
     /// Hit the wall-clock timeout.
     Timeout,
@@ -75,12 +76,6 @@ pub enum TruncationReason {
     MaxNodes,
     /// Hit the maximum recursion depth.
     MaxDepth,
-}
-
-impl Default for TruncationReason {
-    fn default() -> Self {
-        TruncationReason::None
-    }
 }
 
 /// Why a window was skipped during a tree walk.

--- a/cel/cel-accessibility/src/tree.rs
+++ b/cel/cel-accessibility/src/tree.rs
@@ -290,7 +290,10 @@ pub enum AccessibilityEvent {
     /// Focus moved to a different element.
     FocusChanged { element_id: Option<String> },
     /// An element's value changed (input text, checkbox state, slider position).
-    ValueChanged { element_id: String, new_value: Option<String> },
+    ValueChanged {
+        element_id: String,
+        new_value: Option<String>,
+    },
     /// UI layout changed (elements added, removed, or repositioned).
     LayoutChanged,
     /// A new window was created.
@@ -302,7 +305,10 @@ pub enum AccessibilityEvent {
     /// A sheet/dialog appeared.
     SheetCreated,
     /// An element's title changed.
-    TitleChanged { element_id: Option<String>, new_title: Option<String> },
+    TitleChanged {
+        element_id: Option<String>,
+        new_title: Option<String>,
+    },
     /// An application was activated (brought to foreground).
     AppActivated { app_name: Option<String> },
     /// An application was deactivated (sent to background).
@@ -362,8 +368,7 @@ pub trait AccessibilityTree: Send + Sync {
 
     /// Stop observing accessibility events.
     /// Default: no-op.
-    fn stop_observing(&mut self) {
-    }
+    fn stop_observing(&mut self) {}
 
     /// Execute an action on an element by its ID (e.g., "click" on a button).
     /// Uses the native accessibility API (AXPerformAction on macOS) instead of mouse/keyboard.
@@ -389,7 +394,11 @@ pub trait AccessibilityTree: Send + Sync {
     /// Get the accessibility element at a screen coordinate (hit testing).
     /// Returns the element under the given (x, y) point, or None.
     /// Default: not supported.
-    fn element_at_position(&self, _x: f32, _y: f32) -> Result<Option<AccessibilityElement>, AccessibilityError> {
+    fn element_at_position(
+        &self,
+        _x: f32,
+        _y: f32,
+    ) -> Result<Option<AccessibilityElement>, AccessibilityError> {
         Ok(None)
     }
 
@@ -435,7 +444,12 @@ impl AccessibilityTree for StubAccessibility {
             label: Some("Stub Window".into()),
             description: None,
             value: None,
-            bounds: Some(Bounds { x: 0, y: 0, width: 1920, height: 1080 }),
+            bounds: Some(Bounds {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+            }),
             state: ElementState {
                 focused: true,
                 enabled: true,

--- a/cel/cel-accessibility/src/windows.rs
+++ b/cel/cel-accessibility/src/windows.rs
@@ -104,9 +104,11 @@ impl AccessibilityTree for WindowsAccessibility {
             match budget.decide(app_name) {
                 WalkDecision::Full => DEFAULT_MAX_ELEMENTS,
                 WalkDecision::Reduced(n) => n,
-                WalkDecision::Skip => return Err(AccessibilityError::QueryFailed(
-                    "budget: walk skipped".into()
-                )),
+                WalkDecision::Skip => {
+                    return Err(AccessibilityError::QueryFailed(
+                        "budget: walk skipped".into(),
+                    ))
+                }
             }
         };
 
@@ -218,8 +220,8 @@ fn uia_control_type_to_role(control_type_id: i32) -> ElementRole {
 /// `*const ()` with `IUIAutomationElement` and `IUIAutomationTreeWalker`.
 #[allow(dead_code)]
 fn walk_uia_tree(
-    _element: *const (),      // IUIAutomationElement
-    _walker: *const (),       // IUIAutomationTreeWalker
+    _element: *const (), // IUIAutomationElement
+    _walker: *const (),  // IUIAutomationTreeWalker
     _parent_id: Option<String>,
     _depth: usize,
     _max_elements: usize,
@@ -237,7 +239,7 @@ fn walk_uia_tree(
 /// Placeholder — replace `*const ()` with `IUIAutomationElement`.
 #[allow(dead_code)]
 fn build_element(
-    _element: *const (),   // IUIAutomationElement
+    _element: *const (), // IUIAutomationElement
     parent_id: Option<String>,
     _depth: usize,
 ) -> Option<AccessibilityElement> {
@@ -278,30 +280,42 @@ mod tests {
 
     #[test]
     fn test_uia_button_maps_to_button_role() {
-        assert!(matches!(uia_control_type_to_role(50000), ElementRole::Button));
+        assert!(matches!(
+            uia_control_type_to_role(50000),
+            ElementRole::Button
+        ));
     }
 
     #[test]
     fn test_uia_edit_maps_to_input_role() {
-        assert!(matches!(uia_control_type_to_role(50004), ElementRole::Input));
+        assert!(matches!(
+            uia_control_type_to_role(50004),
+            ElementRole::Input
+        ));
     }
 
     #[test]
     fn test_uia_window_maps_to_window_role() {
-        assert!(matches!(uia_control_type_to_role(50032), ElementRole::Window));
+        assert!(matches!(
+            uia_control_type_to_role(50032),
+            ElementRole::Window
+        ));
     }
 
     #[test]
     fn test_uia_unknown_maps_to_custom() {
-        assert!(matches!(uia_control_type_to_role(99999), ElementRole::Custom(_)));
+        assert!(matches!(
+            uia_control_type_to_role(99999),
+            ElementRole::Custom(_)
+        ));
     }
 
     #[test]
     fn test_uia_all_known_roles_dont_panic() {
         let known = [
-            50000, 50002, 50003, 50004, 50006, 50007, 50008, 50009, 50010,
-            50011, 50013, 50014, 50015, 50017, 50018, 50019, 50020, 50021,
-            50023, 50024, 50026, 50032, 50034, 50036, 50057,
+            50000, 50002, 50003, 50004, 50006, 50007, 50008, 50009, 50010, 50011, 50013, 50014,
+            50015, 50017, 50018, 50019, 50020, 50021, 50023, 50024, 50026, 50032, 50034, 50036,
+            50057,
         ];
         for id in known {
             let _ = uia_control_type_to_role(id);

--- a/cel/cel-audio/src/capture.rs
+++ b/cel/cel-audio/src/capture.rs
@@ -19,7 +19,7 @@
 //! empty. Wire in `whisper-rs` or a local Whisper HTTP endpoint at the
 //! `cel-cortex` level.
 
-use crate::transcribe::{TranscriptionHandle, Transcriber};
+use crate::transcribe::{Transcriber, TranscriptionHandle};
 use crate::{AudioCapture, AudioChunk, AudioConfig, AudioError, AudioSource, TranscriptChunk};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use parking_lot::Mutex;
@@ -184,7 +184,9 @@ impl CpalCapture {
 
         macro_rules! mic_callback {
             ($data:expr) => {{
-                let chunk = raw.lock().push_returning(AudioSource::Microphone, $data, sr, ch);
+                let chunk = raw
+                    .lock()
+                    .push_returning(AudioSource::Microphone, $data, sr, ch);
                 let mut tb = tx.lock();
                 if tb.len() < 500 {
                     tb.push_back(chunk);
@@ -202,8 +204,7 @@ impl CpalCapture {
             cpal::SampleFormat::I16 => device.build_input_stream(
                 &cpal_config,
                 move |data: &[i16], _| {
-                    let f32s: Vec<f32> =
-                        data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
+                    let f32s: Vec<f32> = data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
                     mic_callback!(&f32s)
                 },
                 move |err| tracing::error!("mic capture error: {}", err),
@@ -212,8 +213,10 @@ impl CpalCapture {
             cpal::SampleFormat::U16 => device.build_input_stream(
                 &cpal_config,
                 move |data: &[u16], _| {
-                    let f32s: Vec<f32> =
-                        data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).collect();
+                    let f32s: Vec<f32> = data
+                        .iter()
+                        .map(|&s| (s as f32 - 32768.0) / 32768.0)
+                        .collect();
                     mic_callback!(&f32s)
                 },
                 move |err| tracing::error!("mic capture error: {}", err),
@@ -265,9 +268,7 @@ impl CpalCapture {
         let mut candidates: Vec<(usize, cpal::Device)> = devices
             .filter_map(|d| {
                 let name = d.name().ok()?;
-                let priority = LOOPBACK_PREFIXES
-                    .iter()
-                    .position(|&p| name.contains(p))?;
+                let priority = LOOPBACK_PREFIXES.iter().position(|&p| name.contains(p))?;
                 Some((priority, d))
             })
             .collect();
@@ -310,8 +311,9 @@ impl CpalCapture {
 
         macro_rules! sys_callback {
             ($data:expr) => {{
-                let chunk =
-                    raw.lock().push_returning(AudioSource::SystemOutput, $data, sr, ch);
+                let chunk = raw
+                    .lock()
+                    .push_returning(AudioSource::SystemOutput, $data, sr, ch);
                 let mut tb = tx.lock();
                 if tb.len() < 500 {
                     tb.push_back(chunk);
@@ -338,8 +340,10 @@ impl CpalCapture {
             cpal::SampleFormat::U16 => device.build_input_stream(
                 &cpal_config,
                 move |data: &[u16], _| {
-                    let f32s: Vec<f32> =
-                        data.iter().map(|&s| (s as f32 - 32768.0) / 32768.0).collect();
+                    let f32s: Vec<f32> = data
+                        .iter()
+                        .map(|&s| (s as f32 - 32768.0) / 32768.0)
+                        .collect();
                     sys_callback!(&f32s)
                 },
                 move |err| tracing::error!("system audio capture error: {}", err),

--- a/cel/cel-audio/src/lib.rs
+++ b/cel/cel-audio/src/lib.rs
@@ -318,7 +318,10 @@ mod tests {
         let chunks = a.drain_raw_chunks();
         a.stop().unwrap();
 
-        assert!(!chunks.is_empty(), "no system audio chunks received after 300ms");
+        assert!(
+            !chunks.is_empty(),
+            "no system audio chunks received after 300ms"
+        );
         let total_samples: usize = chunks.iter().map(|c| c.samples.len()).sum();
         println!(
             "system_output_delivers_samples: {} chunks, {} samples @ {} Hz",

--- a/cel/cel-audio/src/transcribe.rs
+++ b/cel/cel-audio/src/transcribe.rs
@@ -106,10 +106,7 @@ impl Transcriber for WhisperApiTranscriber {
             form = form.text("language", lang.clone());
         }
 
-        let mut req = self
-            .client
-            .post(&self.config.endpoint)
-            .multipart(form);
+        let mut req = self.client.post(&self.config.endpoint).multipart(form);
 
         if !self.config.api_key.is_empty() {
             req = req.bearer_auth(&self.config.api_key);
@@ -166,7 +163,10 @@ pub fn downmix_to_mono(samples: &[f32], channels: u16) -> Vec<f32> {
     if ch <= 1 {
         return samples.to_vec();
     }
-    samples.chunks(ch).map(|frame| frame.iter().sum::<f32>() / ch as f32).collect()
+    samples
+        .chunks(ch)
+        .map(|frame| frame.iter().sum::<f32>() / ch as f32)
+        .collect()
 }
 
 /// Linear-interpolation resample from src_rate to dst_rate (mono input).
@@ -309,8 +309,7 @@ impl VadState {
             self.segment.extend_from_slice(samples);
         }
 
-        let max_samples =
-            (MAX_SEGMENT_SECS * sample_rate as f32 * channels as f32) as usize;
+        let max_samples = (MAX_SEGMENT_SECS * sample_rate as f32 * channels as f32) as usize;
         let segment_too_long = self.segment.len() >= max_samples;
         let speech_ended =
             self.in_speech && !is_speech && self.silence_frames >= SILENCE_END_FRAMES;
@@ -402,7 +401,11 @@ impl TranscriptionHandle {
                                 chunk.channels,
                                 chunk.timestamp_ms,
                             ) {
-                                let whisper_samples = prepare_for_whisper(&seg.samples, seg.sample_rate, seg.channels);
+                                let whisper_samples = prepare_for_whisper(
+                                    &seg.samples,
+                                    seg.sample_rate,
+                                    seg.channels,
+                                );
                                 let wav = encode_wav(&whisper_samples, 16_000, 1);
                                 if let Some(t) = transcriber.transcribe(
                                     &wav,
@@ -426,7 +429,11 @@ impl TranscriptionHandle {
                                 chunk.channels,
                                 chunk.timestamp_ms,
                             ) {
-                                let whisper_samples = prepare_for_whisper(&seg.samples, seg.sample_rate, seg.channels);
+                                let whisper_samples = prepare_for_whisper(
+                                    &seg.samples,
+                                    seg.sample_rate,
+                                    seg.channels,
+                                );
                                 let wav = encode_wav(&whisper_samples, 16_000, 1);
                                 if let Some(t) = transcriber.transcribe(
                                     &wav,

--- a/cel/cel-cdp/src/client.rs
+++ b/cel/cel-cdp/src/client.rs
@@ -21,7 +21,11 @@ pub enum CdpError {
 
 /// Minimal CDP client — connects via WebSocket and sends commands.
 pub struct CdpClient {
-    ws: Mutex<tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>>,
+    ws: Mutex<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
     next_id: AtomicU64,
 }
 
@@ -72,7 +76,10 @@ impl CdpClient {
                             if let Some(error) = response.get("error") {
                                 return Err(CdpError::CommandFailed(error.to_string()));
                             }
-                            return Ok(response.get("result").cloned().unwrap_or(serde_json::Value::Null));
+                            return Ok(response
+                                .get("result")
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Null));
                         }
                         // Not our response — it's an event, skip it
                     }
@@ -94,10 +101,7 @@ impl CdpClient {
     /// Get the outer HTML of a node.
     pub async fn get_outer_html(&self, node_id: i64) -> Result<String, CdpError> {
         let result = self
-            .send_command(
-                "DOM.getOuterHTML",
-                serde_json::json!({ "nodeId": node_id }),
-            )
+            .send_command("DOM.getOuterHTML", serde_json::json!({ "nodeId": node_id }))
             .await?;
         result
             .get("outerHTML")
@@ -133,17 +137,13 @@ impl CdpClient {
 
     /// Get the page title.
     pub async fn get_title(&self) -> Result<String, CdpError> {
-        let result = self
-            .evaluate("document.title")
-            .await?;
+        let result = self.evaluate("document.title").await?;
         Ok(result.as_str().unwrap_or("").to_string())
     }
 
     /// Get the page URL.
     pub async fn get_url(&self) -> Result<String, CdpError> {
-        let result = self
-            .evaluate("window.location.href")
-            .await?;
+        let result = self.evaluate("window.location.href").await?;
         Ok(result.as_str().unwrap_or("").to_string())
     }
 
@@ -173,11 +173,7 @@ impl CdpClient {
     }
 
     /// Dispatch a key event via CDP Input domain.
-    pub async fn dispatch_key_event(
-        &self,
-        event_type: &str,
-        key: &str,
-    ) -> Result<(), CdpError> {
+    pub async fn dispatch_key_event(&self, event_type: &str, key: &str) -> Result<(), CdpError> {
         self.send_command(
             "Input.dispatchKeyEvent",
             serde_json::json!({
@@ -250,7 +246,10 @@ impl CdpClient {
         let result = self
             .send_command("Network.getCookies", serde_json::json!({}))
             .await?;
-        Ok(result.get("cookies").cloned().unwrap_or(serde_json::Value::Array(vec![])))
+        Ok(result
+            .get("cookies")
+            .cloned()
+            .unwrap_or(serde_json::Value::Array(vec![])))
     }
 
     /// Get a specific cookie by name. Returns the cookie value or None.
@@ -259,7 +258,10 @@ impl CdpClient {
         if let Some(arr) = cookies.as_array() {
             for cookie in arr {
                 if cookie.get("name").and_then(|n| n.as_str()) == Some(name) {
-                    return Ok(cookie.get("value").and_then(|v| v.as_str()).map(|s| s.to_string()));
+                    return Ok(cookie
+                        .get("value")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()));
                 }
             }
         }
@@ -268,7 +270,10 @@ impl CdpClient {
 
     /// Read localStorage for a given key. Returns the value or null.
     pub async fn get_local_storage(&self, key: &str) -> Result<Option<String>, CdpError> {
-        let expr = format!("localStorage.getItem({})", serde_json::to_string(key).unwrap_or_else(|_| format!("\"{}\"", key)));
+        let expr = format!(
+            "localStorage.getItem({})",
+            serde_json::to_string(key).unwrap_or_else(|_| format!("\"{}\"", key))
+        );
         let result = self.evaluate(&expr).await?;
         match result {
             serde_json::Value::String(s) => Ok(Some(s)),
@@ -279,7 +284,10 @@ impl CdpClient {
 
     /// Read sessionStorage for a given key.
     pub async fn get_session_storage(&self, key: &str) -> Result<Option<String>, CdpError> {
-        let expr = format!("sessionStorage.getItem({})", serde_json::to_string(key).unwrap_or_else(|_| format!("\"{}\"", key)));
+        let expr = format!(
+            "sessionStorage.getItem({})",
+            serde_json::to_string(key).unwrap_or_else(|_| format!("\"{}\"", key))
+        );
         let result = self.evaluate(&expr).await?;
         match result {
             serde_json::Value::String(s) => Ok(Some(s)),
@@ -292,8 +300,12 @@ impl CdpClient {
     /// Returns structured HttpEvents with real HTTP data (method, URL, status, timing).
     /// This is more reliable than Network.enable events since it works without
     /// maintaining a persistent event listener.
-    pub async fn get_network_requests(&self, limit: usize) -> Result<Vec<cel_network::HttpEvent>, CdpError> {
-        let js = format!(r#"
+    pub async fn get_network_requests(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<cel_network::HttpEvent>, CdpError> {
+        let js = format!(
+            r#"
             (() => {{
                 const entries = performance.getEntriesByType('resource')
                     .filter(e => e.initiatorType === 'fetch' || e.initiatorType === 'xmlhttprequest')
@@ -310,18 +322,22 @@ impl CdpClient {
                     }}));
                 return entries;
             }})()
-        "#, limit);
+        "#,
+            limit
+        );
 
         let result = self.evaluate(&js).await?;
-        let events: Vec<cel_network::HttpEvent> = serde_json::from_value(result)
-            .unwrap_or_default();
+        let events: Vec<cel_network::HttpEvent> =
+            serde_json::from_value(result).unwrap_or_default();
         Ok(events)
     }
 
     /// Navigate to a URL.
     pub async fn navigate(&self, url: &str) -> Result<(), CdpError> {
-        self.send_command("Page.enable", serde_json::json!({})).await?;
-        self.send_command("Page.navigate", serde_json::json!({ "url": url })).await?;
+        self.send_command("Page.enable", serde_json::json!({}))
+            .await?;
+        self.send_command("Page.navigate", serde_json::json!({ "url": url }))
+            .await?;
         Ok(())
     }
 

--- a/cel/cel-cdp/src/content.rs
+++ b/cel/cel-cdp/src/content.rs
@@ -29,7 +29,7 @@ pub struct ElementBounds {
 /// A console log message captured from the page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsoleMessage {
-    pub level: String,  // "log", "warn", "error", "info", "debug"
+    pub level: String, // "log", "warn", "error", "info", "debug"
     pub text: String,
 }
 
@@ -422,8 +422,7 @@ pub async fn extract_page_content(client: &CdpClient) -> Result<PageContent, Cdp
         .ok()
         .and_then(|v| v.as_str().map(|s| s.to_string()))
         .unwrap_or_else(|| "[]".to_string());
-    let console_logs: Vec<ConsoleMessage> =
-        serde_json::from_str(&console_json).unwrap_or_default();
+    let console_logs: Vec<ConsoleMessage> = serde_json::from_str(&console_json).unwrap_or_default();
 
     // Capture recent fetch/XHR network requests via the Performance API.
     // This avoids needing a WebSocket event listener loop for Network.responseReceived.
@@ -498,7 +497,12 @@ mod tests {
                 input_type: None,
                 value: None,
                 placeholder: None,
-                bounds: Some(ElementBounds { x: 10, y: 20, width: 100, height: 40 }),
+                bounds: Some(ElementBounds {
+                    x: 10,
+                    y: 20,
+                    width: 100,
+                    height: 40,
+                }),
                 backend_node_id: Some(1),
                 aria_role: Some("button".into()),
                 aria_label: Some("Submit form".into()),
@@ -538,7 +542,10 @@ mod tests {
         assert_eq!(back.interactive_elements.len(), 1);
         assert!(back.interactive_elements[0].bounds.is_some());
         assert_eq!(back.interactive_elements[0].backend_node_id, Some(1));
-        assert_eq!(back.interactive_elements[0].aria_role.as_deref(), Some("button"));
+        assert_eq!(
+            back.interactive_elements[0].aria_role.as_deref(),
+            Some("button")
+        );
         assert!(back.interactive_elements[0].is_visible);
         assert_eq!(back.interactive_elements[0].shadow_depth, 0);
         assert_eq!(back.interactive_elements[0].viewport_relation, "visible");

--- a/cel/cel-cdp/src/discovery.rs
+++ b/cel/cel-cdp/src/discovery.rs
@@ -36,18 +36,20 @@ pub struct CdpHttpTarget {
 /// but the file-based scan is the problematic one: it reads stale port files
 /// and connects to apps that didn't ask to be controlled.
 const CDP_PASSIVE_EXCLUDED_APPS: &[&str] = &[
-    "claude",      // Claude Code / Claude Desktop / Codex
-    "codex",       // Codex CLI Electron wrapper
-    "slack",       // Rarely useful for automation
-    "discord",     // Rarely useful for automation
-    "notion",      // Has its own API
-    "obsidian",    // Has its own API
+    "claude",   // Claude Code / Claude Desktop / Codex
+    "codex",    // Codex CLI Electron wrapper
+    "slack",    // Rarely useful for automation
+    "discord",  // Rarely useful for automation
+    "notion",   // Has its own API
+    "obsidian", // Has its own API
 ];
 
 /// Check if an app name matches the passive exclusion list (case-insensitive).
 fn is_passive_excluded(app_name: &str) -> bool {
     let lower = app_name.to_lowercase();
-    CDP_PASSIVE_EXCLUDED_APPS.iter().any(|excl| lower.contains(excl))
+    CDP_PASSIVE_EXCLUDED_APPS
+        .iter()
+        .any(|excl| lower.contains(excl))
 }
 
 /// Discover all available CDP targets on this machine.
@@ -185,7 +187,9 @@ fn extract_debug_port(line: &str) -> Option<&str> {
     let marker = "--remote-debugging-port=";
     let start = line.find(marker)? + marker.len();
     let rest = &line[start..];
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
     if end > 0 {
         Some(&rest[..end])
     } else {
@@ -208,9 +212,16 @@ pub fn list_http_targets(port: u16) -> Vec<CdpHttpTarget> {
 
     let mut targets = Vec::new();
     for entry in entries {
-        let Some(id) = entry.get("id").and_then(|v| v.as_str()) else { continue };
-        let Some(ws_url) = entry.get("webSocketDebuggerUrl").and_then(|v| v.as_str()) else { continue };
-        let entry_type = entry.get("type").and_then(|v| v.as_str()).unwrap_or_default();
+        let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(ws_url) = entry.get("webSocketDebuggerUrl").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let entry_type = entry
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
         if entry_type != "page" {
             continue;
         }
@@ -337,7 +348,11 @@ fn extract_app_name(line: &str) -> String {
     // Fallback: extract from command field
     let fields: Vec<&str> = line.split_whitespace().collect();
     if fields.len() > 10 {
-        fields[10].split('/').last().unwrap_or("unknown").to_string()
+        fields[10]
+            .split('/')
+            .last()
+            .unwrap_or("unknown")
+            .to_string()
     } else {
         "unknown".to_string()
     }
@@ -354,20 +369,59 @@ fn scan_devtools_port_files() -> Vec<CdpTarget> {
 
     // Known app data directories on macOS
     let candidates = vec![
-        ("Google Chrome", format!("{}/Library/Application Support/Google/Chrome", home)),
-        ("Google Chrome Canary", format!("{}/Library/Application Support/Google/Chrome Canary", home)),
-        ("Microsoft Edge", format!("{}/Library/Application Support/Microsoft Edge", home)),
-        ("Brave Browser", format!("{}/Library/Application Support/BraveSoftware/Brave-Browser", home)),
+        (
+            "Google Chrome",
+            format!("{}/Library/Application Support/Google/Chrome", home),
+        ),
+        (
+            "Google Chrome Canary",
+            format!("{}/Library/Application Support/Google/Chrome Canary", home),
+        ),
+        (
+            "Microsoft Edge",
+            format!("{}/Library/Application Support/Microsoft Edge", home),
+        ),
+        (
+            "Brave Browser",
+            format!(
+                "{}/Library/Application Support/BraveSoftware/Brave-Browser",
+                home
+            ),
+        ),
         ("Arc", format!("{}/Library/Application Support/Arc", home)),
-        ("Opera", format!("{}/Library/Application Support/com.operasoftware.Opera", home)),
+        (
+            "Opera",
+            format!(
+                "{}/Library/Application Support/com.operasoftware.Opera",
+                home
+            ),
+        ),
         // Claude/Codex — excluded from passive discovery via CDP_PASSIVE_EXCLUDED_APPS.
         // Available when discover_cdp_targets_filtered(true) is called explicitly.
-        ("Claude", format!("{}/Library/Application Support/Claude", home)),
-        ("Visual Studio Code", format!("{}/Library/Application Support/Code", home)),
-        ("Slack", format!("{}/Library/Application Support/Slack", home)),
-        ("Discord", format!("{}/Library/Application Support/discord", home)),
-        ("Notion", format!("{}/Library/Application Support/Notion", home)),
-        ("Obsidian", format!("{}/Library/Application Support/obsidian", home)),
+        (
+            "Claude",
+            format!("{}/Library/Application Support/Claude", home),
+        ),
+        (
+            "Visual Studio Code",
+            format!("{}/Library/Application Support/Code", home),
+        ),
+        (
+            "Slack",
+            format!("{}/Library/Application Support/Slack", home),
+        ),
+        (
+            "Discord",
+            format!("{}/Library/Application Support/discord", home),
+        ),
+        (
+            "Notion",
+            format!("{}/Library/Application Support/Notion", home),
+        ),
+        (
+            "Obsidian",
+            format!("{}/Library/Application Support/obsidian", home),
+        ),
     ];
 
     for (app_name, dir) in candidates {
@@ -492,16 +546,14 @@ fn http_request_local(port: u16, method: &str, path: &str) -> Option<(u16, Strin
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|raw| raw.parse::<u16>().ok())
         .unwrap_or(0);
-    let content_length = header_text
-        .lines()
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            if name.trim().eq_ignore_ascii_case("content-length") {
-                value.trim().parse::<usize>().ok()
-            } else {
-                None
-            }
-        });
+    let content_length = header_text.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.trim().eq_ignore_ascii_case("content-length") {
+            value.trim().parse::<usize>().ok()
+        } else {
+            None
+        }
+    });
 
     if let Some(content_length) = content_length {
         while response.len() < header_end + content_length {
@@ -515,7 +567,8 @@ fn http_request_local(port: u16, method: &str, path: &str) -> Option<(u16, Strin
         if response.len() < header_end + content_length {
             return None;
         }
-        let body = String::from_utf8(response[header_end..header_end + content_length].to_vec()).ok()?;
+        let body =
+            String::from_utf8(response[header_end..header_end + content_length].to_vec()).ok()?;
         return Some((status_code, body));
     }
 

--- a/cel/cel-cdp/src/discovery.rs
+++ b/cel/cel-cdp/src/discovery.rs
@@ -350,7 +350,7 @@ fn extract_app_name(line: &str) -> String {
     if fields.len() > 10 {
         fields[10]
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("unknown")
             .to_string()
     } else {

--- a/cel/cel-cdp/src/lib.rs
+++ b/cel/cel-cdp/src/lib.rs
@@ -6,15 +6,20 @@
 //! CEL transparently enables CDP on Chromium apps via environment variables
 //! and discovers active debug ports automatically.
 
-mod discovery;
 mod client;
 mod content;
+mod discovery;
 pub mod setup;
 
-pub use discovery::{discover_cdp_targets, discover_cdp_targets_filtered, reset_preferred_target, CdpTarget};
 pub use client::{CdpClient, CdpError};
-pub use content::{extract_page_content, PageContent, TextBlock, DomElement, ConsoleMessage, ResourceEntry, ElementBounds, ViewportInfo};
-pub use setup::{install_cdp_launch_agent, uninstall_cdp_launch_agent, is_cdp_setup_installed};
+pub use content::{
+    extract_page_content, ConsoleMessage, DomElement, ElementBounds, PageContent, ResourceEntry,
+    TextBlock, ViewportInfo,
+};
+pub use discovery::{
+    discover_cdp_targets, discover_cdp_targets_filtered, reset_preferred_target, CdpTarget,
+};
+pub use setup::{install_cdp_launch_agent, is_cdp_setup_installed, uninstall_cdp_launch_agent};
 
 pub const DEFAULT_CEL_CDP_PORT: u16 = 9333;
 
@@ -130,10 +135,7 @@ fn get_frontmost_pid() -> Option<i32> {
         .output()
         .ok()?;
     if output.status.success() {
-        String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .parse()
-            .ok()
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
     } else {
         None
     }

--- a/cel/cel-cdp/src/lib.rs
+++ b/cel/cel-cdp/src/lib.rs
@@ -102,7 +102,7 @@ pub fn activate_preferred_browser_target() -> bool {
     std::process::Command::new("osascript")
         .args(["-e", &script])
         .status()
-        .map_or(false, |status| status.success())
+        .is_ok_and(|status| status.success())
 }
 
 fn preferred_cel_cdp_port_from(value: Option<&str>) -> u16 {

--- a/cel/cel-cdp/src/setup.rs
+++ b/cel/cel-cdp/src/setup.rs
@@ -44,7 +44,11 @@ fn launch_agent_plist() -> String {
 /// Get the LaunchAgent plist file path.
 fn launch_agent_path() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
-    Some(PathBuf::from(home).join("Library/LaunchAgents").join(format!("{}.plist", LAUNCH_AGENT_LABEL)))
+    Some(
+        PathBuf::from(home)
+            .join("Library/LaunchAgents")
+            .join(format!("{}.plist", LAUNCH_AGENT_LABEL)),
+    )
 }
 
 /// Install the LaunchAgent that enables CDP on Electron apps.
@@ -102,8 +106,7 @@ fn chrome_wrapper_dir() -> Option<PathBuf> {
 /// Also creates an Automator app that replaces Dock/Spotlight Chrome with the wrapper.
 fn install_chrome_wrapper() -> Result<(), String> {
     let dir = chrome_wrapper_dir().ok_or("Could not determine wrapper dir")?;
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| format!("Failed to create wrapper dir: {}", e))?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create wrapper dir: {}", e))?;
 
     // Create the wrapper script
     let wrapper_path = dir.join("chrome-cdp-wrapper.sh");
@@ -163,8 +166,7 @@ pub fn uninstall_cdp_launch_agent() -> Result<bool, String> {
         .output();
 
     // Delete the LaunchAgent plist
-    std::fs::remove_file(&path)
-        .map_err(|e| format!("Failed to remove LaunchAgent: {}", e))?;
+    std::fs::remove_file(&path).map_err(|e| format!("Failed to remove LaunchAgent: {}", e))?;
 
     // Remove Chrome wrapper
     if let Some(dir) = chrome_wrapper_dir() {

--- a/cel/cel-cdp/src/setup.rs
+++ b/cel/cel-cdp/src/setup.rs
@@ -179,7 +179,7 @@ pub fn uninstall_cdp_launch_agent() -> Result<bool, String> {
 
 /// Check if the LaunchAgent is installed.
 pub fn is_cdp_setup_installed() -> bool {
-    launch_agent_path().map_or(false, |p| p.exists())
+    launch_agent_path().is_some_and(|p| p.exists())
 }
 
 #[cfg(test)]

--- a/cel/cel-context/examples/context_snapshot.rs
+++ b/cel/cel-context/examples/context_snapshot.rs
@@ -36,7 +36,9 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("[warn] Vision not configured: {}", e);
-                eprintln!("[hint] Set CEL_LLM_PROVIDER, CEL_LLM_API_KEY env vars for vision fallback");
+                eprintln!(
+                    "[hint] Set CEL_LLM_PROVIDER, CEL_LLM_API_KEY env vars for vision fallback"
+                );
             }
         }
     }
@@ -48,30 +50,80 @@ fn main() {
         println!("{}", serde_json::to_string_pretty(&ctx).unwrap());
     } else {
         println!("=== Screen Context Snapshot ===");
-        println!("App:       {}", if ctx.app.is_empty() { "(unknown)" } else { &ctx.app });
-        println!("Window:    {}", if ctx.window.is_empty() { "(unknown)" } else { &ctx.window });
+        println!(
+            "App:       {}",
+            if ctx.app.is_empty() {
+                "(unknown)"
+            } else {
+                &ctx.app
+            }
+        );
+        println!(
+            "Window:    {}",
+            if ctx.window.is_empty() {
+                "(unknown)"
+            } else {
+                &ctx.window
+            }
+        );
         println!("Timestamp: {} ms", ctx.timestamp_ms);
         println!("Elements:  {}", ctx.elements.len());
         println!("Network:   {} events", ctx.network_events.len());
         println!();
 
         // Summary by source
-        let a11y_count = ctx.elements.iter().filter(|e| e.source == cel_context::ContextSource::AccessibilityTree).count();
-        let vision_count = ctx.elements.iter().filter(|e| e.source == cel_context::ContextSource::Vision).count();
-        let native_count = ctx.elements.iter().filter(|e| e.source == cel_context::ContextSource::NativeApi).count();
-        println!("Sources: {} a11y, {} vision, {} native", a11y_count, vision_count, native_count);
+        let a11y_count = ctx
+            .elements
+            .iter()
+            .filter(|e| e.source == cel_context::ContextSource::AccessibilityTree)
+            .count();
+        let vision_count = ctx
+            .elements
+            .iter()
+            .filter(|e| e.source == cel_context::ContextSource::Vision)
+            .count();
+        let native_count = ctx
+            .elements
+            .iter()
+            .filter(|e| e.source == cel_context::ContextSource::NativeApi)
+            .count();
+        println!(
+            "Sources: {} a11y, {} vision, {} native",
+            a11y_count, vision_count, native_count
+        );
 
         // Vision fallback indication
-        let actionable_count = ctx.elements.iter()
+        let actionable_count = ctx
+            .elements
+            .iter()
             .filter(|e| e.source == cel_context::ContextSource::AccessibilityTree)
-            .filter(|e| matches!(e.element_type.as_str(),
-                "button" | "input" | "link" | "checkbox" | "radio_button" |
-                "combobox" | "menu_item" | "tab_item" | "slider" | "list_item" | "tree_item"))
+            .filter(|e| {
+                matches!(
+                    e.element_type.as_str(),
+                    "button"
+                        | "input"
+                        | "link"
+                        | "checkbox"
+                        | "radio_button"
+                        | "combobox"
+                        | "menu_item"
+                        | "tab_item"
+                        | "slider"
+                        | "list_item"
+                        | "tree_item"
+                )
+            })
             .count();
         if vision_count > 0 {
-            println!("Vision fallback: YES ({} a11y actionable < 5 threshold)", actionable_count);
+            println!(
+                "Vision fallback: YES ({} a11y actionable < 5 threshold)",
+                actionable_count
+            );
         } else {
-            println!("Vision fallback: NO ({} a11y actionable >= 5 threshold)", actionable_count);
+            println!(
+                "Vision fallback: NO ({} a11y actionable >= 5 threshold)",
+                actionable_count
+            );
         }
         println!();
 
@@ -86,10 +138,18 @@ fn main() {
             let state_str = {
                 let s = &elem.state;
                 let mut flags = Vec::new();
-                if s.focused { flags.push("focused"); }
-                if s.enabled { flags.push("enabled"); }
-                if s.visible { flags.push("visible"); }
-                if s.selected { flags.push("selected"); }
+                if s.focused {
+                    flags.push("focused");
+                }
+                if s.enabled {
+                    flags.push("enabled");
+                }
+                if s.visible {
+                    flags.push("visible");
+                }
+                if s.selected {
+                    flags.push("selected");
+                }
                 match s.expanded {
                     Some(true) => flags.push("expanded"),
                     Some(false) => flags.push("collapsed"),
@@ -106,10 +166,14 @@ fn main() {
                 Some(p) => format!(" ^{}", truncate(p, 12)),
                 None => String::new(),
             };
-            let desc_str = elem.description.as_deref()
+            let desc_str = elem
+                .description
+                .as_deref()
                 .map(|d| format!(" desc={}", truncate(d, 15)))
                 .unwrap_or_default();
-            let value_str = elem.value.as_deref()
+            let value_str = elem
+                .value
+                .as_deref()
                 .map(|v| format!(" val={}", truncate(v, 15)))
                 .unwrap_or_default();
             let actions_str = if elem.actions.is_empty() {
@@ -134,7 +198,10 @@ fn main() {
         }
 
         if ctx.elements.len() > max_display {
-            println!("  ... and {} more elements", ctx.elements.len() - max_display);
+            println!(
+                "  ... and {} more elements",
+                ctx.elements.len() - max_display
+            );
         }
 
         if !ctx.network_events.is_empty() {
@@ -143,9 +210,16 @@ fn main() {
             for evt in ctx.network_events.iter().take(10) {
                 let service = evt.service.as_deref().unwrap_or("?");
                 let process = evt.process_name.as_deref().unwrap_or("?");
-                println!("  {} {}:{} -> {}:{} [{}] ({})",
-                    evt.protocol, evt.local_addr, evt.local_port,
-                    evt.remote_addr, evt.remote_port, evt.state, service);
+                println!(
+                    "  {} {}:{} -> {}:{} [{}] ({})",
+                    evt.protocol,
+                    evt.local_addr,
+                    evt.local_port,
+                    evt.remote_addr,
+                    evt.remote_port,
+                    evt.state,
+                    service
+                );
                 println!("    process: {}", process);
             }
         }
@@ -154,7 +228,10 @@ fn main() {
             println!();
             println!("HTTP events:");
             for evt in ctx.http_events.iter().take(10) {
-                let status = evt.status_code.map(|s| s.to_string()).unwrap_or_else(|| "-".into());
+                let status = evt
+                    .status_code
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "-".into());
                 println!("  {} {} [{}]", evt.method, evt.url, status);
             }
         }

--- a/cel/cel-context/examples/dump_context.rs
+++ b/cel/cel-context/examples/dump_context.rs
@@ -48,7 +48,10 @@ fn main() {
     println!("=== Context References Test ===");
     if let Some(first) = ctx.elements.first() {
         let reference = first.to_reference(1920, 1080);
-        println!("Created reference for element '{}': {:?}", first.id, reference);
+        println!(
+            "Created reference for element '{}': {:?}",
+            first.id, reference
+        );
 
         let resolved = cel_context::resolve_reference(&ctx, &reference);
         match resolved {

--- a/cel/cel-context/src/confidence.rs
+++ b/cel/cel-context/src/confidence.rs
@@ -66,14 +66,32 @@ mod tests {
     fn test_confidence_behavior_mapping() {
         let thresholds = ConfidenceThresholds::default();
 
-        assert_eq!(thresholds.behavior_for(0.95), ConfidenceBehavior::ActImmediately);
-        assert_eq!(thresholds.behavior_for(0.9), ConfidenceBehavior::ActImmediately);
+        assert_eq!(
+            thresholds.behavior_for(0.95),
+            ConfidenceBehavior::ActImmediately
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.9),
+            ConfidenceBehavior::ActImmediately
+        );
         assert_eq!(thresholds.behavior_for(0.85), ConfidenceBehavior::ActAndLog);
         assert_eq!(thresholds.behavior_for(0.7), ConfidenceBehavior::ActAndLog);
-        assert_eq!(thresholds.behavior_for(0.6), ConfidenceBehavior::ActCautiously);
-        assert_eq!(thresholds.behavior_for(0.5), ConfidenceBehavior::ActCautiously);
-        assert_eq!(thresholds.behavior_for(0.3), ConfidenceBehavior::PauseAndNotify);
-        assert_eq!(thresholds.behavior_for(0.0), ConfidenceBehavior::PauseAndNotify);
+        assert_eq!(
+            thresholds.behavior_for(0.6),
+            ConfidenceBehavior::ActCautiously
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.5),
+            ConfidenceBehavior::ActCautiously
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.3),
+            ConfidenceBehavior::PauseAndNotify
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.0),
+            ConfidenceBehavior::PauseAndNotify
+        );
     }
 
     #[test]
@@ -81,38 +99,71 @@ mod tests {
         let thresholds = ConfidenceThresholds::default();
 
         // Exactly at boundaries
-        assert_eq!(thresholds.behavior_for(0.9), ConfidenceBehavior::ActImmediately);
+        assert_eq!(
+            thresholds.behavior_for(0.9),
+            ConfidenceBehavior::ActImmediately
+        );
         assert_eq!(thresholds.behavior_for(0.7), ConfidenceBehavior::ActAndLog);
-        assert_eq!(thresholds.behavior_for(0.5), ConfidenceBehavior::ActCautiously);
+        assert_eq!(
+            thresholds.behavior_for(0.5),
+            ConfidenceBehavior::ActCautiously
+        );
 
         // Just below boundaries
-        assert_eq!(thresholds.behavior_for(0.8999), ConfidenceBehavior::ActAndLog);
-        assert_eq!(thresholds.behavior_for(0.6999), ConfidenceBehavior::ActCautiously);
-        assert_eq!(thresholds.behavior_for(0.4999), ConfidenceBehavior::PauseAndNotify);
+        assert_eq!(
+            thresholds.behavior_for(0.8999),
+            ConfidenceBehavior::ActAndLog
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.6999),
+            ConfidenceBehavior::ActCautiously
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.4999),
+            ConfidenceBehavior::PauseAndNotify
+        );
     }
 
     #[test]
     fn test_extreme_values() {
         let thresholds = ConfidenceThresholds::default();
 
-        assert_eq!(thresholds.behavior_for(1.0), ConfidenceBehavior::ActImmediately);
-        assert_eq!(thresholds.behavior_for(0.0), ConfidenceBehavior::PauseAndNotify);
+        assert_eq!(
+            thresholds.behavior_for(1.0),
+            ConfidenceBehavior::ActImmediately
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.0),
+            ConfidenceBehavior::PauseAndNotify
+        );
     }
 
     #[test]
     fn test_negative_confidence() {
         let thresholds = ConfidenceThresholds::default();
         // Negative values should result in PauseAndNotify (lowest tier)
-        assert_eq!(thresholds.behavior_for(-0.1), ConfidenceBehavior::PauseAndNotify);
-        assert_eq!(thresholds.behavior_for(-1.0), ConfidenceBehavior::PauseAndNotify);
+        assert_eq!(
+            thresholds.behavior_for(-0.1),
+            ConfidenceBehavior::PauseAndNotify
+        );
+        assert_eq!(
+            thresholds.behavior_for(-1.0),
+            ConfidenceBehavior::PauseAndNotify
+        );
     }
 
     #[test]
     fn test_over_one_confidence() {
         let thresholds = ConfidenceThresholds::default();
         // Values > 1.0 should still map to ActImmediately
-        assert_eq!(thresholds.behavior_for(1.5), ConfidenceBehavior::ActImmediately);
-        assert_eq!(thresholds.behavior_for(100.0), ConfidenceBehavior::ActImmediately);
+        assert_eq!(
+            thresholds.behavior_for(1.5),
+            ConfidenceBehavior::ActImmediately
+        );
+        assert_eq!(
+            thresholds.behavior_for(100.0),
+            ConfidenceBehavior::ActImmediately
+        );
     }
 
     #[test]
@@ -123,10 +174,19 @@ mod tests {
             act_cautiously: 0.6,
         };
 
-        assert_eq!(thresholds.behavior_for(0.96), ConfidenceBehavior::ActImmediately);
+        assert_eq!(
+            thresholds.behavior_for(0.96),
+            ConfidenceBehavior::ActImmediately
+        );
         assert_eq!(thresholds.behavior_for(0.94), ConfidenceBehavior::ActAndLog);
-        assert_eq!(thresholds.behavior_for(0.79), ConfidenceBehavior::ActCautiously);
-        assert_eq!(thresholds.behavior_for(0.59), ConfidenceBehavior::PauseAndNotify);
+        assert_eq!(
+            thresholds.behavior_for(0.79),
+            ConfidenceBehavior::ActCautiously
+        );
+        assert_eq!(
+            thresholds.behavior_for(0.59),
+            ConfidenceBehavior::PauseAndNotify
+        );
     }
 
     #[test]
@@ -162,7 +222,10 @@ mod tests {
                 rank(&behaviors[i]) >= rank(&behaviors[i - 1]),
                 "Behavior should be monotonically non-decreasing with confidence. \
                  At {}/100: {:?}, at {}/100: {:?}",
-                i - 1, behaviors[i - 1], i, behaviors[i]
+                i - 1,
+                behaviors[i - 1],
+                i,
+                behaviors[i]
             );
         }
     }

--- a/cel/cel-context/src/element.rs
+++ b/cel/cel-context/src/element.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::collections::HashMap;
 
 /// Re-export Bounds and ElementState from the accessibility crate — single source of truth.

--- a/cel/cel-context/src/element.rs
+++ b/cel/cel-context/src/element.rs
@@ -47,30 +47,26 @@ pub enum ContentRole {
 }
 
 /// Classify an element's content role based on its type and properties.
-pub fn classify_content_role(element_type: &str, actions: &[String], state: &ElementState) -> ContentRole {
+pub fn classify_content_role(
+    element_type: &str,
+    actions: &[String],
+    state: &ElementState,
+) -> ContentRole {
     match element_type {
         // Interactive controls
-        "button" | "link" | "input" | "textfield" | "textarea" | "combobox"
-        | "select" | "checkbox" | "radio" | "slider" | "switch" | "toggle"
-        | "tab" | "tab_item" | "menuitem" | "menu_item" | "menubar" | "menu"
-        | "toolbar" | "searchfield" | "tree_item" => {
-            ContentRole::Interactive
-        }
+        "button" | "link" | "input" | "textfield" | "textarea" | "combobox" | "select"
+        | "checkbox" | "radio" | "slider" | "switch" | "toggle" | "tab" | "tab_item"
+        | "menuitem" | "menu_item" | "menubar" | "menu" | "toolbar" | "searchfield"
+        | "tree_item" => ContentRole::Interactive,
         // System chrome
-        "scrollbar" | "splitter" | "statusbar" | "status_bar" | "progressbar"
-        | "indicator" | "dialog" | "window" => {
-            ContentRole::System
-        }
+        "scrollbar" | "splitter" | "statusbar" | "status_bar" | "progressbar" | "indicator"
+        | "dialog" | "window" => ContentRole::System,
         // Decorative
-        "separator" | "image" | "icon" | "spacer" => {
-            ContentRole::Decorative
-        }
+        "separator" | "image" | "icon" | "spacer" => ContentRole::Decorative,
         // Text content — untrusted
-        "text" | "statictext" | "paragraph" | "heading" | "label" | "cell"
-        | "table" | "table_row" | "table_cell" | "list" | "listitem" | "list_item"
-        | "article" | "blockquote" => {
-            ContentRole::Content
-        }
+        "text" | "statictext" | "paragraph" | "heading" | "label" | "cell" | "table"
+        | "table_row" | "table_cell" | "list" | "listitem" | "list_item" | "article"
+        | "blockquote" => ContentRole::Content,
         // Default: if it has actions, it's interactive; otherwise content
         _ => {
             if !actions.is_empty() || state.focused {
@@ -119,7 +115,11 @@ pub struct ContextElement {
     /// Keys: "placeholder", "url", "required", "invalid", "role_desc", "selected_text",
     ///        "dom_id", "document", "filename", "min_value", "max_value", "has_popup",
     ///        "column_count", "row_count", "loading_progress"
-    #[serde(default, skip_serializing_if = "HashMap::is_empty", deserialize_with = "flexible_properties")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        deserialize_with = "flexible_properties"
+    )]
     pub properties: HashMap<String, String>,
 }
 
@@ -347,19 +347,49 @@ mod tests {
 
     #[test]
     fn test_classify_interactive_elements() {
-        let types = ["button", "link", "input", "textfield", "textarea",
-                     "combobox", "select", "checkbox", "radio", "slider",
-                     "switch", "toggle", "tab", "menuitem"];
+        let types = [
+            "button",
+            "link",
+            "input",
+            "textfield",
+            "textarea",
+            "combobox",
+            "select",
+            "checkbox",
+            "radio",
+            "slider",
+            "switch",
+            "toggle",
+            "tab",
+            "menuitem",
+        ];
         for t in types {
             let role = classify_content_role(t, &[], &default_state());
-            assert_eq!(role, ContentRole::Interactive, "Expected Interactive for '{}'", t);
+            assert_eq!(
+                role,
+                ContentRole::Interactive,
+                "Expected Interactive for '{}'",
+                t
+            );
         }
     }
 
     #[test]
     fn test_classify_content_elements() {
-        let types = ["text", "statictext", "paragraph", "heading",
-                     "label", "cell", "table", "table_row", "table_cell", "list", "listitem", "list_item"];
+        let types = [
+            "text",
+            "statictext",
+            "paragraph",
+            "heading",
+            "label",
+            "cell",
+            "table",
+            "table_row",
+            "table_cell",
+            "list",
+            "listitem",
+            "list_item",
+        ];
         for t in types {
             let role = classify_content_role(t, &[], &default_state());
             assert_eq!(role, ContentRole::Content, "Expected Content for '{}'", t);
@@ -368,7 +398,15 @@ mod tests {
 
     #[test]
     fn test_classify_system_elements() {
-        let types = ["scrollbar", "splitter", "statusbar", "status_bar", "progressbar", "dialog", "window"];
+        let types = [
+            "scrollbar",
+            "splitter",
+            "statusbar",
+            "status_bar",
+            "progressbar",
+            "dialog",
+            "window",
+        ];
         for t in types {
             let role = classify_content_role(t, &[], &default_state());
             assert_eq!(role, ContentRole::System, "Expected System for '{}'", t);
@@ -380,7 +418,12 @@ mod tests {
         let types = ["separator", "image", "icon", "spacer"];
         for t in types {
             let role = classify_content_role(t, &[], &default_state());
-            assert_eq!(role, ContentRole::Decorative, "Expected Decorative for '{}'", t);
+            assert_eq!(
+                role,
+                ContentRole::Decorative,
+                "Expected Decorative for '{}'",
+                t
+            );
         }
     }
 

--- a/cel/cel-context/src/events.rs
+++ b/cel/cel-context/src/events.rs
@@ -25,9 +25,7 @@ pub enum CelEvent {
         new_value: Option<String>,
     },
     /// A new window was created (from AXObserver).
-    WindowCreated {
-        title: Option<String>,
-    },
+    WindowCreated { title: Option<String> },
     /// A menu was opened (from AXObserver).
     MenuOpened,
     /// A menu was closed (from AXObserver).
@@ -37,17 +35,11 @@ pub enum CelEvent {
     /// UI layout changed (from AXObserver).
     LayoutChanged,
     /// An element's title changed (from AXObserver).
-    TitleChanged {
-        new_title: Option<String>,
-    },
+    TitleChanged { new_title: Option<String> },
     /// An application was activated (brought to foreground).
-    AppActivated {
-        app_name: Option<String>,
-    },
+    AppActivated { app_name: Option<String> },
     /// An application was deactivated (sent to background).
-    AppDeactivated {
-        app_name: Option<String>,
-    },
+    AppDeactivated { app_name: Option<String> },
     /// A window was moved.
     WindowMoved,
     /// A window was resized.

--- a/cel/cel-context/src/lib.rs
+++ b/cel/cel-context/src/lib.rs
@@ -3,22 +3,22 @@
 //! Merges all five context streams (display, input, accessibility, vision, network)
 //! into a single structured world model. This is the core API that agents consume.
 
-mod element;
 mod confidence;
+mod element;
 pub mod events;
 mod merge;
 mod resolve;
 pub mod watchdog;
 
-pub use element::{
-    Bounds, BoundsRegion, ContentRole, ContextElement, ContextReference, ContextSource,
-    ElementState, FocusedContext, ScreenContext, TranscriptEntry, classify_content_role,
-};
 pub use confidence::{ConfidenceBehavior, ConfidenceThresholds};
+pub use element::{
+    classify_content_role, Bounds, BoundsRegion, ContentRole, ContextElement, ContextReference,
+    ContextSource, ElementState, FocusedContext, ScreenContext, TranscriptEntry,
+};
 pub use events::CelEvent;
 pub use merge::{
-    ContextMerger, build_from_external, score_element_confidence,
-    aria_role_to_cel_type, assign_default_actions, is_actionable_type, StreamStatus,
+    aria_role_to_cel_type, assign_default_actions, build_from_external, is_actionable_type,
+    score_element_confidence, ContextMerger, StreamStatus,
 };
 pub use resolve::resolve_reference;
 pub use watchdog::ContextWatchdog;

--- a/cel/cel-context/src/merge.rs
+++ b/cel/cel-context/src/merge.rs
@@ -12,19 +12,52 @@ use std::time::{Duration, Instant};
 /// Set to 5 to avoid unnecessary vision calls on simple dialogs (OK/Cancel = 2 buttons).
 const VISION_FALLBACK_THRESHOLD: usize = 5;
 const GENERIC_ACTION_LABELS: &[&str] = &[
-    "open", "close", "cancel", "ok", "more", "menu", "next", "back",
-    "learn more", "details", "view", "edit", "delete", "remove", "select",
-    "continue", "submit", "save", "apply", "retry", "dismiss",
+    "open",
+    "close",
+    "cancel",
+    "ok",
+    "more",
+    "menu",
+    "next",
+    "back",
+    "learn more",
+    "details",
+    "view",
+    "edit",
+    "delete",
+    "remove",
+    "select",
+    "continue",
+    "submit",
+    "save",
+    "apply",
+    "retry",
+    "dismiss",
 ];
 const CHROME_NOISE_HINTS: &[&str] = &[
-    "header", "nav", "navbar", "toolbar", "menu", "sidebar", "breadcrumb",
-    "footer", "legal", "cookie", "consent", "account", "profile", "help",
-    "support", "social", "share", "newsletter", "chat", "intercom",
+    "header",
+    "nav",
+    "navbar",
+    "toolbar",
+    "menu",
+    "sidebar",
+    "breadcrumb",
+    "footer",
+    "legal",
+    "cookie",
+    "consent",
+    "account",
+    "profile",
+    "help",
+    "support",
+    "social",
+    "share",
+    "newsletter",
+    "chat",
+    "intercom",
 ];
 
-fn frontmost_app_from_signals(
-    snapshot: &cel_signals::SignalSnapshot,
-) -> Option<String> {
+fn frontmost_app_from_signals(snapshot: &cel_signals::SignalSnapshot) -> Option<String> {
     snapshot
         .running_apps
         .iter()
@@ -48,9 +81,7 @@ fn frontmost_window_from_signals(
             .window_list
             .iter()
             .find(|window| {
-                window.is_on_screen
-                    && window.app_name == app_name
-                    && !window.title.is_empty()
+                window.is_on_screen && window.app_name == app_name && !window.title.is_empty()
             })
             .map(|window| window.title.clone())
             .or_else(|| {
@@ -335,7 +366,9 @@ impl ContextMerger {
         });
 
         // Detect foreground app/window — prefer accessibility data over display layer
-        let (app, window) = self.detect_foreground_from_a11y().unwrap_or_else(|| self.detect_foreground());
+        let (app, window) = self
+            .detect_foreground_from_a11y()
+            .unwrap_or_else(|| self.detect_foreground());
 
         // Capture screen dimensions for spatial normalization in reference resolution
         let (screen_width, screen_height) = self
@@ -361,10 +394,16 @@ impl ContextMerger {
             screen_width,
             screen_height,
             clipboard: signal_snapshot.as_ref().and_then(|s| s.clipboard.clone()),
-            window_list: signal_snapshot.as_ref().map(|s| s.window_list.clone()).unwrap_or_default(),
+            window_list: signal_snapshot
+                .as_ref()
+                .map(|s| s.window_list.clone())
+                .unwrap_or_default(),
             audio: signal_snapshot.as_ref().and_then(|s| s.audio.clone()),
             power: signal_snapshot.as_ref().and_then(|s| s.power.clone()),
-            running_apps: signal_snapshot.as_ref().map(|s| s.running_apps.clone()).unwrap_or_default(),
+            running_apps: signal_snapshot
+                .as_ref()
+                .map(|s| s.running_apps.clone())
+                .unwrap_or_default(),
             recent_files: signal_snapshot.map(|s| s.recent_files).unwrap_or_default(),
             http_events: vec![],
             transcripts: vec![],
@@ -478,7 +517,11 @@ impl ContextMerger {
             .into_iter()
             .enumerate()
             .map(|(i, ve)| {
-                let role = crate::classify_content_role(&ve.element_type, &[], &cel_accessibility::ElementState::default_visible());
+                let role = crate::classify_content_role(
+                    &ve.element_type,
+                    &[],
+                    &cel_accessibility::ElementState::default_visible(),
+                );
                 ContextElement {
                     id: format!("vision:{}", i),
                     label: Some(ve.label),
@@ -538,9 +581,11 @@ impl ContextMerger {
             .or_else(|| {
                 // Fallback to display layer when signals not wired
                 self.display.as_ref().and_then(|d| {
-                    d.list_windows()
-                        .ok()
-                        .and_then(|w| w.iter().find(|w| !w.is_minimized).map(|w| w.app_name.clone()))
+                    d.list_windows().ok().and_then(|w| {
+                        w.iter()
+                            .find(|w| !w.is_minimized)
+                            .map(|w| w.app_name.clone())
+                    })
                 })
             })
             .unwrap_or_else(|| window_title.clone());
@@ -700,9 +745,7 @@ impl ContextMerger {
             actions: node.actions.clone(),
             confidence: 0.0, // Will be scored below
             source: ContextSource::AccessibilityTree,
-            content_role: crate::classify_content_role(
-                &element_type, &node.actions, &node.state,
-            ),
+            content_role: crate::classify_content_role(&element_type, &node.actions, &node.state),
             properties: node.properties.clone(),
         };
         elem.confidence = score_element_confidence(&elem);
@@ -808,21 +851,18 @@ pub fn aria_role_to_cel_type(role: &str) -> &'static str {
         "dialog" | "alertdialog" => "dialog",
         "menu" | "menubar" => "menu",
         "navigation" | "toolbar" => "toolbar",
-        "tablist" | "tabpanel" | "group" | "region" | "banner"
-        | "complementary" | "contentinfo" | "form" | "main"
-        | "search" | "article" | "section" | "aside"
-        | "header" | "footer" | "fieldset" | "figure"
-        | "details" | "summary" => "group",
+        "tablist" | "tabpanel" | "group" | "region" | "banner" | "complementary"
+        | "contentinfo" | "form" | "main" | "search" | "article" | "section" | "aside"
+        | "header" | "footer" | "fieldset" | "figure" | "details" | "summary" => "group",
         "tree" => "tree_view",
         "grid" | "table" | "treegrid" => "table",
         "row" => "table_row",
         "img" | "image" => "image",
         "status" => "status_bar",
         "list" | "directory" | "feed" => "list",
-        "heading" | "separator" | "paragraph" | "blockquote"
-        | "caption" | "code" | "definition" | "deletion"
-        | "insertion" | "mark" | "math" | "note"
-        | "subscript" | "superscript" | "term" | "time" => "text",
+        "heading" | "separator" | "paragraph" | "blockquote" | "caption" | "code"
+        | "definition" | "deletion" | "insertion" | "mark" | "math" | "note" | "subscript"
+        | "superscript" | "term" | "time" => "text",
         "scrollbar" => "scrollbar",
         "window" | "application" | "document" => "window",
         _ => "text",
@@ -967,10 +1007,20 @@ fn is_generic_action_label(label: &str) -> bool {
 }
 
 fn has_noise_hint(el: &ContextElement) -> bool {
-    let selector = el.properties.get("css_selector").map(String::as_str).unwrap_or("");
-    let dom_id = el.properties.get("dom_id").map(String::as_str).unwrap_or("");
+    let selector = el
+        .properties
+        .get("css_selector")
+        .map(String::as_str)
+        .unwrap_or("");
+    let dom_id = el
+        .properties
+        .get("dom_id")
+        .map(String::as_str)
+        .unwrap_or("");
     let combined = format!("{} {}", selector.to_lowercase(), dom_id.to_lowercase());
-    CHROME_NOISE_HINTS.iter().any(|hint| combined.contains(hint))
+    CHROME_NOISE_HINTS
+        .iter()
+        .any(|hint| combined.contains(hint))
 }
 
 fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextElement> {
@@ -986,7 +1036,9 @@ fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextEleme
     let mut label_counts: HashMap<(String, String), usize> = HashMap::new();
     for (el, n) in elements.iter().zip(normalized.iter()) {
         if !n.is_empty() {
-            *label_counts.entry((el.element_type.clone(), n.clone())).or_insert(0) += 1;
+            *label_counts
+                .entry((el.element_type.clone(), n.clone()))
+                .or_insert(0) += 1;
         }
     }
 
@@ -1009,8 +1061,13 @@ fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextEleme
     let snapshot_for_phase1 = elements.clone();
     for (i, el) in elements.iter_mut().enumerate() {
         apply_noise_penalty_cached(
-            el, &normalized[i], &snapshot_for_phase1, &normalized,
-            &label_counts, &by_parent, &id_to_idx,
+            el,
+            &normalized[i],
+            &snapshot_for_phase1,
+            &normalized,
+            &label_counts,
+            &by_parent,
+            &id_to_idx,
         );
     }
 
@@ -1034,7 +1091,13 @@ fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextEleme
         if is_actionable_type(&el.element_type)
             && !normalized[i].is_empty()
             && is_generic_action_label(&normalized[i])
-            && !has_structural_identity_cached(el, &snapshot_for_phase2, &normalized, &by_parent, &id_to_idx)
+            && !has_structural_identity_cached(
+                el,
+                &snapshot_for_phase2,
+                &normalized,
+                &by_parent,
+                &id_to_idx,
+            )
             && has_noise_hint(el)
         {
             keep[i] = false;
@@ -1057,9 +1120,15 @@ fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextEleme
 
     'outer: for (i, el) in filtered.into_iter().enumerate() {
         for (j, existing) in deduped.iter_mut().enumerate() {
-            if are_overlapping_duplicates_cached(existing, &deduped_norm[j], &el, &filtered_norm[i]) {
+            if are_overlapping_duplicates_cached(existing, &deduped_norm[j], &el, &filtered_norm[i])
+            {
                 if !should_keep_over_cached(
-                    existing, &el, &snapshot_for_dedup, &dedup_normalized, &by_parent, &id_to_idx,
+                    existing,
+                    &el,
+                    &snapshot_for_dedup,
+                    &dedup_normalized,
+                    &by_parent,
+                    &id_to_idx,
                 ) {
                     deduped_norm[j] = filtered_norm[i].clone();
                     *existing = el;
@@ -1121,8 +1190,10 @@ fn apply_noise_penalty_cached(
 
     if !reasons.is_empty() {
         el.confidence = (el.confidence - penalty).max(0.15);
-        el.properties.insert("noise_penalty".into(), format!("{:.2}", penalty));
-        el.properties.insert("noise_reasons".into(), reasons.join(","));
+        el.properties
+            .insert("noise_penalty".into(), format!("{:.2}", penalty));
+        el.properties
+            .insert("noise_reasons".into(), reasons.join(","));
     }
 }
 
@@ -1150,7 +1221,10 @@ fn has_structural_identity_cached(
             .filter(|&&i| elements[i].id != el.id)
             .filter(|&&i| {
                 !normalized[i].is_empty()
-                    || elements[i].value.as_ref().map_or(false, |v| !normalized_text(Some(v)).is_empty())
+                    || elements[i]
+                        .value
+                        .as_ref()
+                        .map_or(false, |v| !normalized_text(Some(v)).is_empty())
             })
             .count();
         if sibling_labels >= 2 {
@@ -1184,8 +1258,10 @@ fn should_keep_over_cached(
     by_parent: &std::collections::HashMap<String, Vec<usize>>,
     id_to_idx: &std::collections::HashMap<String, usize>,
 ) -> bool {
-    let existing_richness = context_richness_cached(existing, elements, normalized, by_parent, id_to_idx);
-    let candidate_richness = context_richness_cached(candidate, elements, normalized, by_parent, id_to_idx);
+    let existing_richness =
+        context_richness_cached(existing, elements, normalized, by_parent, id_to_idx);
+    let candidate_richness =
+        context_richness_cached(candidate, elements, normalized, by_parent, id_to_idx);
     if existing_richness != candidate_richness {
         return existing_richness > candidate_richness;
     }
@@ -1201,7 +1277,9 @@ fn context_richness_cached(
 ) -> usize {
     let label_len = el.label.as_ref().map_or(0, |label| label.len().min(32));
     let value_len = el.value.as_ref().map_or(0, |value| value.len().min(16));
-    let structural = usize::from(has_structural_identity_cached(el, elements, normalized, by_parent, id_to_idx)) * 4;
+    let structural = usize::from(has_structural_identity_cached(
+        el, elements, normalized, by_parent, id_to_idx,
+    )) * 4;
     el.actions.len() * 3 + el.properties.len() * 2 + label_len + value_len + structural
 }
 
@@ -1239,37 +1317,87 @@ mod tests {
 
     #[test]
     fn test_bounds_overlap_full() {
-        let a = Bounds { x: 0, y: 0, width: 100, height: 100 };
-        let b = Bounds { x: 0, y: 0, width: 100, height: 100 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let b = Bounds {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
         assert!((bounds_overlap(&a, &b) - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_bounds_overlap_none() {
-        let a = Bounds { x: 0, y: 0, width: 50, height: 50 };
-        let b = Bounds { x: 100, y: 100, width: 50, height: 50 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        };
+        let b = Bounds {
+            x: 100,
+            y: 100,
+            width: 50,
+            height: 50,
+        };
         assert_eq!(bounds_overlap(&a, &b), 0.0);
     }
 
     #[test]
     fn test_bounds_overlap_partial() {
-        let a = Bounds { x: 0, y: 0, width: 100, height: 100 };
-        let b = Bounds { x: 50, y: 50, width: 100, height: 100 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let b = Bounds {
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+        };
         let iou = bounds_overlap(&a, &b);
         assert!(iou > 0.0 && iou < 1.0);
     }
 
     #[test]
     fn test_bounds_overlap_adjacent() {
-        let a = Bounds { x: 0, y: 0, width: 50, height: 50 };
-        let b = Bounds { x: 50, y: 0, width: 50, height: 50 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        };
+        let b = Bounds {
+            x: 50,
+            y: 0,
+            width: 50,
+            height: 50,
+        };
         assert_eq!(bounds_overlap(&a, &b), 0.0);
     }
 
     #[test]
     fn test_bounds_overlap_contained() {
-        let a = Bounds { x: 0, y: 0, width: 200, height: 200 };
-        let b = Bounds { x: 50, y: 50, width: 50, height: 50 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 200,
+        };
+        let b = Bounds {
+            x: 50,
+            y: 50,
+            width: 50,
+            height: 50,
+        };
         let iou = bounds_overlap(&a, &b);
         assert!(iou > 0.0 && iou < 0.1);
     }
@@ -1282,8 +1410,14 @@ mod tests {
         assert!(!ctx.elements.is_empty());
         assert_eq!(ctx.elements[0].element_type, "window");
         // Stub has label "Stub Window", bounds 1920x1080, visible+enabled → 0.60+0.10+0.10+0.05 = 0.85
-        assert!(ctx.elements[0].confidence >= 0.60, "Confidence should be at least base 0.60");
-        assert!(ctx.elements[0].confidence <= 0.95, "Confidence should be at most 0.95");
+        assert!(
+            ctx.elements[0].confidence >= 0.60,
+            "Confidence should be at least base 0.60"
+        );
+        assert!(
+            ctx.elements[0].confidence <= 0.95,
+            "Confidence should be at most 0.95"
+        );
         assert_eq!(ctx.elements[0].source, ContextSource::AccessibilityTree);
         assert!(ctx.timestamp_ms > 0);
     }
@@ -1293,9 +1427,20 @@ mod tests {
         let stub = Box::new(cel_accessibility::StubAccessibility);
         let merger = ContextMerger::new(stub);
         let mut ctx = ScreenContext {
-            app: "".into(), window: "".into(), network_events: vec![], http_events: vec![], timestamp_ms: 0, screen_width: None, screen_height: None,
-            clipboard: None, window_list: vec![],
-            audio: None, power: None, running_apps: vec![], recent_files: vec![], transcripts: vec![],
+            app: "".into(),
+            window: "".into(),
+            network_events: vec![],
+            http_events: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
             elements: vec![ContextElement {
                 id: "root".into(),
                 label: Some("Stub Window".into()),
@@ -1341,9 +1486,20 @@ mod tests {
         let stub = Box::new(cel_accessibility::StubAccessibility);
         let merger = ContextMerger::new(stub);
         let mut ctx = ScreenContext {
-            app: "".into(), window: "".into(), network_events: vec![], http_events: vec![], timestamp_ms: 0, screen_width: None, screen_height: None,
-            clipboard: None, window_list: vec![],
-            audio: None, power: None, running_apps: vec![], recent_files: vec![], transcripts: vec![],
+            app: "".into(),
+            window: "".into(),
+            network_events: vec![],
+            http_events: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
             elements: vec![ContextElement {
                 id: "root".into(),
                 label: None,
@@ -1368,7 +1524,12 @@ mod tests {
             description: None,
             element_type: "table_cell".into(),
             value: Some("Revenue".into()),
-            bounds: Some(Bounds { x: 120, y: 200, width: 80, height: 20 }),
+            bounds: Some(Bounds {
+                x: 120,
+                y: 200,
+                width: 80,
+                height: 20,
+            }),
             state: cel_accessibility::ElementState::default(),
             parent_id: None,
             actions: vec![],
@@ -1411,7 +1572,12 @@ mod tests {
             description: None,
             element_type: "button".into(),
             value: None,
-            bounds: Some(Bounds { x: 500, y: 500, width: 100, height: 40 }),
+            bounds: Some(Bounds {
+                x: 500,
+                y: 500,
+                width: 100,
+                height: 40,
+            }),
             state: cel_accessibility::ElementState::default(),
             parent_id: None,
             actions: vec![],
@@ -1440,7 +1606,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 100, y: 100, width: 80, height: 30 }),
+                bounds: Some(Bounds {
+                    x: 100,
+                    y: 100,
+                    width: 80,
+                    height: 30,
+                }),
                 state: cel_accessibility::ElementState::default(),
                 parent_id: None,
                 actions: vec![],
@@ -1468,7 +1639,12 @@ mod tests {
             description: None,
             element_type: "button".into(),
             value: None,
-            bounds: Some(Bounds { x: 100, y: 100, width: 80, height: 30 }),
+            bounds: Some(Bounds {
+                x: 100,
+                y: 100,
+                width: 80,
+                height: 30,
+            }),
             state: cel_accessibility::ElementState::default(),
             parent_id: None,
             actions: vec![],
@@ -1483,7 +1659,10 @@ mod tests {
         assert_eq!(ctx.elements.len(), 1);
         // Source stays a11y, but confidence boosted
         assert_eq!(ctx.elements[0].source, ContextSource::AccessibilityTree);
-        assert_eq!(ctx.elements[0].confidence, 0.90, "Should be boosted from 0.85 by 0.05");
+        assert_eq!(
+            ctx.elements[0].confidence, 0.90,
+            "Should be boosted from 0.85 by 0.05"
+        );
     }
 
     #[test]
@@ -1501,7 +1680,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 100, y: 100, width: 100, height: 50 }), // A11y bounds (slightly larger)
+                bounds: Some(Bounds {
+                    x: 100,
+                    y: 100,
+                    width: 100,
+                    height: 50,
+                }), // A11y bounds (slightly larger)
                 state: cel_accessibility::ElementState::default(),
                 parent_id: None,
                 actions: vec![],
@@ -1529,7 +1713,12 @@ mod tests {
             description: None,
             element_type: "button".into(),
             value: None,
-            bounds: Some(Bounds { x: 105, y: 105, width: 80, height: 40 }),
+            bounds: Some(Bounds {
+                x: 105,
+                y: 105,
+                width: 80,
+                height: 40,
+            }),
             state: cel_accessibility::ElementState::default(),
             parent_id: None,
             actions: vec![],
@@ -1552,37 +1741,66 @@ mod tests {
         let stub = Box::new(cel_accessibility::StubAccessibility);
         let merger = ContextMerger::new(stub);
         let mut ctx = ScreenContext {
-            app: "".into(), window: "".into(), network_events: vec![], http_events: vec![], timestamp_ms: 0, screen_width: None, screen_height: None,
-            clipboard: None, window_list: vec![],
-            audio: None, power: None, running_apps: vec![], recent_files: vec![], transcripts: vec![],
+            app: "".into(),
+            window: "".into(),
+            network_events: vec![],
+            http_events: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
             elements: vec![ContextElement {
-                id: "root".into(), label: None, description: None,
+                id: "root".into(),
+                label: None,
+                description: None,
                 element_type: "window".into(),
-                value: None, bounds: None, state: cel_accessibility::ElementState::default(), parent_id: None,
+                value: None,
+                bounds: None,
+                state: cel_accessibility::ElementState::default(),
+                parent_id: None,
                 actions: vec![],
                 properties: std::collections::HashMap::new(),
-                confidence: 0.85, source: ContextSource::AccessibilityTree,
+                confidence: 0.85,
+                source: ContextSource::AccessibilityTree,
                 content_role: ContentRole::default(),
             }],
         };
 
         let native = vec![
             ContextElement {
-                id: "low".into(), label: None, description: None,
+                id: "low".into(),
+                label: None,
+                description: None,
                 element_type: "text".into(),
-                value: None, bounds: None, state: cel_accessibility::ElementState::default(), parent_id: None,
+                value: None,
+                bounds: None,
+                state: cel_accessibility::ElementState::default(),
+                parent_id: None,
                 actions: vec![],
                 properties: std::collections::HashMap::new(),
-                confidence: 0.50, source: ContextSource::NativeApi,
+                confidence: 0.50,
+                source: ContextSource::NativeApi,
                 content_role: ContentRole::default(),
             },
             ContextElement {
-                id: "high".into(), label: None, description: None,
+                id: "high".into(),
+                label: None,
+                description: None,
                 element_type: "button".into(),
-                value: None, bounds: None, state: cel_accessibility::ElementState::default(), parent_id: None,
+                value: None,
+                bounds: None,
+                state: cel_accessibility::ElementState::default(),
+                parent_id: None,
                 actions: vec![],
                 properties: std::collections::HashMap::new(),
-                confidence: 0.99, source: ContextSource::NativeApi,
+                confidence: 0.99,
+                source: ContextSource::NativeApi,
                 content_role: ContentRole::default(),
             },
         ];
@@ -1834,19 +2052,48 @@ mod tests {
     #[test]
     fn test_bounds_overlap_iou_value() {
         // 50% overlap: two 100x100 boxes offset by 50px
-        let a = Bounds { x: 0, y: 0, width: 100, height: 100 };
-        let b = Bounds { x: 50, y: 0, width: 100, height: 100 };
+        let a = Bounds {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let b = Bounds {
+            x: 50,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
         let iou = bounds_overlap(&a, &b);
         // Intersection: 50x100 = 5000, Union: 10000 + 10000 - 5000 = 15000
         let expected = 5000.0 / 15000.0;
-        assert!((iou - expected).abs() < 0.01, "Expected IoU ~{:.3}, got {:.3}", expected, iou);
+        assert!(
+            (iou - expected).abs() < 0.01,
+            "Expected IoU ~{:.3}, got {:.3}",
+            expected,
+            iou
+        );
     }
 
     #[test]
     fn test_bounds_overlap_zero_area() {
-        let a = Bounds { x: 10, y: 10, width: 0, height: 0 };
-        let b = Bounds { x: 10, y: 10, width: 0, height: 0 };
-        assert_eq!(bounds_overlap(&a, &b), 0.0, "Zero-area bounds should have 0 IoU");
+        let a = Bounds {
+            x: 10,
+            y: 10,
+            width: 0,
+            height: 0,
+        };
+        let b = Bounds {
+            x: 10,
+            y: 10,
+            width: 0,
+            height: 0,
+        };
+        assert_eq!(
+            bounds_overlap(&a, &b),
+            0.0,
+            "Zero-area bounds should have 0 IoU"
+        );
     }
 
     #[test]
@@ -1854,11 +2101,21 @@ mod tests {
         let stub = Box::new(cel_accessibility::StubAccessibility);
         let merger = ContextMerger::new(stub);
         let mut ctx = ScreenContext {
-            app: "test".into(), window: "test".into(),
-            network_events: vec![], http_events: vec![], elements: vec![], timestamp_ms: 0,
-            screen_width: None, screen_height: None,
-            clipboard: None, window_list: vec![],
-            audio: None, power: None, running_apps: vec![], recent_files: vec![], transcripts: vec![],
+            app: "test".into(),
+            window: "test".into(),
+            network_events: vec![],
+            http_events: vec![],
+            elements: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
         };
 
         let vision = vec![
@@ -1868,7 +2125,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 100, y: 200, width: 80, height: 30 }),
+                bounds: Some(Bounds {
+                    x: 100,
+                    y: 200,
+                    width: 80,
+                    height: 30,
+                }),
                 state: cel_accessibility::ElementState::default(),
                 parent_id: None,
                 actions: vec![],
@@ -1883,7 +2145,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 200, y: 200, width: 80, height: 30 }),
+                bounds: Some(Bounds {
+                    x: 200,
+                    y: 200,
+                    width: 80,
+                    height: 30,
+                }),
                 state: cel_accessibility::ElementState::default(),
                 parent_id: None,
                 actions: vec![],
@@ -1899,7 +2166,10 @@ mod tests {
         assert_eq!(ctx.elements.len(), 2);
         for e in &ctx.elements {
             assert_eq!(e.source, ContextSource::Vision);
-            assert!(e.confidence < 0.85, "Vision elements should have lower confidence");
+            assert!(
+                e.confidence < 0.85,
+                "Vision elements should have lower confidence"
+            );
             assert!(e.bounds.is_some(), "Vision elements should have bounds");
             assert!(e.label.is_some(), "Vision elements should have labels");
         }
@@ -1910,16 +2180,29 @@ mod tests {
         let stub = Box::new(cel_accessibility::StubAccessibility);
         let merger = ContextMerger::new(stub);
         let mut ctx = ScreenContext {
-            app: "".into(), window: "".into(), network_events: vec![], http_events: vec![], timestamp_ms: 0, screen_width: None, screen_height: None,
-            clipboard: None, window_list: vec![],
-            audio: None, power: None, running_apps: vec![], recent_files: vec![], transcripts: vec![],
+            app: "".into(),
+            window: "".into(),
+            network_events: vec![],
+            http_events: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
             elements: vec![ContextElement {
                 id: "btn1".into(),
                 label: Some("OK".into()),
                 description: None,
                 element_type: "button".into(),
-                value: None, bounds: None,
-                state: cel_accessibility::ElementState::default(), parent_id: None,
+                value: None,
+                bounds: None,
+                state: cel_accessibility::ElementState::default(),
+                parent_id: None,
                 actions: vec![],
                 properties: std::collections::HashMap::new(),
                 confidence: 0.95,
@@ -1934,8 +2217,10 @@ mod tests {
             label: Some("OK (native)".into()),
             description: None,
             element_type: "button".into(),
-            value: None, bounds: None,
-            state: cel_accessibility::ElementState::default(), parent_id: None,
+            value: None,
+            bounds: None,
+            state: cel_accessibility::ElementState::default(),
+            parent_id: None,
             actions: vec![],
             confidence: 0.80,
             source: ContextSource::NativeApi,
@@ -1958,7 +2243,12 @@ mod tests {
             description: None,
             element_type: "button".into(),
             value: None,
-            bounds: Some(Bounds { x: 100, y: 100, width: 120, height: 32 }),
+            bounds: Some(Bounds {
+                x: 100,
+                y: 100,
+                width: 120,
+                height: 32,
+            }),
             state: cel_accessibility::ElementState {
                 visible: true,
                 enabled: true,
@@ -1969,9 +2259,10 @@ mod tests {
             confidence: 0.0,
             source: ContextSource::AccessibilityTree,
             content_role: ContentRole::Interactive,
-            properties: std::collections::HashMap::from([
-                ("css_selector".into(), "#save-primary".into()),
-            ]),
+            properties: std::collections::HashMap::from([(
+                "css_selector".into(),
+                "#save-primary".into(),
+            )]),
         };
         let button_b = ContextElement {
             id: "dom:save-2".into(),
@@ -1979,7 +2270,12 @@ mod tests {
             description: Some("Duplicate wrapper".into()),
             element_type: "button".into(),
             value: None,
-            bounds: Some(Bounds { x: 101, y: 100, width: 120, height: 32 }),
+            bounds: Some(Bounds {
+                x: 101,
+                y: 100,
+                width: 120,
+                height: 32,
+            }),
             state: cel_accessibility::ElementState {
                 visible: true,
                 enabled: true,
@@ -2003,8 +2299,16 @@ mod tests {
             "Test".into(),
         );
 
-        let save_buttons: Vec<_> = ctx.elements.iter().filter(|el| el.label.as_deref() == Some("Save")).collect();
-        assert_eq!(save_buttons.len(), 1, "Expected overlapping duplicate buttons to collapse to one");
+        let save_buttons: Vec<_> = ctx
+            .elements
+            .iter()
+            .filter(|el| el.label.as_deref() == Some("Save"))
+            .collect();
+        assert_eq!(
+            save_buttons.len(),
+            1,
+            "Expected overlapping duplicate buttons to collapse to one"
+        );
     }
 
     #[test]
@@ -2017,7 +2321,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 1200, y: 24, width: 80, height: 28 }),
+                bounds: Some(Bounds {
+                    x: 1200,
+                    y: 24,
+                    width: 80,
+                    height: 28,
+                }),
                 state: cel_accessibility::ElementState {
                     visible: true,
                     enabled: true,
@@ -2028,9 +2337,10 @@ mod tests {
                 confidence: 0.0,
                 source: ContextSource::AccessibilityTree,
                 content_role: ContentRole::Interactive,
-                properties: std::collections::HashMap::from([
-                    ("css_selector".into(), "header .toolbar .more".into()),
-                ]),
+                properties: std::collections::HashMap::from([(
+                    "css_selector".into(),
+                    "header .toolbar .more".into(),
+                )]),
             },
             ContextElement {
                 id: row_id.into(),
@@ -2038,7 +2348,12 @@ mod tests {
                 description: None,
                 element_type: "group".into(),
                 value: None,
-                bounds: Some(Bounds { x: 100, y: 200, width: 900, height: 48 }),
+                bounds: Some(Bounds {
+                    x: 100,
+                    y: 200,
+                    width: 900,
+                    height: 48,
+                }),
                 state: cel_accessibility::ElementState {
                     visible: true,
                     enabled: true,
@@ -2057,7 +2372,12 @@ mod tests {
                 description: None,
                 element_type: "text".into(),
                 value: None,
-                bounds: Some(Bounds { x: 120, y: 210, width: 220, height: 24 }),
+                bounds: Some(Bounds {
+                    x: 120,
+                    y: 210,
+                    width: 220,
+                    height: 24,
+                }),
                 state: cel_accessibility::ElementState {
                     visible: true,
                     enabled: true,
@@ -2076,7 +2396,12 @@ mod tests {
                 description: None,
                 element_type: "text".into(),
                 value: None,
-                bounds: Some(Bounds { x: 360, y: 210, width: 90, height: 24 }),
+                bounds: Some(Bounds {
+                    x: 360,
+                    y: 210,
+                    width: 90,
+                    height: 24,
+                }),
                 state: cel_accessibility::ElementState {
                     visible: true,
                     enabled: true,
@@ -2095,7 +2420,12 @@ mod tests {
                 description: None,
                 element_type: "button".into(),
                 value: None,
-                bounds: Some(Bounds { x: 840, y: 206, width: 120, height: 28 }),
+                bounds: Some(Bounds {
+                    x: 840,
+                    y: 206,
+                    width: 120,
+                    height: 28,
+                }),
                 state: cel_accessibility::ElementState {
                     visible: true,
                     enabled: true,
@@ -2106,9 +2436,10 @@ mod tests {
                 confidence: 0.0,
                 source: ContextSource::AccessibilityTree,
                 content_role: ContentRole::Interactive,
-                properties: std::collections::HashMap::from([
-                    ("css_selector".into(), ".user-row [data-action='remove']".into()),
-                ]),
+                properties: std::collections::HashMap::from([(
+                    "css_selector".into(),
+                    ".user-row [data-action='remove']".into(),
+                )]),
             },
         ];
 
@@ -2142,8 +2473,18 @@ mod tests {
 
         // All a11y elements should have confidence in valid range (0.60 base to ~0.90 max)
         for e in &ctx.elements {
-            assert!(e.confidence >= 0.60, "Confidence {} too low for {}", e.confidence, e.id);
-            assert!(e.confidence <= 0.95, "Confidence {} too high for {}", e.confidence, e.id);
+            assert!(
+                e.confidence >= 0.60,
+                "Confidence {} too low for {}",
+                e.confidence,
+                e.id
+            );
+            assert!(
+                e.confidence <= 0.95,
+                "Confidence {} too high for {}",
+                e.confidence,
+                e.id
+            );
             assert_eq!(e.source, ContextSource::AccessibilityTree);
         }
     }
@@ -2152,22 +2493,48 @@ mod tests {
     fn test_role_to_string_covers_all_roles() {
         // Ensure no role maps to empty string
         let roles = vec![
-            ElementRole::Button, ElementRole::Input, ElementRole::Text,
-            ElementRole::Window, ElementRole::List, ElementRole::ListItem,
-            ElementRole::Menu, ElementRole::MenuItem, ElementRole::Checkbox,
-            ElementRole::ComboBox, ElementRole::Table, ElementRole::TableRow,
-            ElementRole::TableCell, ElementRole::Dialog, ElementRole::Tab,
-            ElementRole::TabItem, ElementRole::RadioButton, ElementRole::Slider,
-            ElementRole::ScrollBar, ElementRole::TreeView, ElementRole::TreeItem,
-            ElementRole::Toolbar, ElementRole::StatusBar, ElementRole::Group,
-            ElementRole::Image, ElementRole::Link,
+            ElementRole::Button,
+            ElementRole::Input,
+            ElementRole::Text,
+            ElementRole::Window,
+            ElementRole::List,
+            ElementRole::ListItem,
+            ElementRole::Menu,
+            ElementRole::MenuItem,
+            ElementRole::Checkbox,
+            ElementRole::ComboBox,
+            ElementRole::Table,
+            ElementRole::TableRow,
+            ElementRole::TableCell,
+            ElementRole::Dialog,
+            ElementRole::Tab,
+            ElementRole::TabItem,
+            ElementRole::RadioButton,
+            ElementRole::Slider,
+            ElementRole::ScrollBar,
+            ElementRole::TreeView,
+            ElementRole::TreeItem,
+            ElementRole::Toolbar,
+            ElementRole::StatusBar,
+            ElementRole::Group,
+            ElementRole::Image,
+            ElementRole::Link,
             ElementRole::Custom("custom_widget".into()),
         ];
 
         for role in &roles {
             let s = role_to_string(role);
-            assert!(!s.is_empty(), "role_to_string({:?}) returned empty string", role);
-            assert!(!s.contains(' '), "role_to_string({:?}) contains spaces: '{}'", role, s);
+            assert!(
+                !s.is_empty(),
+                "role_to_string({:?}) returned empty string",
+                role
+            );
+            assert!(
+                !s.contains(' '),
+                "role_to_string({:?}) contains spaces: '{}'",
+                role,
+                s
+            );
         }
     }
 }

--- a/cel/cel-context/src/merge.rs
+++ b/cel/cel-context/src/merge.rs
@@ -430,18 +430,14 @@ impl ContextMerger {
         let context = self.get_context();
 
         // Try exact ID match first
-        let target = context
-            .elements
-            .iter()
-            .find(|e| e.id == element_id)
-            .or_else(|| {
-                // Fallback: parse the element_id to extract type+label hints.
-                // If the caller provides "button:Submit", match by type and label.
-                // Otherwise, try to find by reference resolution.
-                // For now, just try to find by the element's old type+label combo
-                // using the resolve_reference system.
-                None
-            })?;
+        let target = context.elements.iter().find(|e| e.id == element_id).or({
+            // Fallback: parse the element_id to extract type+label hints.
+            // If the caller provides "button:Submit", match by type and label.
+            // Otherwise, try to find by reference resolution.
+            // For now, just try to find by the element's old type+label combo
+            // using the resolve_reference system.
+            None
+        })?;
 
         // Build ancestor path by following parent_id chain
         let mut ancestor_path = Vec::new();
@@ -557,6 +553,7 @@ impl ContextMerger {
     /// Strategy:
     /// 1. Try the accessibility tree's focused element (most reliable).
     /// 2. Fall back to the display layer's window list (first non-minimized).
+    ///
     /// Detect foreground app/window from the accessibility tree.
     /// Returns (app_name, window_title) if available.
     fn detect_foreground_from_a11y(&self) -> Option<(String, String)> {
@@ -658,6 +655,7 @@ impl ContextMerger {
     /// When a vision element overlaps an existing element (IoU > 0.5):
     /// - Upgrades bounds if vision bounds are more precise (smaller area)
     /// - Boosts confidence by 0.05 for cross-source confirmation
+    ///
     /// When no overlap exists, adds the vision element as a new discovery.
     pub fn merge_vision_elements(&self, base: &mut ScreenContext, vision: Vec<ContextElement>) {
         for elem in vision {
@@ -697,6 +695,7 @@ impl ContextMerger {
     /// - +0.10 if has valid bounds (non-zero area)
     /// - +0.05 if state indicates visible and enabled
     /// - +0.05 if element is an actionable type (button, input, etc.)
+    ///
     /// Maximum: ~0.90 for a fully-qualified element
     fn flatten_a11y_tree(&self, node: &AccessibilityElement, out: &mut Vec<ContextElement>) {
         let element_type = role_to_string(&node.role);
@@ -710,8 +709,8 @@ impl ContextMerger {
 
         // Filter out noise: skip elements that are invisible AND have no useful data.
         // Keep the element if it has children (they might be useful), or if it has a label/value.
-        let has_label = node.label.as_ref().map_or(false, |l| !l.is_empty());
-        let has_value = node.value.as_ref().map_or(false, |v| !v.is_empty());
+        let has_label = node.label.as_ref().is_some_and(|l| !l.is_empty());
+        let has_value = node.value.as_ref().is_some_and(|v| !v.is_empty());
         if !node.state.visible && !has_label && !has_value && node.children.is_empty() {
             return; // Skip invisible leaf elements with no data
         }
@@ -745,7 +744,7 @@ impl ContextMerger {
             actions: node.actions.clone(),
             confidence: 0.0, // Will be scored below
             source: ContextSource::AccessibilityTree,
-            content_role: crate::classify_content_role(&element_type, &node.actions, &node.state),
+            content_role: crate::classify_content_role(element_type, &node.actions, &node.state),
             properties: node.properties.clone(),
         };
         elem.confidence = score_element_confidence(&elem);
@@ -801,8 +800,8 @@ fn role_to_string(role: &ElementRole) -> &str {
 pub fn score_element_confidence(element: &ContextElement) -> f64 {
     let mut confidence: f64 = 0.60;
 
-    let has_label = element.label.as_ref().map_or(false, |l| !l.is_empty());
-    let has_value = element.value.as_ref().map_or(false, |v| !v.is_empty());
+    let has_label = element.label.as_ref().is_some_and(|l| !l.is_empty());
+    let has_value = element.value.as_ref().is_some_and(|v| !v.is_empty());
     if has_label || has_value {
         confidence += 0.10;
     }
@@ -909,8 +908,8 @@ pub fn build_from_external(
         .into_iter()
         .filter(|e| {
             // Filter invisible leaf elements with no data
-            let has_label = e.label.as_ref().map_or(false, |l| !l.is_empty());
-            let has_value = e.value.as_ref().map_or(false, |v| !v.is_empty());
+            let has_label = e.label.as_ref().is_some_and(|l| !l.is_empty());
+            let has_value = e.value.as_ref().is_some_and(|v| !v.is_empty());
             if !e.state.visible && !has_label && !has_value {
                 return false;
             }
@@ -1105,7 +1104,7 @@ fn suppress_obvious_noise(mut elements: Vec<ContextElement>) -> Vec<ContextEleme
     }
     let mut filtered: Vec<ContextElement> = Vec::with_capacity(elements.len());
     let mut filtered_norm: Vec<String> = Vec::with_capacity(elements.len());
-    for (i, (el, n)) in elements.into_iter().zip(normalized.into_iter()).enumerate() {
+    for (i, (el, n)) in elements.into_iter().zip(normalized).enumerate() {
         if keep[i] {
             filtered_norm.push(n);
             filtered.push(el);
@@ -1224,7 +1223,7 @@ fn has_structural_identity_cached(
                     || elements[i]
                         .value
                         .as_ref()
-                        .map_or(false, |v| !normalized_text(Some(v)).is_empty())
+                        .is_some_and(|v| !normalized_text(Some(v)).is_empty())
             })
             .count();
         if sibling_labels >= 2 {

--- a/cel/cel-context/src/resolve.rs
+++ b/cel/cel-context/src/resolve.rs
@@ -26,10 +26,8 @@ pub fn resolve_reference<'a>(
 
     for el in &context.elements {
         let score = score_element(el, reference, context);
-        if score >= MATCH_THRESHOLD {
-            if best.is_none() || score > best.unwrap().1 {
-                best = Some((el, score));
-            }
+        if score >= MATCH_THRESHOLD && (best.is_none() || score > best.unwrap().1) {
+            best = Some((el, score));
         }
     }
 

--- a/cel/cel-context/src/resolve.rs
+++ b/cel/cel-context/src/resolve.rs
@@ -59,7 +59,11 @@ fn build_ancestor_path(el: &ContextElement, all_elements: &[ContextElement]) -> 
     path
 }
 
-fn score_element(el: &ContextElement, reference: &ContextReference, context: &ScreenContext) -> f64 {
+fn score_element(
+    el: &ContextElement,
+    reference: &ContextReference,
+    context: &ScreenContext,
+) -> f64 {
     // Type must match exactly — it's a hard requirement.
     if el.element_type != reference.element_type {
         return 0.0;

--- a/cel/cel-context/src/watchdog.rs
+++ b/cel/cel-context/src/watchdog.rs
@@ -37,8 +37,7 @@ impl ContextWatchdog {
     ///
     /// Returns a list of events that occurred since the last tick.
     pub fn tick(&mut self, context: &ScreenContext, network_idle: bool) -> Vec<CelEvent> {
-        let current_ids: HashSet<String> =
-            context.elements.iter().map(|e| e.id.clone()).collect();
+        let current_ids: HashSet<String> = context.elements.iter().map(|e| e.id.clone()).collect();
 
         let current_focused = context
             .elements
@@ -96,7 +95,10 @@ impl ContextWatchdog {
 
     /// Convert AXObserver push events into CelEvents and append them.
     /// Call this after `tick()` to merge push-based notifications with polling-based detections.
-    pub fn merge_ax_events(&self, ax_events: Vec<cel_accessibility::AccessibilityEvent>) -> Vec<CelEvent> {
+    pub fn merge_ax_events(
+        &self,
+        ax_events: Vec<cel_accessibility::AccessibilityEvent>,
+    ) -> Vec<CelEvent> {
         ax_events
             .into_iter()
             .filter_map(|e| match e {
@@ -106,10 +108,16 @@ impl ContextWatchdog {
                         new: element_id,
                     })
                 }
-                cel_accessibility::AccessibilityEvent::ValueChanged { element_id, new_value } => {
-                    Some(CelEvent::ValueChanged { element_id, new_value })
+                cel_accessibility::AccessibilityEvent::ValueChanged {
+                    element_id,
+                    new_value,
+                } => Some(CelEvent::ValueChanged {
+                    element_id,
+                    new_value,
+                }),
+                cel_accessibility::AccessibilityEvent::LayoutChanged => {
+                    Some(CelEvent::LayoutChanged)
                 }
-                cel_accessibility::AccessibilityEvent::LayoutChanged => Some(CelEvent::LayoutChanged),
                 cel_accessibility::AccessibilityEvent::WindowCreated { title } => {
                     Some(CelEvent::WindowCreated { title })
                 }
@@ -126,13 +134,27 @@ impl ContextWatchdog {
                     Some(CelEvent::AppDeactivated { app_name })
                 }
                 cel_accessibility::AccessibilityEvent::WindowMoved => Some(CelEvent::WindowMoved),
-                cel_accessibility::AccessibilityEvent::WindowResized => Some(CelEvent::WindowResized),
-                cel_accessibility::AccessibilityEvent::WindowMinimized => Some(CelEvent::WindowMinimized),
-                cel_accessibility::AccessibilityEvent::WindowRestored => Some(CelEvent::WindowRestored),
-                cel_accessibility::AccessibilityEvent::SelectionChanged => Some(CelEvent::SelectionChanged),
-                cel_accessibility::AccessibilityEvent::RowCountChanged => Some(CelEvent::RowCountChanged),
-                cel_accessibility::AccessibilityEvent::ElementDestroyed => Some(CelEvent::LayoutChanged),
-                cel_accessibility::AccessibilityEvent::MainWindowChanged => Some(CelEvent::LayoutChanged),
+                cel_accessibility::AccessibilityEvent::WindowResized => {
+                    Some(CelEvent::WindowResized)
+                }
+                cel_accessibility::AccessibilityEvent::WindowMinimized => {
+                    Some(CelEvent::WindowMinimized)
+                }
+                cel_accessibility::AccessibilityEvent::WindowRestored => {
+                    Some(CelEvent::WindowRestored)
+                }
+                cel_accessibility::AccessibilityEvent::SelectionChanged => {
+                    Some(CelEvent::SelectionChanged)
+                }
+                cel_accessibility::AccessibilityEvent::RowCountChanged => {
+                    Some(CelEvent::RowCountChanged)
+                }
+                cel_accessibility::AccessibilityEvent::ElementDestroyed => {
+                    Some(CelEvent::LayoutChanged)
+                }
+                cel_accessibility::AccessibilityEvent::MainWindowChanged => {
+                    Some(CelEvent::LayoutChanged)
+                }
                 cel_accessibility::AccessibilityEvent::AppHidden { app_name } => {
                     Some(CelEvent::AppDeactivated { app_name })
                 }
@@ -271,7 +293,9 @@ mod tests {
 
         let ctx2 = make_context(vec![make_element("a", false), make_element("b", true)]);
         let events = wd.tick(&ctx2, true);
-        assert!(events.iter().any(|e| matches!(e, CelEvent::FocusChanged { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CelEvent::FocusChanged { .. })));
     }
 
     #[test]

--- a/cel/cel-context/src/watchdog.rs
+++ b/cel/cel-context/src/watchdog.rs
@@ -20,6 +20,12 @@ pub struct ContextWatchdog {
     initialized: bool,
 }
 
+impl Default for ContextWatchdog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ContextWatchdog {
     pub fn new() -> Self {
         Self {

--- a/cel/cel-context/tests/integration.rs
+++ b/cel/cel-context/tests/integration.rs
@@ -117,7 +117,7 @@ fn test_screen_context_serialization() {
 #[test]
 fn test_context_source_variants() {
     // Verify all source variants exist and are distinct
-    let sources = vec![
+    let sources = [
         ContextSource::AccessibilityTree,
         ContextSource::NativeApi,
         ContextSource::Vision,

--- a/cel/cel-context/tests/integration.rs
+++ b/cel/cel-context/tests/integration.rs
@@ -3,15 +3,27 @@
 //! Tests the full flow: accessibility → merge → confidence scoring.
 
 use cel_accessibility::{AccessibilityElement, AccessibilityTree, ElementRole};
-use cel_context::{ConfidenceBehavior, ConfidenceThresholds, ContentRole, ContextElement, ContextSource, ElementState, ScreenContext};
+use cel_context::{
+    ConfidenceBehavior, ConfidenceThresholds, ContentRole, ContextElement, ContextSource,
+    ElementState, ScreenContext,
+};
 
 #[test]
 fn test_confidence_thresholds_default() {
     let thresholds = ConfidenceThresholds::default();
-    assert_eq!(thresholds.behavior_for(0.95), ConfidenceBehavior::ActImmediately);
+    assert_eq!(
+        thresholds.behavior_for(0.95),
+        ConfidenceBehavior::ActImmediately
+    );
     assert_eq!(thresholds.behavior_for(0.8), ConfidenceBehavior::ActAndLog);
-    assert_eq!(thresholds.behavior_for(0.6), ConfidenceBehavior::ActCautiously);
-    assert_eq!(thresholds.behavior_for(0.3), ConfidenceBehavior::PauseAndNotify);
+    assert_eq!(
+        thresholds.behavior_for(0.6),
+        ConfidenceBehavior::ActCautiously
+    );
+    assert_eq!(
+        thresholds.behavior_for(0.3),
+        ConfidenceBehavior::PauseAndNotify
+    );
 }
 
 #[test]
@@ -22,7 +34,12 @@ fn test_context_element_serialization() {
         description: None,
         element_type: "button".into(),
         value: None,
-        bounds: Some(cel_context::Bounds { x: 100, y: 200, width: 80, height: 30 }),
+        bounds: Some(cel_context::Bounds {
+            x: 100,
+            y: 200,
+            width: 80,
+            height: 30,
+        }),
         state: cel_context::ElementState::default(),
         parent_id: None,
         actions: vec![],
@@ -126,10 +143,16 @@ fn get_confidence_for(element: AccessibilityElement) -> f64 {
         fn get_tree(&self) -> Result<AccessibilityElement, cel_accessibility::AccessibilityError> {
             Ok(self.0.clone())
         }
-        fn find_elements(&self, _: Option<&ElementRole>, _: Option<&str>) -> Result<Vec<AccessibilityElement>, cel_accessibility::AccessibilityError> {
+        fn find_elements(
+            &self,
+            _: Option<&ElementRole>,
+            _: Option<&str>,
+        ) -> Result<Vec<AccessibilityElement>, cel_accessibility::AccessibilityError> {
             Ok(vec![])
         }
-        fn focused_element(&self) -> Result<Option<AccessibilityElement>, cel_accessibility::AccessibilityError> {
+        fn focused_element(
+            &self,
+        ) -> Result<Option<AccessibilityElement>, cel_accessibility::AccessibilityError> {
             Ok(None)
         }
     }
@@ -181,43 +204,104 @@ fn test_confidence_bare_minimum_element() {
     // Let's use a visible element with no label/bounds to test base.
     let elem2 = make_element(ElementRole::Group, None, None, true, false, vec![]);
     let conf2 = get_confidence_for(elem2);
-    assert!((conf2 - 0.60).abs() < 0.01, "Bare minimum should be 0.60, got {}", conf2);
+    assert!(
+        (conf2 - 0.60).abs() < 0.01,
+        "Bare minimum should be 0.60, got {}",
+        conf2
+    );
 }
 
 #[test]
 fn test_confidence_with_label() {
     let elem = make_element(ElementRole::Group, Some("Hello"), None, true, false, vec![]);
     let conf = get_confidence_for(elem);
-    assert!((conf - 0.70).abs() < 0.01, "With label should be 0.70, got {}", conf);
+    assert!(
+        (conf - 0.70).abs() < 0.01,
+        "With label should be 0.70, got {}",
+        conf
+    );
 }
 
 #[test]
 fn test_confidence_with_label_and_bounds() {
-    let bounds = cel_accessibility::Bounds { x: 0, y: 0, width: 100, height: 50 };
-    let elem = make_element(ElementRole::Group, Some("Hello"), Some(bounds), true, false, vec![]);
+    let bounds = cel_accessibility::Bounds {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+    };
+    let elem = make_element(
+        ElementRole::Group,
+        Some("Hello"),
+        Some(bounds),
+        true,
+        false,
+        vec![],
+    );
     let conf = get_confidence_for(elem);
-    assert!((conf - 0.80).abs() < 0.01, "With label+bounds should be 0.80, got {}", conf);
+    assert!(
+        (conf - 0.80).abs() < 0.01,
+        "With label+bounds should be 0.80, got {}",
+        conf
+    );
 }
 
 #[test]
 fn test_confidence_with_label_bounds_visible_enabled() {
-    let bounds = cel_accessibility::Bounds { x: 0, y: 0, width: 100, height: 50 };
-    let elem = make_element(ElementRole::Group, Some("Hello"), Some(bounds), true, true, vec![]);
+    let bounds = cel_accessibility::Bounds {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+    };
+    let elem = make_element(
+        ElementRole::Group,
+        Some("Hello"),
+        Some(bounds),
+        true,
+        true,
+        vec![],
+    );
     let conf = get_confidence_for(elem);
-    assert!((conf - 0.85).abs() < 0.01, "With label+bounds+state should be 0.85, got {}", conf);
+    assert!(
+        (conf - 0.85).abs() < 0.01,
+        "With label+bounds+state should be 0.85, got {}",
+        conf
+    );
 }
 
 #[test]
 fn test_confidence_actionable_type() {
-    let bounds = cel_accessibility::Bounds { x: 0, y: 0, width: 100, height: 50 };
-    let elem = make_element(ElementRole::Button, Some("Create Account"), Some(bounds), true, true, vec![]);
+    let bounds = cel_accessibility::Bounds {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+    };
+    let elem = make_element(
+        ElementRole::Button,
+        Some("Create Account"),
+        Some(bounds),
+        true,
+        true,
+        vec![],
+    );
     let conf = get_confidence_for(elem);
-    assert!((conf - 0.90).abs() < 0.01, "Actionable should be 0.90, got {}", conf);
+    assert!(
+        (conf - 0.90).abs() < 0.01,
+        "Actionable should be 0.90, got {}",
+        conf
+    );
 }
 
 #[test]
 fn test_confidence_with_actions() {
-    let bounds = cel_accessibility::Bounds { x: 0, y: 0, width: 100, height: 50 };
+    let bounds = cel_accessibility::Bounds {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+    };
     let elem = make_element(
         ElementRole::Button,
         Some("Create Account"),
@@ -229,7 +313,11 @@ fn test_confidence_with_actions() {
     let conf = get_confidence_for(elem);
     // 0.60 + 0.10 (label) + 0.10 (bounds) + 0.05 (visible+enabled) + 0.05 (actionable) + 0.05 (actions)
     // = 0.95 raw, capped at 0.95 by score_element_confidence()
-    assert!((conf - 0.95).abs() < 0.01, "Fully loaded should be ~0.95 (capped), got {}", conf);
+    assert!(
+        (conf - 0.95).abs() < 0.01,
+        "Fully loaded should be ~0.95 (capped), got {}",
+        conf
+    );
 }
 
 // --- Phase 6.2: State bit parsing tests ---
@@ -269,41 +357,63 @@ fn test_state_bit_selected() {
 fn test_state_bit_expandable_and_expanded() {
     // Bit 9 = EXPANDABLE, Bit 10 = EXPANDED
     let state = parse_state_bits((1 << 9) | (1 << 10));
-    assert_eq!(state.expanded, Some(true), "Bits 9+10 should map to expanded=Some(true)");
+    assert_eq!(
+        state.expanded,
+        Some(true),
+        "Bits 9+10 should map to expanded=Some(true)"
+    );
 }
 
 #[test]
 fn test_state_bit_expandable_but_collapsed() {
     // Bit 9 = EXPANDABLE only (no bit 10)
     let state = parse_state_bits(1 << 9);
-    assert_eq!(state.expanded, Some(false), "Bit 9 only should map to expanded=Some(false)");
+    assert_eq!(
+        state.expanded,
+        Some(false),
+        "Bit 9 only should map to expanded=Some(false)"
+    );
 }
 
 #[test]
 fn test_state_bit_not_expandable() {
     // Neither bit 9 nor bit 10
     let state = parse_state_bits(0);
-    assert_eq!(state.expanded, None, "No expandable bit should map to expanded=None");
+    assert_eq!(
+        state.expanded, None,
+        "No expandable bit should map to expanded=None"
+    );
 }
 
 #[test]
 fn test_state_bit_checkable_and_checked() {
     // Bit 41 = CHECKABLE (in second u32, bit 9), Bit 4 = CHECKED
     let state = parse_state_bits((1u64 << 41) | (1 << 4));
-    assert_eq!(state.checked, Some(true), "Bits 41+4 should map to checked=Some(true)");
+    assert_eq!(
+        state.checked,
+        Some(true),
+        "Bits 41+4 should map to checked=Some(true)"
+    );
 }
 
 #[test]
 fn test_state_bit_checkable_but_unchecked() {
     // Bit 41 only
     let state = parse_state_bits(1u64 << 41);
-    assert_eq!(state.checked, Some(false), "Bit 41 only should map to checked=Some(false)");
+    assert_eq!(
+        state.checked,
+        Some(false),
+        "Bit 41 only should map to checked=Some(false)"
+    );
 }
 
 #[test]
 fn test_state_bit_not_checkable() {
     let state = parse_state_bits(0);
-    assert_eq!(state.checked, None, "No checkable bit should map to checked=None");
+    assert_eq!(
+        state.checked, None,
+        "No checkable bit should map to checked=None"
+    );
 }
 
 #[test]
@@ -334,9 +444,9 @@ fn test_state_bits_combined() {
 /// This mirrors the logic in linux.rs get_state() for testability.
 fn parse_state_bits(bits: u64) -> ElementState {
     ElementState {
-        focused:  bits & (1 << 12) != 0,
-        enabled:  bits & (1 << 8) != 0,
-        visible:  bits & (1 << 30) != 0,
+        focused: bits & (1 << 12) != 0,
+        enabled: bits & (1 << 8) != 0,
+        visible: bits & (1 << 30) != 0,
         selected: bits & (1 << 23) != 0,
         expanded: if bits & (1 << 9) != 0 {
             Some(bits & (1 << 10) != 0)

--- a/cel/cel-context/tests/live_e2e.rs
+++ b/cel/cel-context/tests/live_e2e.rs
@@ -53,7 +53,11 @@ fn live_desktop_produces_valid_context() {
 
         // If bounds exist, they should be non-negative dimensions
         if let Some(ref b) = elem.bounds {
-            assert!(b.width > 0 || b.height > 0, "Element {} has zero-area bounds", elem.id);
+            assert!(
+                b.width > 0 || b.height > 0,
+                "Element {} has zero-area bounds",
+                elem.id
+            );
         }
     }
 

--- a/cel/cel-context/tests/vision_fallback.rs
+++ b/cel/cel-context/tests/vision_fallback.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use cel_accessibility::{
-    AccessibilityElement, AccessibilityError, AccessibilityTree, Bounds as A11yBounds,
-    ElementRole, ElementState,
+    AccessibilityElement, AccessibilityError, AccessibilityTree, Bounds as A11yBounds, ElementRole,
+    ElementState,
 };
 use cel_context::{ContextMerger, ContextSource};
 use cel_display::{CaptureError, Frame, MonitorInfo, ScreenCapture, WindowInfo};
@@ -43,7 +43,12 @@ impl AccessibilityTree for SparseAccessibility {
             label: Some("Legacy App".into()),
             description: None,
             value: None,
-            bounds: Some(A11yBounds { x: 0, y: 0, width: 800, height: 600 }),
+            bounds: Some(A11yBounds {
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 600,
+            }),
             state: default_state(),
             parent_id: None,
             actions: vec![],
@@ -54,7 +59,12 @@ impl AccessibilityTree for SparseAccessibility {
                 label: Some("Title".into()),
                 description: None,
                 value: None,
-                bounds: Some(A11yBounds { x: 10, y: 10, width: 200, height: 30 }),
+                bounds: Some(A11yBounds {
+                    x: 10,
+                    y: 10,
+                    width: 200,
+                    height: 30,
+                }),
                 state: default_state(),
                 parent_id: Some("root".into()),
                 actions: vec![],
@@ -103,7 +113,12 @@ impl AccessibilityTree for RichAccessibility {
             label: Some("Rich App".into()),
             description: None,
             value: None,
-            bounds: Some(A11yBounds { x: 0, y: 0, width: 1920, height: 1080 }),
+            bounds: Some(A11yBounds {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+            }),
             state: default_state(),
             parent_id: None,
             actions: vec![],
@@ -115,7 +130,12 @@ impl AccessibilityTree for RichAccessibility {
                     label: Some("OK".into()),
                     description: None,
                     value: None,
-                    bounds: Some(A11yBounds { x: 100, y: 100, width: 80, height: 30 }),
+                    bounds: Some(A11yBounds {
+                        x: 100,
+                        y: 100,
+                        width: 80,
+                        height: 30,
+                    }),
                     state: default_state(),
                     parent_id: Some("root".into()),
                     actions: vec![],
@@ -129,7 +149,12 @@ impl AccessibilityTree for RichAccessibility {
                     label: Some("Name".into()),
                     description: None,
                     value: Some("John".into()),
-                    bounds: Some(A11yBounds { x: 100, y: 150, width: 200, height: 30 }),
+                    bounds: Some(A11yBounds {
+                        x: 100,
+                        y: 150,
+                        width: 200,
+                        height: 30,
+                    }),
                     state: default_state(),
                     parent_id: Some("root".into()),
                     actions: vec![],
@@ -143,7 +168,12 @@ impl AccessibilityTree for RichAccessibility {
                     label: Some("Help".into()),
                     description: None,
                     value: None,
-                    bounds: Some(A11yBounds { x: 100, y: 200, width: 60, height: 20 }),
+                    bounds: Some(A11yBounds {
+                        x: 100,
+                        y: 200,
+                        width: 60,
+                        height: 20,
+                    }),
                     state: default_state(),
                     parent_id: Some("root".into()),
                     actions: vec![],
@@ -157,7 +187,12 @@ impl AccessibilityTree for RichAccessibility {
                     label: Some("Remember me".into()),
                     description: None,
                     value: None,
-                    bounds: Some(A11yBounds { x: 100, y: 250, width: 120, height: 20 }),
+                    bounds: Some(A11yBounds {
+                        x: 100,
+                        y: 250,
+                        width: 120,
+                        height: 20,
+                    }),
                     state: default_state(),
                     parent_id: Some("root".into()),
                     actions: vec![],
@@ -171,7 +206,12 @@ impl AccessibilityTree for RichAccessibility {
                     label: Some("Cancel".into()),
                     description: None,
                     value: None,
-                    bounds: Some(A11yBounds { x: 200, y: 100, width: 80, height: 30 }),
+                    bounds: Some(A11yBounds {
+                        x: 200,
+                        y: 100,
+                        width: 80,
+                        height: 30,
+                    }),
                     state: default_state(),
                     parent_id: Some("root".into()),
                     actions: vec![],
@@ -242,7 +282,12 @@ impl HugeAccessibility {
             label: Some(format!("Node {}", prefix)),
             description: None,
             value: None,
-            bounds: Some(A11yBounds { x: 0, y: 0, width: 100, height: 30 }),
+            bounds: Some(A11yBounds {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 30,
+            }),
             state: default_state(),
             parent_id: None,
             actions: vec![],
@@ -468,19 +513,34 @@ fn make_vision_elements() -> Vec<VisionElement> {
         VisionElement {
             label: "Submit".into(),
             element_type: "button".into(),
-            bounds: Some(VisionBounds { x: 300, y: 400, width: 100, height: 35 }),
+            bounds: Some(VisionBounds {
+                x: 300,
+                y: 400,
+                width: 100,
+                height: 35,
+            }),
             confidence: 0.82,
         },
         VisionElement {
             label: "Cancel".into(),
             element_type: "button".into(),
-            bounds: Some(VisionBounds { x: 420, y: 400, width: 100, height: 35 }),
+            bounds: Some(VisionBounds {
+                x: 420,
+                y: 400,
+                width: 100,
+                height: 35,
+            }),
             confidence: 0.78,
         },
         VisionElement {
             label: "Email".into(),
             element_type: "input".into(),
-            bounds: Some(VisionBounds { x: 200, y: 300, width: 300, height: 30 }),
+            bounds: Some(VisionBounds {
+                x: 200,
+                y: 300,
+                width: 300,
+                height: 30,
+            }),
             confidence: 0.75,
         },
     ]
@@ -497,12 +557,10 @@ fn test_vision_fallback_triggers_on_sparse_a11y() {
     let vision = MockVision::new(make_vision_elements());
     let call_count = vision.call_count();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(vision))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(vision))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
@@ -522,7 +580,9 @@ fn test_vision_fallback_triggers_on_sparse_a11y() {
     );
 
     // Vision elements should have correct IDs and types
-    let submit = vision_elements.iter().find(|e| e.label.as_deref() == Some("Submit"));
+    let submit = vision_elements
+        .iter()
+        .find(|e| e.label.as_deref() == Some("Submit"));
     assert!(submit.is_some(), "Should find Submit button from vision");
     assert_eq!(submit.unwrap().element_type, "button");
     assert_eq!(submit.unwrap().source, ContextSource::Vision);
@@ -535,12 +595,10 @@ fn test_vision_fallback_does_not_trigger_on_rich_a11y() {
     let vision = MockVision::new(make_vision_elements());
     let call_count = vision.call_count();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(RichAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(vision))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(RichAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(vision))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
@@ -548,56 +606,62 @@ fn test_vision_fallback_does_not_trigger_on_rich_a11y() {
     assert_eq!(call_count.load(Ordering::SeqCst), 0);
 
     // All elements should be from accessibility
-    assert!(ctx.elements.iter().all(|e| e.source == ContextSource::AccessibilityTree));
+    assert!(ctx
+        .elements
+        .iter()
+        .all(|e| e.source == ContextSource::AccessibilityTree));
 }
 
 #[test]
 fn test_vision_fallback_graceful_on_capture_failure() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(FailingCapture),
-    )
-    .with_vision(Box::new(MockVision::new(make_vision_elements())))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(FailingCapture))
+            .with_vision(Box::new(MockVision::new(make_vision_elements())))
+            .with_runtime(rt.handle().clone());
 
     // Should not panic — gracefully falls back to a11y-only
     let ctx = merger.get_context();
     assert!(!ctx.elements.is_empty());
-    assert!(ctx.elements.iter().all(|e| e.source == ContextSource::AccessibilityTree));
+    assert!(ctx
+        .elements
+        .iter()
+        .all(|e| e.source == ContextSource::AccessibilityTree));
 }
 
 #[test]
 fn test_vision_fallback_graceful_on_vision_api_failure() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(FailingVision))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(FailingVision))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
     // Should still have a11y elements, no vision elements
     assert!(!ctx.elements.is_empty());
-    assert!(ctx.elements.iter().all(|e| e.source == ContextSource::AccessibilityTree));
+    assert!(ctx
+        .elements
+        .iter()
+        .all(|e| e.source == ContextSource::AccessibilityTree));
 }
 
 #[test]
 fn test_vision_fallback_empty_results_produces_no_vision_elements() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(EmptyVision))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(EmptyVision))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
-    assert!(ctx.elements.iter().all(|e| e.source == ContextSource::AccessibilityTree));
+    assert!(ctx
+        .elements
+        .iter()
+        .all(|e| e.source == ContextSource::AccessibilityTree));
 }
 
 #[test]
@@ -605,11 +669,9 @@ fn test_vision_fallback_without_runtime_does_nothing() {
     // Outside a tokio context, Handle::try_current() returns None,
     // so the vision fallback path has no runtime and should be skipped.
     // with_display() calls try_current() in the constructor.
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(make_vision_elements())));
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(make_vision_elements())));
     // No with_runtime() call — runtime is whatever try_current() got (None outside tokio).
 
     // Should not panic — gracefully falls back to a11y-only
@@ -625,28 +687,41 @@ fn test_vision_supplements_overlapping_a11y_element() {
     let overlapping_vision = vec![VisionElement {
         label: "Title (vision)".into(),
         element_type: "text".into(),
-        bounds: Some(VisionBounds { x: 10, y: 10, width: 200, height: 30 }), // Same as a11y title
+        bounds: Some(VisionBounds {
+            x: 10,
+            y: 10,
+            width: 200,
+            height: 30,
+        }), // Same as a11y title
         confidence: 0.7,
     }];
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(overlapping_vision)))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(overlapping_vision)))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
     // Overlapping vision element should NOT appear as a separate element
-    let vision_count = ctx.elements.iter().filter(|e| e.source == ContextSource::Vision).count();
-    assert_eq!(vision_count, 0, "Overlapping vision element should be merged into a11y, not added separately");
+    let vision_count = ctx
+        .elements
+        .iter()
+        .filter(|e| e.source == ContextSource::Vision)
+        .count();
+    assert_eq!(
+        vision_count, 0,
+        "Overlapping vision element should be merged into a11y, not added separately"
+    );
 
     // The a11y element should have gotten a confidence boost from cross-source confirmation
     let title = ctx.elements.iter().find(|e| e.id == "title").unwrap();
     assert_eq!(title.source, ContextSource::AccessibilityTree);
     // Should be boosted: original confidence + 0.05
-    assert!(title.confidence > 0.70, "Title confidence should be boosted by cross-source confirmation");
+    assert!(
+        title.confidence > 0.70,
+        "Title confidence should be boosted by cross-source confirmation"
+    );
 }
 
 #[test]
@@ -658,16 +733,19 @@ fn test_vision_upgrades_bounds_when_more_precise() {
     let precise_vision = vec![VisionElement {
         label: "Title (precise)".into(),
         element_type: "text".into(),
-        bounds: Some(VisionBounds { x: 15, y: 12, width: 180, height: 26 }),
+        bounds: Some(VisionBounds {
+            x: 15,
+            y: 12,
+            width: 180,
+            height: 26,
+        }),
         confidence: 0.7,
     }];
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(precise_vision)))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(precise_vision)))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
@@ -688,22 +766,33 @@ fn test_vision_adds_non_overlapping_elements() {
     let new_vision = vec![VisionElement {
         label: "Hidden Button".into(),
         element_type: "button".into(),
-        bounds: Some(VisionBounds { x: 500, y: 500, width: 100, height: 35 }),
+        bounds: Some(VisionBounds {
+            x: 500,
+            y: 500,
+            width: 100,
+            height: 35,
+        }),
         confidence: 0.8,
     }];
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(new_vision)))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(new_vision)))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
     // Non-overlapping vision element should be added
-    let vision_elems: Vec<_> = ctx.elements.iter().filter(|e| e.source == ContextSource::Vision).collect();
-    assert_eq!(vision_elems.len(), 1, "Non-overlapping vision element should be added");
+    let vision_elems: Vec<_> = ctx
+        .elements
+        .iter()
+        .filter(|e| e.source == ContextSource::Vision)
+        .collect();
+    assert_eq!(
+        vision_elems.len(),
+        1,
+        "Non-overlapping vision element should be added"
+    );
     assert_eq!(vision_elems[0].label.as_deref(), Some("Hidden Button"));
 }
 
@@ -737,10 +826,8 @@ fn test_foreground_falls_back_to_display_window_list() {
 
 #[test]
 fn test_foreground_empty_when_all_fail() {
-    let mut merger = ContextMerger::with_display(
-        Box::new(FailingAccessibility),
-        Box::new(FailingCapture),
-    );
+    let mut merger =
+        ContextMerger::with_display(Box::new(FailingAccessibility), Box::new(FailingCapture));
     let ctx = merger.get_context();
 
     assert_eq!(ctx.app, "");
@@ -764,7 +851,10 @@ fn test_huge_tree_flattening_performance() {
     let ctx = merger.get_context();
     let elapsed = start.elapsed();
 
-    assert!(ctx.elements.len() > 1000, "Should have thousands of elements");
+    assert!(
+        ctx.elements.len() > 1000,
+        "Should have thousands of elements"
+    );
     let budget_ms = if cfg!(debug_assertions) { 5000 } else { 1000 };
     assert!(
         elapsed.as_millis() < budget_ms,
@@ -772,7 +862,11 @@ fn test_huge_tree_flattening_performance() {
         ctx.elements.len(),
         elapsed.as_millis(),
         budget_ms,
-        if cfg!(debug_assertions) { "debug" } else { "release" }
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        }
     );
 
     // All elements should have valid data
@@ -842,9 +936,7 @@ fn test_deep_tree_does_not_stack_overflow() {
         ) -> Result<Vec<AccessibilityElement>, AccessibilityError> {
             Ok(vec![])
         }
-        fn focused_element(
-            &self,
-        ) -> Result<Option<AccessibilityElement>, AccessibilityError> {
+        fn focused_element(&self) -> Result<Option<AccessibilityElement>, AccessibilityError> {
             Ok(None)
         }
     }
@@ -854,7 +946,10 @@ fn test_deep_tree_does_not_stack_overflow() {
 
     // Should have processed the deep tree without stack overflow.
     // Noise filter may remove unlabeled leaf groups, but the leaf button must survive.
-    assert!(ctx.elements.len() >= 1, "Deep tree should produce at least the leaf element");
+    assert!(
+        ctx.elements.len() >= 1,
+        "Deep tree should produce at least the leaf element"
+    );
 
     // The leaf button should be present
     let leaf = ctx.elements.iter().find(|e| e.element_type == "button");
@@ -896,9 +991,7 @@ fn test_empty_tree_produces_valid_context() {
         ) -> Result<Vec<AccessibilityElement>, AccessibilityError> {
             Ok(vec![])
         }
-        fn focused_element(
-            &self,
-        ) -> Result<Option<AccessibilityElement>, AccessibilityError> {
+        fn focused_element(&self) -> Result<Option<AccessibilityElement>, AccessibilityError> {
             Ok(None)
         }
     }
@@ -921,17 +1014,19 @@ fn test_garbage_vision_output_deduplicated() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     // Vision returns 100 overlapping elements at (0,0 100x30)
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(GarbageVision))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(GarbageVision))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
     // Most garbage elements should be deduplicated (they all overlap each other)
-    let vision_count = ctx.elements.iter().filter(|e| e.source == ContextSource::Vision).count();
+    let vision_count = ctx
+        .elements
+        .iter()
+        .filter(|e| e.source == ContextSource::Vision)
+        .count();
 
     // Only the first non-dominated element should survive; subsequent ones overlap with it
     // The exact count depends on whether the first vision element overlaps with a11y elements,
@@ -947,17 +1042,19 @@ fn test_garbage_vision_output_deduplicated() {
 fn test_a11y_failure_still_produces_context_with_vision_fallback() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(FailingAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(make_vision_elements())))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(FailingAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(make_vision_elements())))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 
     // A11y failed, but vision should have kicked in
-    let vision_count = ctx.elements.iter().filter(|e| e.source == ContextSource::Vision).count();
+    let vision_count = ctx
+        .elements
+        .iter()
+        .filter(|e| e.source == ContextSource::Vision)
+        .count();
     assert!(
         vision_count >= 2,
         "Vision should provide elements when a11y fails entirely, got {}",
@@ -1006,12 +1103,10 @@ fn test_multiple_get_context_calls_stable() {
 fn test_elements_always_sorted_by_confidence_desc() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let mut merger = ContextMerger::with_display(
-        Box::new(SparseAccessibility),
-        Box::new(MockCapture::new()),
-    )
-    .with_vision(Box::new(MockVision::new(make_vision_elements())))
-    .with_runtime(rt.handle().clone());
+    let mut merger =
+        ContextMerger::with_display(Box::new(SparseAccessibility), Box::new(MockCapture::new()))
+            .with_vision(Box::new(MockVision::new(make_vision_elements())))
+            .with_runtime(rt.handle().clone());
 
     let ctx = merger.get_context();
 

--- a/cel/cel-context/tests/vision_fallback.rs
+++ b/cel/cel-context/tests/vision_fallback.rs
@@ -947,7 +947,7 @@ fn test_deep_tree_does_not_stack_overflow() {
     // Should have processed the deep tree without stack overflow.
     // Noise filter may remove unlabeled leaf groups, but the leaf button must survive.
     assert!(
-        ctx.elements.len() >= 1,
+        !ctx.elements.is_empty(),
         "Deep tree should produce at least the leaf element"
     );
 

--- a/cel/cel-cortex/src/anomaly.rs
+++ b/cel/cel-cortex/src/anomaly.rs
@@ -25,21 +25,19 @@ pub fn detect_anomalies_from_events(events: &[CelEvent], expected_app: &str) -> 
                     element_ids: vec![],
                 });
             }
-            CelEvent::AppActivated { app_name } => {
-                if let Some(name) = app_name {
-                    if name != expected_app {
-                        anomalies.push(Anomaly {
-                            anomaly_type: AnomalyType::AppSwitch,
-                            title: Some(name.clone()),
-                            description: format!(
-                                "App switched to \"{}\" (expected \"{}\")",
-                                name, expected_app
-                            ),
-                            timestamp: now,
-                            element_ids: vec![],
-                        });
-                    }
-                }
+            CelEvent::AppActivated {
+                app_name: Some(name),
+            } if name != expected_app => {
+                anomalies.push(Anomaly {
+                    anomaly_type: AnomalyType::AppSwitch,
+                    title: Some(name.clone()),
+                    description: format!(
+                        "App switched to \"{}\" (expected \"{}\")",
+                        name, expected_app
+                    ),
+                    timestamp: now,
+                    element_ids: vec![],
+                });
             }
             _ => {}
         }

--- a/cel/cel-cortex/src/cortex.rs
+++ b/cel/cel-cortex/src/cortex.rs
@@ -17,9 +17,13 @@ use crate::differ::{diff_contexts, is_diff_significant, ContextDiff};
 use crate::model::*;
 use crate::skeleton::{is_skeleton_screen, skeleton_wait_ms};
 
-use cel_accessibility::{AccessibilityTree, ElementRole};
+use cel_accessibility::AccessibilityTree;
+#[cfg(target_os = "macos")]
+use cel_accessibility::ElementRole;
 use cel_context::{CelEvent, ContextMerger, ContextWatchdog, ScreenContext};
-use cel_input::{create_controller, InputError, MouseButton};
+#[cfg(target_os = "macos")]
+use cel_input::InputError;
+use cel_input::{create_controller, MouseButton};
 use cel_planner::PlannedAction;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -865,7 +869,7 @@ impl Cortex {
                     while m
                         .anomaly_queue
                         .front()
-                        .map_or(false, |a| a.timestamp < ttl_cutoff)
+                        .is_some_and(|a| a.timestamp < ttl_cutoff)
                     {
                         m.anomaly_queue.pop_front();
                     }
@@ -1117,9 +1121,7 @@ impl Cortex {
     /// legitimate browser-chrome AX ids don't come up in web-content
     /// goals in practice.
     fn refuse_ax_on_browser_page(&self, target_id: &str, action: &str) -> Option<String> {
-        if self.cdp_client.is_none() {
-            return None;
-        }
+        self.cdp_client.as_ref()?;
         if !target_id.starts_with("ax:") {
             return None;
         }
@@ -1514,7 +1516,7 @@ impl Cortex {
                         && el
                             .label
                             .as_ref()
-                            .map_or(false, |l| lower.contains(&l.to_lowercase()))
+                            .is_some_and(|l| lower.contains(&l.to_lowercase()))
                 }) {
                     let click = PlannedAction::Click {
                         target_id: el.id.clone(),
@@ -2128,7 +2130,7 @@ fn parse_extracted(raw: &str, parse_as: &str) -> Option<serde_json::Value> {
                 .ok()
                 .map(|n| serde_json::Value::Number(n.into()))
         }
-        "html" | "text" | _ => Some(serde_json::Value::String(cleaned.to_string())),
+        _ => Some(serde_json::Value::String(cleaned.to_string())),
     }
 }
 
@@ -2145,6 +2147,7 @@ fn truncate(s: &str, max: usize) -> String {
 /// `"108432.5"`, `"$108,432.50"` becomes `"108432.5"`. Compare as
 /// floats when both sides parse; otherwise fall back to trimmed
 /// string equality.
+#[cfg(target_os = "macos")]
 fn cells_match(requested: &str, got: &str) -> bool {
     let r = requested.trim();
     let g = got.trim();
@@ -2240,9 +2243,7 @@ fn parse_role_hint(hint: &str) -> Option<cel_accessibility::ElementRole> {
         .trim()
         .to_ascii_lowercase()
         .trim_start_matches("ax")
-        .replace('_', "")
-        .replace('-', "")
-        .replace(' ', "");
+        .replace(['_', '-', ' '], "");
     Some(match normalized.as_str() {
         "button" => ElementRole::Button,
         "input" | "textfield" | "text" => ElementRole::Input,
@@ -2277,7 +2278,7 @@ fn try_set_value(target_id: &str, value: &str) -> Result<bool, CortexError> {
 /// Try to dispatch the action through CDP. Returns:
 ///  * `Ok(Some(result))` — we handled it (succeeded or failed via CDP)
 ///  * `Ok(None)` — not a browser-targeted action; caller should fall back
-///                 to the native execution path
+///    to the native execution path
 ///
 /// Targets a `dom:*` element by parsing the embedded backend_node_id (the
 /// element id format is `dom:<element_type>:<id>` per the CDP context pump

--- a/cel/cel-cortex/src/lib.rs
+++ b/cel/cel-cortex/src/lib.rs
@@ -53,8 +53,8 @@ pub use cortex::{Cortex, CortexError, TargetValidation};
 pub use manager::CortexManager;
 pub use memory::{Memory, MemoryEntry, MemoryError, MemoryLenses};
 pub use model::{
-    Anomaly, AnomalyType, DiffSummary, ElementStability, ErrorState,
-    FocusedElement, FreshnessAssessment, FreshnessState, LoadingState, MentalModel, PerceptionDiff,
+    Anomaly, AnomalyType, DiffSummary, ElementStability, ErrorState, FocusedElement,
+    FreshnessAssessment, FreshnessState, LoadingState, MentalModel, PerceptionDiff,
     SemanticInsight, SourceSummary, StalenessCause, TaskPhase, TemporalFlags,
 };
 pub use process_driver::ProcessDriver;

--- a/cel/cel-cortex/src/memory.rs
+++ b/cel/cel-cortex/src/memory.rs
@@ -231,7 +231,7 @@ impl Memory {
     /// renderer deduplicates by line-id if it wants to.
     pub fn lens(&self, goal_type: &str, per_lens: usize) -> Result<MemoryLenses, MemoryError> {
         let mut all = self.all()?;
-        all.sort_by(|a, b| b.ts_ms.cmp(&a.ts_ms));
+        all.sort_by_key(|a| std::cmp::Reverse(a.ts_ms));
 
         let same_cortex: Vec<_> = all
             .iter()

--- a/cel/cel-cortex/src/model.rs
+++ b/cel/cel-cortex/src/model.rs
@@ -514,9 +514,11 @@ impl MentalModel {
             TaskPhase::Input
         } else if self.temporal.idle_since.is_some() {
             TaskPhase::Idle
-        } else if self.last_diff_summary.as_ref().map_or(false, |diff| {
-            diff.added_count + diff.removed_count + diff.changed_count > 0
-        }) {
+        } else if self
+            .last_diff_summary
+            .as_ref()
+            .is_some_and(|diff| diff.added_count + diff.removed_count + diff.changed_count > 0)
+        {
             TaskPhase::Navigation
         } else {
             TaskPhase::Review

--- a/cel/cel-cortex/src/skeleton.rs
+++ b/cel/cel-cortex/src/skeleton.rs
@@ -76,10 +76,8 @@ pub fn is_skeleton_screen(context: &ScreenContext) -> bool {
 
     // Check for explicit loading indicators (aria-busy)
     let has_aria_busy = elements.iter().any(|el| {
-        el.properties
-            .get("aria-busy")
-            .map_or(false, |v| v == "true")
-            || el.properties.get("busy").map_or(false, |v| v == "true")
+        el.properties.get("aria-busy").is_some_and(|v| v == "true")
+            || el.properties.get("busy").is_some_and(|v| v == "true")
     });
     if has_aria_busy {
         return true;
@@ -89,8 +87,8 @@ pub fn is_skeleton_screen(context: &ScreenContext) -> bool {
     let text_bearing_count = elements
         .iter()
         .filter(|el| {
-            el.label.as_ref().map_or(false, |l| !l.trim().is_empty())
-                || el.value.as_ref().map_or(false, |v| !v.trim().is_empty())
+            el.label.as_ref().is_some_and(|l| !l.trim().is_empty())
+                || el.value.as_ref().is_some_and(|v| !v.trim().is_empty())
         })
         .count();
     let text_ratio = text_bearing_count as f64 / elements.len() as f64;
@@ -108,7 +106,7 @@ pub fn is_skeleton_screen(context: &ScreenContext) -> bool {
 
     // Check for aria-live regions with loading text
     let has_aria_live_loading = elements.iter().any(|el| {
-        if el.properties.get("aria-live").is_none() {
+        if !el.properties.contains_key("aria-live") {
             return false;
         }
         let text = format!(
@@ -134,10 +132,8 @@ pub fn skeleton_wait_ms(context: &ScreenContext) -> u64 {
     }
 
     let has_aria_busy = elements.iter().any(|el| {
-        el.properties
-            .get("aria-busy")
-            .map_or(false, |v| v == "true")
-            || el.properties.get("busy").map_or(false, |v| v == "true")
+        el.properties.get("aria-busy").is_some_and(|v| v == "true")
+            || el.properties.get("busy").is_some_and(|v| v == "true")
     });
     if has_aria_busy {
         return EXTENDED_SKELETON_WAIT_MS;
@@ -146,8 +142,8 @@ pub fn skeleton_wait_ms(context: &ScreenContext) -> u64 {
     let text_bearing_count = elements
         .iter()
         .filter(|el| {
-            el.label.as_ref().map_or(false, |l| !l.trim().is_empty())
-                || el.value.as_ref().map_or(false, |v| !v.trim().is_empty())
+            el.label.as_ref().is_some_and(|l| !l.trim().is_empty())
+                || el.value.as_ref().is_some_and(|v| !v.trim().is_empty())
         })
         .count();
     let text_ratio = text_bearing_count as f64 / elements.len() as f64;
@@ -163,7 +159,7 @@ pub fn skeleton_wait_ms(context: &ScreenContext) -> u64 {
     }
 
     let has_aria_live_loading = elements.iter().any(|el| {
-        if el.properties.get("aria-live").is_none() {
+        if !el.properties.contains_key("aria-live") {
             return false;
         }
         let text = format!(

--- a/cel/cel-cortex/tests/cortex_integration.rs
+++ b/cel/cel-cortex/tests/cortex_integration.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses `Cortex::isolated()` (StubAccessibility — no OS permissions needed)
 //! and cel_audio::StubAudioCapture to verify the engine lifecycle without hardware.
+#![allow(dead_code)]
 
 use cel_accessibility::StubAccessibility;
 use cel_audio::{

--- a/cel/cel-cortex/tests/liveness.rs
+++ b/cel/cel-cortex/tests/liveness.rs
@@ -134,7 +134,7 @@ async fn refresh_now_does_not_break_natural_cadence() {
     tokio::time::sleep(Duration::from_millis(500)).await;
     let later = cortex.tick_count();
     assert!(
-        later >= after_refresh + 1,
+        later > after_refresh,
         "natural ticks must keep firing after refresh_now: was {after_refresh}, now {later}"
     );
     cortex.shutdown();

--- a/cel/cel-display/src/capture.rs
+++ b/cel/cel-display/src/capture.rs
@@ -122,8 +122,8 @@ pub fn resize_frame(frame: &Frame, max_width: u32, max_height: u32) -> Result<Fr
         frame.data.clone(),
     )
     .ok_or(CaptureError::EncodingError("Invalid frame data".into()))?;
-    let ratio = (max_width as f64 / frame.width as f64)
-        .min(max_height as f64 / frame.height as f64);
+    let ratio =
+        (max_width as f64 / frame.width as f64).min(max_height as f64 / frame.height as f64);
     let new_w = (frame.width as f64 * ratio) as u32;
     let new_h = (frame.height as f64 * ratio) as u32;
     let resized =
@@ -244,7 +244,11 @@ pub fn diff_regions(a: &Frame, b: &Frame, cell_size: u32) -> Vec<(u32, u32, u32,
 /// One-call optimization for the LLM vision path.
 /// Resize to fit within max_dimension (longest side), encode as JPEG, return base64.
 /// This is the hot path for screenshot → LLM API calls.
-pub fn encode_for_llm(frame: &Frame, max_dimension: u32, jpeg_quality: u8) -> Result<String, CaptureError> {
+pub fn encode_for_llm(
+    frame: &Frame,
+    max_dimension: u32,
+    jpeg_quality: u8,
+) -> Result<String, CaptureError> {
     use base64::Engine;
     let resized = resize_frame(frame, max_dimension, max_dimension)?;
     let jpeg = encode_jpeg(&resized, jpeg_quality)?;

--- a/cel/cel-display/src/capture.rs
+++ b/cel/cel-display/src/capture.rs
@@ -202,8 +202,8 @@ pub fn diff_regions(a: &Frame, b: &Frame, cell_size: u32) -> Vec<(u32, u32, u32,
     if a.width != b.width || a.height != b.height || cell_size == 0 {
         return vec![(0, 0, a.width, a.height)]; // Entirely different
     }
-    let cols = (a.width + cell_size - 1) / cell_size;
-    let rows = (a.height + cell_size - 1) / cell_size;
+    let cols = a.width.div_ceil(cell_size);
+    let rows = a.height.div_ceil(cell_size);
     let mut changed_cells = Vec::new();
 
     for row in 0..rows {

--- a/cel/cel-display/src/lib.rs
+++ b/cel/cel-display/src/lib.rs
@@ -10,9 +10,8 @@ mod stub_capture;
 mod xcap_capture;
 
 pub use capture::{
-    crop_frame, diff_regions, encode_for_llm, encode_jpeg, encode_png, frames_differ,
-    pixel_color, resize_frame, CaptureError, Frame, LatestFrame, MonitorInfo, ScreenCapture,
-    WindowInfo,
+    crop_frame, diff_regions, encode_for_llm, encode_jpeg, encode_png, frames_differ, pixel_color,
+    resize_frame, CaptureError, Frame, LatestFrame, MonitorInfo, ScreenCapture, WindowInfo,
 };
 #[cfg(not(feature = "xcap"))]
 pub use stub_capture::StubCapture;
@@ -68,10 +67,7 @@ mod tests {
     fn test_encode_png_valid_2x2() {
         let frame = Frame {
             data: vec![
-                255, 0, 0, 255,
-                0, 255, 0, 255,
-                0, 0, 255, 255,
-                255, 255, 0, 255,
+                255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
             ],
             width: 2,
             height: 2,
@@ -163,10 +159,7 @@ mod tests {
             CaptureError::NotInitialized.to_string(),
             "Capture not initialized"
         );
-        assert_eq!(
-            CaptureError::NoMonitors.to_string(),
-            "No monitors found"
-        );
+        assert_eq!(CaptureError::NoMonitors.to_string(), "No monitors found");
         assert_eq!(
             CaptureError::EncodingError("bad".into()).to_string(),
             "Image encoding error: bad"
@@ -204,14 +197,31 @@ mod tests {
         // 4x4 frame: 64 bytes (4 pixels wide × 4 pixels tall × 4 channels)
         let mut data = vec![0u8; 4 * 4 * 4];
         // Top-left pixel: red
-        data[0] = 255; data[1] = 0; data[2] = 0; data[3] = 255;
+        data[0] = 255;
+        data[1] = 0;
+        data[2] = 0;
+        data[3] = 255;
         // (1,0): green
-        data[4] = 0; data[5] = 255; data[6] = 0; data[7] = 255;
+        data[4] = 0;
+        data[5] = 255;
+        data[6] = 0;
+        data[7] = 255;
         // (2,0): blue
-        data[8] = 0; data[9] = 0; data[10] = 255; data[11] = 255;
+        data[8] = 0;
+        data[9] = 0;
+        data[10] = 255;
+        data[11] = 255;
         // (3,0): white
-        data[12] = 255; data[13] = 255; data[14] = 255; data[15] = 255;
-        Frame { data, width: 4, height: 4, timestamp_ms: 1000 }
+        data[12] = 255;
+        data[13] = 255;
+        data[14] = 255;
+        data[15] = 255;
+        Frame {
+            data,
+            width: 4,
+            height: 4,
+            timestamp_ms: 1000,
+        }
     }
 
     #[test]
@@ -278,7 +288,9 @@ mod tests {
         assert!(!b64.is_empty());
         // Should be valid base64
         use base64::Engine;
-        let decoded = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
         assert!(!decoded.is_empty());
     }
 }

--- a/cel/cel-display/src/lib.rs
+++ b/cel/cel-display/src/lib.rs
@@ -22,7 +22,7 @@ pub use xcap_capture::XcapCapture;
 pub fn create_capture() -> Box<dyn ScreenCapture> {
     #[cfg(feature = "xcap")]
     {
-        return Box::new(XcapCapture::new());
+        Box::new(XcapCapture::new())
     }
     #[cfg(not(feature = "xcap"))]
     {

--- a/cel/cel-display/src/xcap_capture.rs
+++ b/cel/cel-display/src/xcap_capture.rs
@@ -8,6 +8,12 @@ pub struct XcapCapture {
     primary_height: u32,
 }
 
+impl Default for XcapCapture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl XcapCapture {
     pub fn new() -> Self {
         Self {

--- a/cel/cel-goal-runner/src/canonical_runner.rs
+++ b/cel/cel-goal-runner/src/canonical_runner.rs
@@ -114,7 +114,11 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
 
     /// Run `goal` to completion or structured failure.
     pub async fn run(&self, goal: &str, limits: RunLimits) -> GoalOutcome {
-        info!(goal, max_steps = limits.max_steps, "Canonical runner started");
+        info!(
+            goal,
+            max_steps = limits.max_steps,
+            "Canonical runner started"
+        );
         let start = Instant::now();
         let mut history: Vec<AttemptRecord> = Vec::new();
         let mut shared_memory = serde_json::json!({});
@@ -435,7 +439,11 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
                                     .unwrap_or(data.clone());
                                 merge_into_shared_memory(&mut shared_memory, name, value);
                             } else {
-                                merge_into_shared_memory(&mut shared_memory, &step.purpose, data.clone());
+                                merge_into_shared_memory(
+                                    &mut shared_memory,
+                                    &step.purpose,
+                                    data.clone(),
+                                );
                             }
                             consecutive_repeat = 0;
                         } else if action_hash == last_action_hash {
@@ -558,9 +566,7 @@ fn budget_exhausted(kind: &str, last_purpose: &str, steps_used: u32) -> GoalOutc
     GoalOutcome::Failed(FailureReport {
         failing_sub_goal: last_purpose.to_string(),
         failing_step: "<budget>".into(),
-        attempts: vec![format!(
-            "{kind} budget exhausted after {steps_used} steps"
-        )],
+        attempts: vec![format!("{kind} budget exhausted after {steps_used} steps")],
     })
 }
 
@@ -607,8 +613,7 @@ fn phase_gate_check(
         r.succeeded
             && matches!(
                 &r.action,
-                PlannedAction::WriteCells { .. }
-                // Future: SaveDocument goes here too.
+                PlannedAction::WriteCells { .. } // Future: SaveDocument goes here too.
             )
     });
     if landed {
@@ -634,7 +639,11 @@ fn phase_gate_check(
             used_pct,
             steps_used,
             limits.max_steps,
-            if perception.app.is_empty() { "<unknown>" } else { &perception.app },
+            if perception.app.is_empty() {
+                "<unknown>"
+            } else {
+                &perception.app
+            },
             terminal_app,
             terminal_app
         )),
@@ -691,9 +700,9 @@ fn hash_action(action: &PlannedAction) -> u64 {
 /// it had concluded arrow keys were off-limits).
 fn should_ban_on_repeat(action: &PlannedAction) -> bool {
     match action {
-        PlannedAction::Key { .. }
-        | PlannedAction::KeyCombo { .. }
-        | PlannedAction::Wait { .. } => false,
+        PlannedAction::Key { .. } | PlannedAction::KeyCombo { .. } | PlannedAction::Wait { .. } => {
+            false
+        }
         PlannedAction::Type { target_id, .. } => target_id.is_some(),
         _ => true,
     }
@@ -814,7 +823,11 @@ impl StepExecutor for CortexStepExecutor {
         };
         RuntimeCaps {
             cdp_bound,
-            cdp_browser: if cdp_bound { Some("Google Chrome".into()) } else { None },
+            cdp_browser: if cdp_bound {
+                Some("Google Chrome".into())
+            } else {
+                None
+            },
             cdp_url,
             native_input: self.cortex.native_input_allowed(),
             steps_used: 0,
@@ -824,7 +837,10 @@ impl StepExecutor for CortexStepExecutor {
 }
 
 fn is_unrecoverable(action: &PlannedAction) -> bool {
-    matches!(action, PlannedAction::Done { .. } | PlannedAction::Fail { .. })
+    matches!(
+        action,
+        PlannedAction::Done { .. } | PlannedAction::Fail { .. }
+    )
 }
 
 fn action_kind(action: &PlannedAction) -> String {
@@ -911,7 +927,14 @@ fn action_args_summary(action: &PlannedAction) -> Option<String> {
             let mut summary = app.clone();
             if !cell_refs.is_empty() {
                 summary.push(' ');
-                summary.push_str(&cell_refs.iter().take(8).cloned().collect::<Vec<_>>().join(", "));
+                summary.push_str(
+                    &cell_refs
+                        .iter()
+                        .take(8)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
             }
             if cell_refs.len() > 8 {
                 summary.push_str(", ...");
@@ -1096,7 +1119,11 @@ mod tests {
         let planner = ScriptedPlanner::new(vec![
             NextMove::Batch {
                 purpose: "extract".into(),
-                steps: vec![failing_step.clone(), failing_step.clone(), failing_step.clone()],
+                steps: vec![
+                    failing_step.clone(),
+                    failing_step.clone(),
+                    failing_step.clone(),
+                ],
             },
             NextMove::Done {
                 summary: "proceeded with partial data".into(),
@@ -1150,7 +1177,11 @@ mod tests {
         let got = phase_gate_check(&limits, 50, &history, &empty_perception("Google Chrome"), 0);
         let rec = got.expect("gate should fire at 50% with wrong frontmost");
         assert!(rec.error.as_ref().unwrap().contains("phase gate"));
-        assert!(rec.error.as_ref().unwrap().contains("activate_app(Numbers)"));
+        assert!(rec
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("activate_app(Numbers)"));
     }
 
     #[test]

--- a/cel/cel-goal-runner/src/canonical_runner.rs
+++ b/cel/cel-goal-runner/src/canonical_runner.rs
@@ -348,9 +348,9 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
                     // (exactly what happened in the crypto scenario
                     // when the agent concluded "arrow keys are
                     // banned" and couldn't move to cell D3).
-                    let mut steps_iter = steps.into_iter();
+                    let steps_iter = steps.into_iter();
                     let mut remaining: Vec<Step> = Vec::new();
-                    while let Some(s) = steps_iter.next() {
+                    for s in steps_iter {
                         if !should_ban_on_repeat(&s.action) {
                             remaining.push(s);
                             continue;

--- a/cel/cel-goal-runner/src/config.rs
+++ b/cel/cel-goal-runner/src/config.rs
@@ -46,11 +46,21 @@ pub struct GoalConfig {
     pub deterministic_seed: Option<u64>,
 }
 
-fn default_max_steps() -> u32 { 30 }
-fn default_step_delay() -> u64 { 500 }
-fn default_timeout() -> u64 { 120_000 }
-fn default_max_failures() -> u32 { 8 }
-fn default_max_rate_limits() -> u32 { 3 }
+fn default_max_steps() -> u32 {
+    30
+}
+fn default_step_delay() -> u64 {
+    500
+}
+fn default_timeout() -> u64 {
+    120_000
+}
+fn default_max_failures() -> u32 {
+    8
+}
+fn default_max_rate_limits() -> u32 {
+    3
+}
 
 impl Default for GoalConfig {
     fn default() -> Self {

--- a/cel/cel-goal-runner/src/runtime_backend.rs
+++ b/cel/cel-goal-runner/src/runtime_backend.rs
@@ -14,8 +14,10 @@ use serde::{Deserialize, Serialize};
 /// Which execution backend a goal run should target.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
+#[derive(Default)]
 pub enum RuntimeBackend {
     /// Run in the current process (today's default).
+    #[default]
     Local,
     /// Send goals to a remote `cellar-worker` over HTTP.
     Remote {
@@ -25,12 +27,6 @@ pub enum RuntimeBackend {
         #[serde(skip_serializing_if = "Option::is_none")]
         token: Option<String>,
     },
-}
-
-impl Default for RuntimeBackend {
-    fn default() -> Self {
-        Self::Local
-    }
 }
 
 impl RuntimeBackend {

--- a/cel/cel-goal-runner/src/runtime_backend.rs
+++ b/cel/cel-goal-runner/src/runtime_backend.rs
@@ -92,7 +92,9 @@ fn from_env() -> Option<RuntimeBackend> {
 
 fn from_config_file() -> Option<RuntimeBackend> {
     let home = std::env::var("HOME").ok()?;
-    let path = std::path::PathBuf::from(home).join(".cellar").join("config.toml");
+    let path = std::path::PathBuf::from(home)
+        .join(".cellar")
+        .join("config.toml");
     let content = std::fs::read_to_string(&path).ok()?;
     let file: ConfigFile = toml::from_str(&content).ok()?;
     let runtime = file.runtime?;

--- a/cel/cel-input/src/applescript.rs
+++ b/cel/cel-input/src/applescript.rs
@@ -163,8 +163,7 @@ fn build_jxa_write_script(
         .iter()
         .map(|w| serde_json::json!({ "ref": w.cell_ref, "value": w.value }))
         .collect();
-    let writes_json_literal =
-        serde_json::to_string(&writes_json).unwrap_or_else(|_| "[]".into());
+    let writes_json_literal = serde_json::to_string(&writes_json).unwrap_or_else(|_| "[]".into());
 
     format!(
         r#"
@@ -198,16 +197,11 @@ fn build_jxa_write_script(
 }
 
 /// Build the read JXA script.
-fn build_jxa_read_script(
-    sheet: Option<&str>,
-    table: Option<&str>,
-    cell_refs: &[String],
-) -> String {
+fn build_jxa_read_script(sheet: Option<&str>, table: Option<&str>, cell_refs: &[String]) -> String {
     let sheet_js = sheet_selector(sheet);
     let table_js = table_selector(table);
     let numbers_app_resolver = numbers_app_resolver_jxa();
-    let refs_json_literal =
-        serde_json::to_string(cell_refs).unwrap_or_else(|_| "[]".into());
+    let refs_json_literal = serde_json::to_string(cell_refs).unwrap_or_else(|_| "[]".into());
 
     format!(
         r#"
@@ -236,8 +230,7 @@ fn build_jxa_read_script(
 }
 
 fn numbers_app_resolver_jxa() -> String {
-    let candidates = serde_json::to_string(NUMBERS_APP_CANDIDATES)
-        .unwrap_or_else(|_| "[]".into());
+    let candidates = serde_json::to_string(NUMBERS_APP_CANDIDATES).unwrap_or_else(|_| "[]".into());
     format!(
         r#"
         function resolveNumbersApp() {{

--- a/cel/cel-input/src/enigo_input.rs
+++ b/cel/cel-input/src/enigo_input.rs
@@ -49,12 +49,9 @@ fn parse_key(key: &str) -> Result<enigo::Key, InputError> {
         "left" | "leftarrow" | "arrowleft" | "left arrow" | "left_arrow" | "arrow left" => {
             Ok(enigo::Key::LeftArrow)
         }
-        "right"
-        | "rightarrow"
-        | "arrowright"
-        | "right arrow"
-        | "right_arrow"
-        | "arrow right" => Ok(enigo::Key::RightArrow),
+        "right" | "rightarrow" | "arrowright" | "right arrow" | "right_arrow" | "arrow right" => {
+            Ok(enigo::Key::RightArrow)
+        }
         "home" => Ok(enigo::Key::Home),
         "end" => Ok(enigo::Key::End),
         "pageup" => Ok(enigo::Key::PageUp),
@@ -124,7 +121,10 @@ impl InputController for EnigoInput {
     }
 
     fn key_combo(&mut self, keys: &[&str]) -> Result<(), InputError> {
-        let parsed: Vec<enigo::Key> = keys.iter().map(|k| parse_key(k)).collect::<Result<_, _>>()?;
+        let parsed: Vec<enigo::Key> = keys
+            .iter()
+            .map(|k| parse_key(k))
+            .collect::<Result<_, _>>()?;
 
         // Track which keys were pressed so we can release them all on error
         let mut pressed = Vec::with_capacity(parsed.len());
@@ -166,8 +166,7 @@ impl InputController for EnigoInput {
     }
 
     fn mouse_position(&self) -> Result<(i32, i32), InputError> {
-        enigo::Mouse::location(&self.enigo)
-            .map_err(|e| InputError::Failed(e.to_string()))
+        enigo::Mouse::location(&self.enigo).map_err(|e| InputError::Failed(e.to_string()))
     }
 
     fn drag(&mut self, from_x: i32, from_y: i32, to_x: i32, to_y: i32) -> Result<(), InputError> {
@@ -182,7 +181,8 @@ impl InputController for EnigoInput {
         let move_result = self.mouse_move(to_x, to_y);
 
         // Always release the button, even if the move failed
-        let release_result = self.enigo
+        let release_result = self
+            .enigo
             .button(Button::Left, Direction::Release)
             .map_err(|e| InputError::Failed(e.to_string()));
 

--- a/cel/cel-input/src/enigo_input.rs
+++ b/cel/cel-input/src/enigo_input.rs
@@ -251,7 +251,7 @@ impl InputController for EnigoInput {
         }
 
         let (start_x, start_y) = self.mouse_position()?;
-        let steps = (duration_ms / 10).max(5).min(100) as i32; // 10ms per step, 5-100 steps
+        let steps = (duration_ms / 10).clamp(5, 100) as i32; // 10ms per step, 5-100 steps
         let sleep_per_step = Duration::from_millis((duration_ms as u64) / (steps as u64));
 
         for i in 1..=steps {

--- a/cel/cel-input/src/inject.rs
+++ b/cel/cel-input/src/inject.rs
@@ -28,18 +28,46 @@ pub enum MouseButton {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InputEvent {
-    MouseMove { x: i32, y: i32 },
-    MouseClick { x: i32, y: i32, button: MouseButton },
-    MouseDown { x: i32, y: i32, button: MouseButton },
-    MouseUp { x: i32, y: i32, button: MouseButton },
-    KeyPress { key: String },
-    KeyDown { key: String },
-    KeyUp { key: String },
-    TypeText { text: String },
-    Scroll { dx: i32, dy: i32 },
+    MouseMove {
+        x: i32,
+        y: i32,
+    },
+    MouseClick {
+        x: i32,
+        y: i32,
+        button: MouseButton,
+    },
+    MouseDown {
+        x: i32,
+        y: i32,
+        button: MouseButton,
+    },
+    MouseUp {
+        x: i32,
+        y: i32,
+        button: MouseButton,
+    },
+    KeyPress {
+        key: String,
+    },
+    KeyDown {
+        key: String,
+    },
+    KeyUp {
+        key: String,
+    },
+    TypeText {
+        text: String,
+    },
+    Scroll {
+        dx: i32,
+        dy: i32,
+    },
     /// Trackpad gesture observed during recording.
     /// Stored semantically — replay uses keyboard equivalents.
-    Gesture { gesture: GestureEvent },
+    Gesture {
+        gesture: GestureEvent,
+    },
 }
 
 /// A trackpad gesture observed via CGEventTap (macOS) or libinput (Linux).

--- a/cel/cel-input/src/lib.rs
+++ b/cel/cel-input/src/lib.rs
@@ -3,15 +3,15 @@
 //! Input injection and interception for mouse and keyboard events.
 //! Uses enigo for cross-platform input simulation (Windows, macOS, Linux).
 
-mod inject;
-mod enigo_input;
 #[cfg(target_os = "macos")]
 pub mod applescript;
+mod enigo_input;
+mod inject;
 
-pub use inject::{GestureEvent, InputController, InputError, InputEvent, MouseButton};
-pub use enigo_input::EnigoInput;
 #[cfg(target_os = "macos")]
 pub use applescript::{read_numbers_cells, write_numbers_cells, CellWrite};
+pub use enigo_input::EnigoInput;
+pub use inject::{GestureEvent, InputController, InputError, InputEvent, MouseButton};
 
 /// Create a platform-appropriate input controller.
 pub fn create_controller() -> Result<Box<dyn InputController>, InputError> {
@@ -47,7 +47,11 @@ mod tests {
 
     #[test]
     fn test_input_event_click() {
-        let event = InputEvent::MouseClick { x: 50, y: 75, button: MouseButton::Right };
+        let event = InputEvent::MouseClick {
+            x: 50,
+            y: 75,
+            button: MouseButton::Right,
+        };
         let json = serde_json::to_string(&event).unwrap();
         let back: InputEvent = serde_json::from_str(&json).unwrap();
         match back {
@@ -62,14 +66,18 @@ mod tests {
 
     #[test]
     fn test_input_event_key_press() {
-        let event = InputEvent::KeyPress { key: "Enter".into() };
+        let event = InputEvent::KeyPress {
+            key: "Enter".into(),
+        };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Enter"));
     }
 
     #[test]
     fn test_input_event_type_text() {
-        let event = InputEvent::TypeText { text: "Hello, World!".into() };
+        let event = InputEvent::TypeText {
+            text: "Hello, World!".into(),
+        };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Hello, World!"));
     }
@@ -92,13 +100,31 @@ mod tests {
     fn test_all_input_event_variants_serializable() {
         let events = vec![
             InputEvent::MouseMove { x: 0, y: 0 },
-            InputEvent::MouseClick { x: 0, y: 0, button: MouseButton::Left },
-            InputEvent::MouseDown { x: 0, y: 0, button: MouseButton::Left },
-            InputEvent::MouseUp { x: 0, y: 0, button: MouseButton::Left },
+            InputEvent::MouseClick {
+                x: 0,
+                y: 0,
+                button: MouseButton::Left,
+            },
+            InputEvent::MouseDown {
+                x: 0,
+                y: 0,
+                button: MouseButton::Left,
+            },
+            InputEvent::MouseUp {
+                x: 0,
+                y: 0,
+                button: MouseButton::Left,
+            },
             InputEvent::KeyPress { key: "a".into() },
-            InputEvent::KeyDown { key: "Shift".into() },
-            InputEvent::KeyUp { key: "Shift".into() },
-            InputEvent::TypeText { text: "test".into() },
+            InputEvent::KeyDown {
+                key: "Shift".into(),
+            },
+            InputEvent::KeyUp {
+                key: "Shift".into(),
+            },
+            InputEvent::TypeText {
+                text: "test".into(),
+            },
             InputEvent::Scroll { dx: 0, dy: 1 },
         ];
         for event in events {

--- a/cel/cel-llm/src/client.rs
+++ b/cel/cel-llm/src/client.rs
@@ -86,6 +86,9 @@ struct AnthropicResponseContent {
     text: Option<String>,
 }
 
+type MockFn =
+    std::sync::Arc<dyn Fn(Vec<ChatMessage>, u32) -> Result<String, LlmError> + Send + Sync>;
+
 /// Reusable LLM client that speaks both the OpenAI-compatible chat completions
 /// protocol and the Anthropic Messages API.
 pub struct LlmClient {
@@ -95,9 +98,7 @@ pub struct LlmClient {
     model: String,
     /// When set, `chat()` calls this function instead of making an HTTP request.
     /// Used by tests to inject deterministic responses without a real LLM endpoint.
-    mock_fn: Option<
-        std::sync::Arc<dyn Fn(Vec<ChatMessage>, u32) -> Result<String, LlmError> + Send + Sync>,
-    >,
+    mock_fn: Option<MockFn>,
 }
 
 impl LlmClient {

--- a/cel/cel-llm/src/client.rs
+++ b/cel/cel-llm/src/client.rs
@@ -95,7 +95,9 @@ pub struct LlmClient {
     model: String,
     /// When set, `chat()` calls this function instead of making an HTTP request.
     /// Used by tests to inject deterministic responses without a real LLM endpoint.
-    mock_fn: Option<std::sync::Arc<dyn Fn(Vec<ChatMessage>, u32) -> Result<String, LlmError> + Send + Sync>>,
+    mock_fn: Option<
+        std::sync::Arc<dyn Fn(Vec<ChatMessage>, u32) -> Result<String, LlmError> + Send + Sync>,
+    >,
 }
 
 impl LlmClient {
@@ -191,7 +193,10 @@ impl LlmClient {
             };
             match result {
                 Ok(response) => return Ok(response),
-                Err(LlmError::HttpError { status: 429, ref body }) => {
+                Err(LlmError::HttpError {
+                    status: 429,
+                    ref body,
+                }) => {
                     tracing::warn!(
                         "Rate limited (429), retry {}/3 after {}s: {}",
                         attempt + 1,
@@ -240,9 +245,15 @@ impl LlmClient {
             response_format: if is_reasoning {
                 None // reasoning models don't support response_format
             } else {
-                Some(ResponseFormat { r#type: "json_object".to_string() })
+                Some(ResponseFormat {
+                    r#type: "json_object".to_string(),
+                })
             },
-            temperature: if is_reasoning { None } else { self.config.temperature },
+            temperature: if is_reasoning {
+                None
+            } else {
+                self.config.temperature
+            },
         };
 
         let api_key = self.config.api_key.as_deref().unwrap_or("");
@@ -495,10 +506,7 @@ fn parse_data_url(url: &str) -> (String, String) {
     // Format: data:image/png;base64,<data>
     if let Some(rest) = url.strip_prefix("data:") {
         if let Some((header, data)) = rest.split_once(',') {
-            let media_type = header
-                .strip_suffix(";base64")
-                .unwrap_or(header)
-                .to_string();
+            let media_type = header.strip_suffix(";base64").unwrap_or(header).to_string();
             return (media_type, data.to_string());
         }
     }

--- a/cel/cel-llm/src/config.rs
+++ b/cel/cel-llm/src/config.rs
@@ -3,7 +3,11 @@ use serde::{Deserialize, Serialize};
 /// Path to the user-level config file written by `cellar init`.
 fn config_file_path() -> Option<std::path::PathBuf> {
     let home = std::env::var("HOME").ok()?;
-    Some(std::path::PathBuf::from(home).join(".cellar").join("config.toml"))
+    Some(
+        std::path::PathBuf::from(home)
+            .join(".cellar")
+            .join("config.toml"),
+    )
 }
 
 /// On-disk config file schema. Only the `[llm]` section is consulted today.
@@ -339,8 +343,9 @@ impl LlmProviderConfig {
             ProviderKind::Gemini => nonempty("GEMINI_API_KEY")
                 .or_else(|| nonempty("GOOGLE_GEMINI_API_KEY"))
                 .or_else(|| nonempty("GOOGLE_API_KEY")),
-            ProviderKind::HuggingFace => nonempty("HUGGINGFACE_API_KEY")
-                .or_else(|| nonempty("HF_API_KEY")),
+            ProviderKind::HuggingFace => {
+                nonempty("HUGGINGFACE_API_KEY").or_else(|| nonempty("HF_API_KEY"))
+            }
             ProviderKind::Ollama | ProviderKind::Custom => None,
         }
     }
@@ -450,10 +455,7 @@ temperature = 0.2
         let _lock = ENV_MUTEX.lock().unwrap();
         let prev_home = std::env::var("HOME").ok();
 
-        let tmp = std::env::temp_dir().join(format!(
-            "cel-llm-config-test-{}",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("cel-llm-config-test-{}", std::process::id()));
         let cellar_dir = tmp.join(".cellar");
         std::fs::create_dir_all(&cellar_dir).unwrap();
         std::fs::write(
@@ -554,30 +556,63 @@ model = "gemma4:e4b"
 
     #[test]
     fn test_model_tier_flash() {
-        assert_eq!(ModelProfile::from_model_id("gemini-2.0-flash").tier, ModelTier::Flash);
-        assert_eq!(ModelProfile::from_model_id("gpt-4o-mini").tier, ModelTier::Flash);
-        assert_eq!(ModelProfile::from_model_id("claude-haiku-4-5").tier, ModelTier::Flash);
+        assert_eq!(
+            ModelProfile::from_model_id("gemini-2.0-flash").tier,
+            ModelTier::Flash
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("gpt-4o-mini").tier,
+            ModelTier::Flash
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("claude-haiku-4-5").tier,
+            ModelTier::Flash
+        );
     }
 
     #[test]
     fn test_model_tier_standard() {
-        assert_eq!(ModelProfile::from_model_id("gpt-4o").tier, ModelTier::Standard);
-        assert_eq!(ModelProfile::from_model_id("claude-sonnet-4-20250514").tier, ModelTier::Standard);
+        assert_eq!(
+            ModelProfile::from_model_id("gpt-4o").tier,
+            ModelTier::Standard
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("claude-sonnet-4-20250514").tier,
+            ModelTier::Standard
+        );
     }
 
     #[test]
     fn test_model_tier_premium() {
-        assert_eq!(ModelProfile::from_model_id("claude-opus-4-6").tier, ModelTier::Premium);
+        assert_eq!(
+            ModelProfile::from_model_id("claude-opus-4-6").tier,
+            ModelTier::Premium
+        );
         assert_eq!(ModelProfile::from_model_id("o3").tier, ModelTier::Premium);
-        assert_eq!(ModelProfile::from_model_id("gpt-5").tier, ModelTier::Premium);
+        assert_eq!(
+            ModelProfile::from_model_id("gpt-5").tier,
+            ModelTier::Premium
+        );
     }
 
     #[test]
     fn test_model_profile_provider_detection() {
-        assert_eq!(ModelProfile::from_model_id("claude-sonnet-4").provider, ProviderKind::Anthropic);
-        assert_eq!(ModelProfile::from_model_id("gpt-4o").provider, ProviderKind::OpenAI);
-        assert_eq!(ModelProfile::from_model_id("gemini-2.0-flash").provider, ProviderKind::Gemini);
-        assert_eq!(ModelProfile::from_model_id("llama-3").provider, ProviderKind::Custom);
+        assert_eq!(
+            ModelProfile::from_model_id("claude-sonnet-4").provider,
+            ProviderKind::Anthropic
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("gpt-4o").provider,
+            ProviderKind::OpenAI
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("gemini-2.0-flash").provider,
+            ProviderKind::Gemini
+        );
+        assert_eq!(
+            ModelProfile::from_model_id("llama-3").provider,
+            ProviderKind::Custom
+        );
     }
 
     #[test]

--- a/cel/cel-llm/src/config.rs
+++ b/cel/cel-llm/src/config.rs
@@ -97,21 +97,16 @@ impl From<&str> for ProviderKind {
 }
 
 /// Model capability tier — determines prompt complexity and context budget.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModelTier {
     /// Small/fast models (gemini-flash, gpt-4o-mini, haiku). Short prompts, aggressive filtering.
     Flash,
     /// Standard models (gpt-4o, claude-sonnet, gemini-pro). Default behavior.
+    #[default]
     Standard,
     /// Premium models (claude-opus, o3, gpt-5). Extended prompts, more context.
     Premium,
-}
-
-impl Default for ModelTier {
-    fn default() -> Self {
-        Self::Standard
-    }
 }
 
 /// Profile describing a model's capabilities.

--- a/cel/cel-llm/src/error.rs
+++ b/cel/cel-llm/src/error.rs
@@ -36,6 +36,12 @@ impl LlmError {
     /// consecutive 429s instead of chewing through `max_consecutive_failures`
     /// × built-in-retry-latency. See `GoalRunner::max_consecutive_rate_limits`.
     pub fn is_rate_limited(&self) -> bool {
-        matches!(self, LlmError::HttpError { status: 429 | 529, .. })
+        matches!(
+            self,
+            LlmError::HttpError {
+                status: 429 | 529,
+                ..
+            }
+        )
     }
 }

--- a/cel/cel-llm/src/lib.rs
+++ b/cel/cel-llm/src/lib.rs
@@ -127,14 +127,8 @@ pub fn strip_code_fences(content: &str) -> &str {
     let s = content.trim();
 
     // Case 1: code fences
-    if let Some(inner) = s
-        .strip_prefix("```json")
-        .or_else(|| s.strip_prefix("```"))
-    {
-        return inner
-            .strip_suffix("```")
-            .unwrap_or(inner)
-            .trim();
+    if let Some(inner) = s.strip_prefix("```json").or_else(|| s.strip_prefix("```")) {
+        return inner.strip_suffix("```").unwrap_or(inner).trim();
     }
 
     // Case 2: already valid JSON start

--- a/cel/cel-llm/src/lib.rs
+++ b/cel/cel-llm/src/lib.rs
@@ -65,7 +65,7 @@ impl ChatMessage {
 /// Encode raw bytes as base64.
 pub fn base64_encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut result = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = chunk.get(1).copied().unwrap_or(0) as u32;

--- a/cel/cel-napi/src/adapter_registry.rs
+++ b/cel/cel-napi/src/adapter_registry.rs
@@ -21,15 +21,9 @@ fn adapters() -> &'static tokio::sync::Mutex<HashMap<String, Box<dyn Adapter>>> 
 // ── Factory: create adapter by name ────────────────────────────────────────
 
 fn create_adapter(name: &str) -> napi::Result<Box<dyn Adapter>> {
-    match name {
-        // Future: "excel" => Ok(Box::new(excel_adapter::ExcelAdapter::new())),
-        // Future: "sap-gui" => Ok(Box::new(sap_gui_adapter::SapGuiAdapter::new())),
-        // Future: "bloomberg" => Ok(Box::new(bloomberg_adapter::BloombergAdapter::new())),
-        // Future: "metatrader" => Ok(Box::new(metatrader_adapter::MetaTraderAdapter::new())),
-        _ => Err(napi::Error::from_reason(format!(
-            "Unknown adapter: \"{name}\". Available: excel, sap-gui, bloomberg, metatrader"
-        ))),
-    }
+    Err(napi::Error::from_reason(format!(
+        "Unknown adapter: \"{name}\". Available: excel, sap-gui, bloomberg, metatrader"
+    )))
 }
 
 // ── NAPI exports ───────────────────────────────────────────────────────────

--- a/cel/cel-napi/src/cortex.rs
+++ b/cel/cel-napi/src/cortex.rs
@@ -125,6 +125,7 @@ pub fn boot_cortex() -> napi::Result<()> {
     // automatically when a CDP target is bound; this is the fallback for
     // desktop apps.
     let mut cortex = cel_cortex::Cortex::new("mcp-default".into()).with_native_input_unsafe();
+    #[cfg(target_os = "macos")]
     cortex.register_adapter(Box::new(adapter_numbers::NumbersAdapter::new()));
     if let Some((capture, config)) = default_audio_capture() {
         cortex = cortex.with_audio(capture, config);
@@ -272,7 +273,7 @@ pub fn is_cortex_running() -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
-    state.cortex.as_ref().map_or(false, |c| c.is_running())
+    state.cortex.as_ref().is_some_and(|c| c.is_running())
 }
 
 // ─── Liveness API (Phase 1) ───────────────────────────────────────────────

--- a/cel/cel-napi/src/input.rs
+++ b/cel/cel-napi/src/input.rs
@@ -259,7 +259,7 @@ pub fn shell_exec(command: String, args: Vec<String>) -> napi::Result<String> {
         "pmset",
         "sw_vers",
     ];
-    let cmd_name = command.split('/').last().unwrap_or(&command);
+    let cmd_name = command.split('/').next_back().unwrap_or(&command);
     if !ALLOWED.contains(&cmd_name) {
         return Err(napi::Error::from_reason(format!(
             "Command '{}' not in allowlist: {:?}",

--- a/cel/cel-napi/src/lib.rs
+++ b/cel/cel-napi/src/lib.rs
@@ -8,6 +8,9 @@
 // The ctor crate (used by napi-rs for module registration) triggers cfg warnings
 // on newer Rust compilers. Safe to suppress until napi-rs updates ctor.
 #![allow(unexpected_cfgs)]
+// FFI signatures often have many arguments by necessity (passing primitive values
+// across the napi boundary instead of structs).
+#![allow(clippy::too_many_arguments)]
 
 use napi_derive::napi;
 

--- a/cel/cel-network/src/lib.rs
+++ b/cel/cel-network/src/lib.rs
@@ -45,7 +45,9 @@ pub fn service_for_port(port: u16) -> Option<&'static str> {
     }
 }
 
-fn default_protocol() -> String { "tcp".to_string() }
+fn default_protocol() -> String {
+    "tcp".to_string()
+}
 
 /// A raw TCP/UDP connection observed at the OS level.
 ///
@@ -185,8 +187,10 @@ impl ProcNetMonitor {
                     if let Some(event) = self.parse_proc_line(line, now, proto) {
                         let key = format!(
                             "{}:{}->{}:{}",
-                            event.local_addr, event.local_port,
-                            event.remote_addr, event.remote_port
+                            event.local_addr,
+                            event.local_port,
+                            event.remote_addr,
+                            event.remote_port
                         );
                         if self.known_connections.insert(key) {
                             if let Ok(mut events) = self.events.lock() {
@@ -314,7 +318,10 @@ fn parse_hex_ip(addr: &str) -> Option<String> {
             .filter_map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
             .collect();
         if bytes.len() == 4 {
-            Some(format!("{}.{}.{}.{}", bytes[3], bytes[2], bytes[1], bytes[0]))
+            Some(format!(
+                "{}.{}.{}.{}",
+                bytes[3], bytes[2], bytes[1], bytes[0]
+            ))
         } else {
             None
         }

--- a/cel/cel-network/src/lib.rs
+++ b/cel/cel-network/src/lib.rs
@@ -161,6 +161,13 @@ pub struct ProcNetMonitor {
 }
 
 #[cfg(target_os = "linux")]
+impl Default for ProcNetMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "linux")]
 impl ProcNetMonitor {
     pub fn new() -> Self {
         Self {
@@ -353,11 +360,11 @@ fn tcp_state_name(hex: &str) -> &str {
 pub fn create_monitor() -> Box<dyn NetworkMonitor> {
     #[cfg(target_os = "linux")]
     {
-        return Box::new(ProcNetMonitor::new());
+        Box::new(ProcNetMonitor::new())
     }
     #[cfg(target_os = "macos")]
     {
-        return Box::new(macos::LsofNetMonitor::new());
+        Box::new(macos::LsofNetMonitor::new())
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {

--- a/cel/cel-network/src/macos.rs
+++ b/cel/cel-network/src/macos.rs
@@ -232,19 +232,14 @@ mod tests {
 
     #[test]
     fn test_parse_lsof_connection_localhost_filtered() {
-        let event =
-            parse_lsof_connection("127.0.0.1:3000->127.0.0.1:54321", 1000, None, None);
+        let event = parse_lsof_connection("127.0.0.1:3000->127.0.0.1:54321", 1000, None, None);
         assert!(event.is_none());
     }
 
     #[test]
     fn test_parse_lsof_connection_no_fake_http() {
-        let event = parse_lsof_connection(
-            "192.168.1.100:54321->93.184.216.34:80",
-            1000,
-            None,
-            None,
-        );
+        let event =
+            parse_lsof_connection("192.168.1.100:54321->93.184.216.34:80", 1000, None, None);
         assert!(event.is_some());
         let e = event.unwrap();
         // Service is "http" (from port), but no fabricated HTTP method/status

--- a/cel/cel-planner/src/canonical.rs
+++ b/cel/cel-planner/src/canonical.rs
@@ -53,9 +53,7 @@ pub enum NextMove {
         extracted_data: serde_json::Value,
     },
     /// Give up — goal can't be completed given the state.
-    Fail {
-        reason: String,
-    },
+    Fail { reason: String },
 }
 
 /// Snapshot of what tools / channels the runtime has wired up this
@@ -399,8 +397,12 @@ mod tests {
             message: "selector returned null".into(),
             recoverable: true,
         };
-        assert!(serde_json::to_string(&ok).unwrap().contains("\"status\":\"ok\""));
-        assert!(serde_json::to_string(&err).unwrap().contains("\"status\":\"err\""));
+        assert!(serde_json::to_string(&ok)
+            .unwrap()
+            .contains("\"status\":\"ok\""));
+        assert!(serde_json::to_string(&err)
+            .unwrap()
+            .contains("\"status\":\"err\""));
     }
 
     #[test]

--- a/cel/cel-planner/src/canonical_plan_producer.rs
+++ b/cel/cel-planner/src/canonical_plan_producer.rs
@@ -82,7 +82,10 @@ pub trait PlanProducer: Send + Sync {
         _perception: &ScreenContext,
         _screenshot_png: Option<&[u8]>,
     ) -> Result<DoneVerdict, String> {
-        Ok(DoneVerdict { verified: true, reason: String::new() })
+        Ok(DoneVerdict {
+            verified: true,
+            reason: String::new(),
+        })
     }
 }
 

--- a/cel/cel-planner/src/decompose.rs
+++ b/cel/cel-planner/src/decompose.rs
@@ -6,7 +6,6 @@
 ///
 /// The LLM can add, skip, or reorder milestones during execution.
 /// They're guidance, not gates.
-
 use serde::{Deserialize, Serialize};
 
 /// A single milestone from the decomposition.
@@ -123,7 +122,13 @@ pub fn format_milestones_for_prompt(milestones: &[Milestone]) -> String {
 
     let mut out = String::from("\n\nMILESTONES for this goal:\n");
     for (i, m) in milestones.iter().enumerate() {
-        out.push_str(&format!("{}. {} — {} (~{} steps)\n", i + 1, m.label, m.description, m.step_budget));
+        out.push_str(&format!(
+            "{}. {} — {} (~{} steps)\n",
+            i + 1,
+            m.label,
+            m.description,
+            m.step_budget
+        ));
     }
     out.push_str("When you reach a milestone, set progress to \"milestone:<label>\".\n");
     out
@@ -166,8 +171,16 @@ mod tests {
     #[test]
     fn test_format_milestones() {
         let milestones = vec![
-            Milestone { label: "search".into(), description: "Fill search form".into(), step_budget: 5 },
-            Milestone { label: "select".into(), description: "Pick best option".into(), step_budget: 10 },
+            Milestone {
+                label: "search".into(),
+                description: "Fill search form".into(),
+                step_budget: 5,
+            },
+            Milestone {
+                label: "select".into(),
+                description: "Pick best option".into(),
+                step_budget: 10,
+            },
         ];
         let formatted = format_milestones_for_prompt(&milestones);
         assert!(formatted.contains("1. search"));

--- a/cel/cel-planner/src/distiller.rs
+++ b/cel/cel-planner/src/distiller.rs
@@ -9,33 +9,75 @@ use std::collections::HashSet;
 
 /// Actionable element types (can be clicked/interacted with).
 const ACTIONABLE_TYPES: &[&str] = &[
-    "button", "input", "select", "textarea", "a", "link",
-    "checkbox", "radio_button", "combobox", "slider",
-    "tab", "menu_item",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "a",
+    "link",
+    "checkbox",
+    "radio_button",
+    "combobox",
+    "slider",
+    "tab",
+    "menu_item",
 ];
 
 /// Generic action labels that get deprioritized when repeated.
 const GENERIC_ACTION_LABELS: &[&str] = &[
-    "open", "close", "cancel", "ok", "more", "menu", "next", "back",
-    "learn more", "details", "view", "edit", "delete", "remove", "select",
-    "continue", "submit", "save", "apply", "retry", "dismiss",
+    "open",
+    "close",
+    "cancel",
+    "ok",
+    "more",
+    "menu",
+    "next",
+    "back",
+    "learn more",
+    "details",
+    "view",
+    "edit",
+    "delete",
+    "remove",
+    "select",
+    "continue",
+    "submit",
+    "save",
+    "apply",
+    "retry",
+    "dismiss",
 ];
 
 /// Chrome/UI noise patterns to deprioritize.
 const CHROME_HINT_KEYWORDS: &[&str] = &[
-    "header", "nav", "navbar", "toolbar", "menu", "sidebar", "breadcrumb",
-    "footer", "legal", "cookie", "consent", "account", "profile", "help",
-    "support", "social", "share", "newsletter", "chat", "intercom",
+    "header",
+    "nav",
+    "navbar",
+    "toolbar",
+    "menu",
+    "sidebar",
+    "breadcrumb",
+    "footer",
+    "legal",
+    "cookie",
+    "consent",
+    "account",
+    "profile",
+    "help",
+    "support",
+    "social",
+    "share",
+    "newsletter",
+    "chat",
+    "intercom",
 ];
 
 /// Stop words filtered from goal keywords.
 const STOP_WORDS: &[&str] = &[
-    "the", "a", "an", "is", "are", "was", "were", "be", "been",
-    "and", "or", "but", "in", "on", "at", "to", "for", "of",
-    "with", "from", "by", "as", "it", "do", "not", "this", "that",
-    "my", "me", "i", "you", "we", "can", "will", "just", "any",
-    "all", "each", "find", "search", "open", "read", "get", "show",
-    "tell", "what", "how", "please",
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "and", "or", "but", "in", "on",
+    "at", "to", "for", "of", "with", "from", "by", "as", "it", "do", "not", "this", "that", "my",
+    "me", "i", "you", "we", "can", "will", "just", "any", "all", "each", "find", "search", "open",
+    "read", "get", "show", "tell", "what", "how", "please",
 ];
 
 fn is_actionable(element_type: &str) -> bool {
@@ -84,13 +126,22 @@ fn extract_quoted_phrases(goal: &str) -> Vec<String> {
 /// Check if the goal is an extraction/reading goal.
 fn is_extraction_goal(goal: &str) -> bool {
     let lower = goal.to_lowercase();
-    lower.contains("extract") || lower.contains("read") || lower.contains("what is")
-        || lower.contains("how many") || lower.contains("find") || lower.contains("list")
+    lower.contains("extract")
+        || lower.contains("read")
+        || lower.contains("what is")
+        || lower.contains("how many")
+        || lower.contains("find")
+        || lower.contains("list")
         || lower.contains("get the")
 }
 
 /// Score a single element's relevance to the goal.
-fn score_element(el: &ContextElement, keywords: &[String], quoted_phrases: &[String], is_extract: bool) -> f64 {
+fn score_element(
+    el: &ContextElement,
+    keywords: &[String],
+    quoted_phrases: &[String],
+    is_extract: bool,
+) -> f64 {
     let mut score: f64 = 0.0;
     let label = el.label.as_deref().unwrap_or("").to_lowercase();
     let value = el.value.as_deref().unwrap_or("").to_lowercase();
@@ -132,15 +183,25 @@ fn score_element(el: &ContextElement, keywords: &[String], quoted_phrases: &[Str
     }
 
     // Actionable boost
-    if is_actionable(&el.element_type) { score += 1.0; }
-    if el.state.visible && el.state.enabled { score += 0.5; }
-    if !el.actions.is_empty() { score += 0.5; }
+    if is_actionable(&el.element_type) {
+        score += 1.0;
+    }
+    if el.state.visible && el.state.enabled {
+        score += 0.5;
+    }
+    if !el.actions.is_empty() {
+        score += 0.5;
+    }
 
     // Content length
     let label_len = el.label.as_ref().map(|l| l.len()).unwrap_or(0);
-    if label_len > 30 { score += 2.0; }
-    else if label_len > 15 { score += 1.0; }
-    else if label_len <= 5 && is_actionable(&el.element_type) { score -= 1.0; }
+    if label_len > 30 {
+        score += 2.0;
+    } else if label_len > 15 {
+        score += 1.0;
+    } else if label_len <= 5 && is_actionable(&el.element_type) {
+        score -= 1.0;
+    }
 
     // Generic action label deprioritization
     if is_generic_label(&label) && is_actionable(&el.element_type) {
@@ -148,7 +209,11 @@ fn score_element(el: &ContextElement, keywords: &[String], quoted_phrases: &[Str
     }
 
     // Chrome noise deprioritization
-    let props_hint = el.properties.get("css_selector").map(|s| s.as_str()).unwrap_or("");
+    let props_hint = el
+        .properties
+        .get("css_selector")
+        .map(|s| s.as_str())
+        .unwrap_or("");
     for kw in CHROME_HINT_KEYWORDS {
         if props_hint.contains(kw) {
             score -= 4.0;
@@ -171,7 +236,9 @@ pub fn distill_for_goal(
 
     if keywords.is_empty() && quoted.is_empty() {
         // No keywords — return actionable elements
-        return context.elements.iter()
+        return context
+            .elements
+            .iter()
             .filter(|el| is_actionable(&el.element_type) || el.id == "page-text")
             .take(max_elements)
             .cloned()
@@ -179,7 +246,9 @@ pub fn distill_for_goal(
     }
 
     // Score all elements
-    let mut scored: Vec<(f64, &ContextElement)> = context.elements.iter()
+    let mut scored: Vec<(f64, &ContextElement)> = context
+        .elements
+        .iter()
         .map(|el| (score_element(el, &keywords, &quoted, is_extract), el))
         .collect();
 
@@ -187,7 +256,8 @@ pub fn distill_for_goal(
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
 
     // Take top elements, ensuring page-text is included
-    let mut result: Vec<ContextElement> = scored.iter()
+    let mut result: Vec<ContextElement> = scored
+        .iter()
         .filter(|(s, _)| *s > 0.0)
         .take(max_elements)
         .map(|(_, el)| (*el).clone())

--- a/cel/cel-planner/src/history.rs
+++ b/cel/cel-planner/src/history.rs
@@ -4,7 +4,6 @@
 /// older steps are summarized into a compact digest instead of being
 /// dropped entirely. This prevents context overflow while preserving
 /// key information (browser-use learned this matters Feb 2026).
-
 use crate::types::{PlannedAction, StepRecord};
 
 /// When total steps exceed this, compact older ones into a summary.
@@ -132,20 +131,33 @@ impl StepHistory {
                 let label = s.element_label.as_deref().unwrap_or("");
                 let action_type = match &s.action {
                     PlannedAction::Click { target_id } => {
-                        if label.is_empty() { format!("clicked {}", target_id) }
-                        else { format!("clicked '{}'", label) }
+                        if label.is_empty() {
+                            format!("clicked {}", target_id)
+                        } else {
+                            format!("clicked '{}'", label)
+                        }
                     }
                     PlannedAction::Type { text, .. } => {
-                        if label.is_empty() { format!("typed \"{}\"", &text[..text.len().min(15)]) }
-                        else { format!("typed '{}' = \"{}\"", label, &text[..text.len().min(15)]) }
+                        if label.is_empty() {
+                            format!("typed \"{}\"", &text[..text.len().min(15)])
+                        } else {
+                            format!("typed '{}' = \"{}\"", label, &text[..text.len().min(15)])
+                        }
                     }
                     PlannedAction::SetValue { value, .. } => {
-                        if label.is_empty() { format!("set \"{}\"", &value[..value.len().min(15)]) }
-                        else { format!("set '{}' = \"{}\"", label, &value[..value.len().min(15)]) }
+                        if label.is_empty() {
+                            format!("set \"{}\"", &value[..value.len().min(15)])
+                        } else {
+                            format!("set '{}' = \"{}\"", label, &value[..value.len().min(15)])
+                        }
                     }
                     _ => format!("{:?}", s.action).chars().take(20).collect(),
                 };
-                if s.success { action_type } else { format!("FAILED: {}", action_type) }
+                if s.success {
+                    action_type
+                } else {
+                    format!("FAILED: {}", action_type)
+                }
             })
             .collect();
 
@@ -199,13 +211,18 @@ mod tests {
         let mut history = StepHistory::new();
         history.record(
             0,
-            PlannedAction::Click { target_id: "btn1".into() },
+            PlannedAction::Click {
+                target_id: "btn1".into(),
+            },
             true,
             None,
         );
         history.record(
             1,
-            PlannedAction::Type { target_id: Some("inp".into()), text: "hello".into() },
+            PlannedAction::Type {
+                target_id: Some("inp".into()),
+                text: "hello".into(),
+            },
             true,
             None,
         );
@@ -220,7 +237,9 @@ mod tests {
         for i in 0..8 {
             history.record(
                 i,
-                PlannedAction::Click { target_id: format!("btn{}", i) },
+                PlannedAction::Click {
+                    target_id: format!("btn{}", i),
+                },
                 true,
                 None,
             );
@@ -236,7 +255,9 @@ mod tests {
         let mut history = StepHistory::new();
         history.record(
             0,
-            PlannedAction::Click { target_id: "btn".into() },
+            PlannedAction::Click {
+                target_id: "btn".into(),
+            },
             true,
             None,
         );
@@ -249,7 +270,9 @@ mod tests {
         let records = vec![
             StepRecord {
                 step_index: 0,
-                action: PlannedAction::Click { target_id: "a".into() },
+                action: PlannedAction::Click {
+                    target_id: "a".into(),
+                },
                 success: true,
                 error: None,
                 element_label: Some("Submit".into()),
@@ -257,7 +280,9 @@ mod tests {
             },
             StepRecord {
                 step_index: 1,
-                action: PlannedAction::Fail { reason: "not found".into() },
+                action: PlannedAction::Fail {
+                    reason: "not found".into(),
+                },
                 success: false,
                 error: Some("Element missing".into()),
                 element_label: None,
@@ -276,9 +301,15 @@ mod tests {
         for i in 0..11 {
             history.record(
                 i,
-                PlannedAction::Click { target_id: format!("btn{}", i) },
+                PlannedAction::Click {
+                    target_id: format!("btn{}", i),
+                },
                 i % 3 != 0, // Every 3rd step fails
-                if i % 3 == 0 { Some(format!("Error at step {}", i)) } else { None },
+                if i % 3 == 0 {
+                    Some(format!("Error at step {}", i))
+                } else {
+                    None
+                },
             );
         }
 
@@ -297,7 +328,9 @@ mod tests {
         for i in 0..15 {
             history.record(
                 i,
-                PlannedAction::Click { target_id: format!("btn{}", i) },
+                PlannedAction::Click {
+                    target_id: format!("btn{}", i),
+                },
                 true,
                 None,
             );
@@ -314,7 +347,9 @@ mod tests {
         for i in 0..11 {
             history.record(
                 i,
-                PlannedAction::Click { target_id: "btn".into() },
+                PlannedAction::Click {
+                    target_id: "btn".into(),
+                },
                 false,
                 Some(format!("Failed: {}", i)),
             );

--- a/cel/cel-planner/src/lib.rs
+++ b/cel/cel-planner/src/lib.rs
@@ -68,15 +68,17 @@ pub use canonical::{
     StepKind, StepResult, SubGoal,
 };
 pub use canonical_plan_producer::{DoneVerdict, PlanProducer};
-pub use llm_plan_producer::{build_user_prompt as build_next_move_user_prompt, LlmPlanProducer, NEXT_MOVE_SYSTEM_PROMPT};
 pub use error::PlannerError;
 pub use history::StepHistory;
+pub use llm_plan_producer::{
+    build_user_prompt as build_next_move_user_prompt, LlmPlanProducer, NEXT_MOVE_SYSTEM_PROMPT,
+};
 pub use planner::{find_blocking_error, validate_grounding, Planner, PlannerBackend};
 pub use prompt::{build_user_prompt, PromptOptions, PromptResult};
 pub use signals::{CortexSignals, LoadingSignal};
 pub use types::{
-    CellWrite, ContextDetail, ContextTier, GoalConfig, NotebookWrite, PlannedAction,
-    PlannedPlan, PlannedStep, PlannerEvent, ProgressAssessment, StepRecord,
+    CellWrite, ContextDetail, ContextTier, GoalConfig, NotebookWrite, PlannedAction, PlannedPlan,
+    PlannedStep, PlannerEvent, ProgressAssessment, StepRecord,
 };
 
 /// Create a planner from environment-configured LLM.

--- a/cel/cel-planner/src/llm_plan_producer.rs
+++ b/cel/cel-planner/src/llm_plan_producer.rs
@@ -391,8 +391,12 @@ fn parse_verify_done_lenient(
         #[serde(default)]
         reason: String,
     }
-    let parsed: Raw =
-        serde_json::from_str(trimmed).map_err(|e| format!("{e} (raw starts: {:?})", &trimmed.chars().take(80).collect::<String>()))?;
+    let parsed: Raw = serde_json::from_str(trimmed).map_err(|e| {
+        format!(
+            "{e} (raw starts: {:?})",
+            &trimmed.chars().take(80).collect::<String>()
+        )
+    })?;
     Ok(crate::canonical_plan_producer::DoneVerdict {
         verified: parsed.verified,
         reason: parsed.reason,
@@ -444,10 +448,7 @@ pub fn build_user_prompt(
     out.push_str("\n## Runtime capabilities\n");
     if caps.cdp_bound {
         let browser = caps.cdp_browser.as_deref().unwrap_or("Chrome");
-        out.push_str(&format!(
-            "  - CDP-controlled browser: {}\n",
-            browser
-        ));
+        out.push_str(&format!("  - CDP-controlled browser: {}\n", browser));
         if let Some(url) = &caps.cdp_url {
             out.push_str(&format!("  - Current page: {}\n", url));
         }
@@ -455,7 +456,7 @@ pub fn build_user_prompt(
             "  - `navigate` and `cdp_eval` dispatch THROUGH THIS BROWSER ONLY.\n  \
              - DO NOT switch to Safari or any other browser. Our CDP is bound\n    \
                to the one named above. Actions on any other browser are blind.\n  \
-             - Prefer `navigate` with a direct URL over typing into a search box.\n"
+             - Prefer `navigate` with a direct URL over typing into a search box.\n",
         );
     } else {
         out.push_str("  - No CDP-controlled browser bound. Skip `cdp_eval` and `navigate`.\n");
@@ -466,7 +467,7 @@ pub fn build_user_prompt(
         out.push_str(
             "  - Native input DISABLED (sandboxed eval mode). `ax_action`,\n    \
                `set_value`, `click`, `key`, `key_combo`, `type`, `activate_app`\n    \
-               will be REFUSED by the runtime — pick cdp_eval-based actions.\n"
+               will be REFUSED by the runtime — pick cdp_eval-based actions.\n",
         );
     }
 
@@ -485,14 +486,14 @@ pub fn build_user_prompt(
                    have into the goal's target surface (spreadsheet, doc, form)\n    \
                    and then emit Done with whatever's been accomplished — even\n    \
                    if partial. Running out of steps without a terminal is a\n    \
-                   worse outcome than a partial Done.\n"
+                   worse outcome than a partial Done.\n",
             );
         } else if remaining <= caps.max_steps / 2 {
             // Midpoint — pivot away from exploration.
             out.push_str(
                 "  - You are past the midpoint. Start folding gathered data into\n    \
                    the goal's target surface. Don't open new threads of work\n    \
-                   unless they're required for the goal.\n"
+                   unless they're required for the goal.\n",
             );
         }
     }
@@ -533,12 +534,7 @@ pub fn build_user_prompt(
         // Fixation guard: if the last several turns produced no new
         // successful actions, tell the LLM to pivot strategy entirely
         // (or emit Fail) rather than iterate on the same approach.
-        let recent_wins = history
-            .iter()
-            .rev()
-            .take(5)
-            .filter(|r| r.succeeded)
-            .count();
+        let recent_wins = history.iter().rev().take(5).filter(|r| r.succeeded).count();
         if history.len() >= 5 && recent_wins == 0 {
             out.push_str(
                 "\n## FIXATION WARNING\n\
@@ -601,7 +597,10 @@ pub fn build_user_prompt(
         out.push_str("\n## Shared memory (data you've extracted)\n");
         out.push_str(&format!(
             "  {}\n",
-            truncate(&serde_json::to_string(shared_memory).unwrap_or_default(), 800)
+            truncate(
+                &serde_json::to_string(shared_memory).unwrap_or_default(),
+                800
+            )
         ));
     }
 
@@ -677,9 +676,9 @@ fn banned_action_strings(history: &[AttemptRecord], limit: usize) -> Vec<String>
 fn is_bannable(action: &crate::types::PlannedAction) -> bool {
     use crate::types::PlannedAction;
     match action {
-        PlannedAction::Key { .. }
-        | PlannedAction::KeyCombo { .. }
-        | PlannedAction::Wait { .. } => false,
+        PlannedAction::Key { .. } | PlannedAction::KeyCombo { .. } | PlannedAction::Wait { .. } => {
+            false
+        }
         PlannedAction::Type { target_id, .. } => target_id.is_some(),
         _ => true,
     }
@@ -723,7 +722,9 @@ fn parse_next_move_lenient(raw: &str) -> Result<NextMove, String> {
     let mv: NextMove = serde_json::from_str(body).map_err(|e| e.to_string())?;
     if let NextMove::Batch { steps, .. } = &mv {
         if steps.is_empty() {
-            return Err("batch has no steps (if done, emit kind=done; if stuck, emit kind=fail)".into());
+            return Err(
+                "batch has no steps (if done, emit kind=done; if stuck, emit kind=fail)".into(),
+            );
         }
     }
     Ok(mv)
@@ -801,7 +802,10 @@ mod tests {
             &RuntimeCaps::default(),
         );
         assert!(out.contains("error=\""));
-        assert!(out.contains("…"), "long error should be truncated with ellipsis");
+        assert!(
+            out.contains("…"),
+            "long error should be truncated with ellipsis"
+        );
     }
 
     fn empty_perception() -> ScreenContext {

--- a/cel/cel-planner/src/llm_plan_producer.rs
+++ b/cel/cel-planner/src/llm_plan_producer.rs
@@ -438,7 +438,7 @@ pub fn build_user_prompt(
     let mut out = String::with_capacity(4096);
     out.push_str("## Goal\n");
     out.push_str(goal.trim());
-    out.push_str("\n");
+    out.push('\n');
 
     // Runtime capabilities block — tells the LLM what tools are
     // actually wired up. This prevents the very common failure mode
@@ -593,7 +593,7 @@ pub fn build_user_prompt(
         }
     }
 
-    if shared_memory.as_object().map_or(false, |o| !o.is_empty()) {
+    if shared_memory.as_object().is_some_and(|o| !o.is_empty()) {
         out.push_str("\n## Shared memory (data you've extracted)\n");
         out.push_str(&format!(
             "  {}\n",
@@ -733,7 +733,7 @@ fn parse_next_move_lenient(raw: &str) -> Result<NextMove, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::canonical::{Step, StepKind};
+    use crate::canonical::StepKind;
     use crate::types::PlannedAction;
 
     #[test]

--- a/cel/cel-planner/src/planner.rs
+++ b/cel/cel-planner/src/planner.rs
@@ -212,6 +212,7 @@ impl Planner {
     /// `&CortexSignals::default()` from callers that don't track them.
     /// `recent_memory` — pre-rendered "## Recent runs" block from the
     /// runner's cross-goal memory (Phase 3B). Pass `""` to skip.
+    #[allow(clippy::too_many_arguments)]
     pub async fn plan_step(
         &self,
         system: &str,
@@ -261,6 +262,7 @@ impl Planner {
     /// No retry logic (vision is already expensive — a parse failure
     /// falls back to the non-vision path on the next step via normal
     /// runner gating).
+    #[allow(clippy::too_many_arguments)]
     pub async fn plan_step_with_vision(
         &self,
         system: &str,

--- a/cel/cel-planner/src/planner.rs
+++ b/cel/cel-planner/src/planner.rs
@@ -8,7 +8,6 @@
 /// - Empty context recovery (retry on sparse/empty screens)
 /// - Loop detection (repeat, ping-pong, stale context)
 /// - Step budget awareness (passed to prompt)
-
 use async_trait::async_trait;
 use cel_context::ScreenContext;
 
@@ -71,10 +70,7 @@ impl Planner {
     /// `cel_goal_runner::CanonicalGoalRunner::run` instead. The body is
     /// preserved verbatim but with loop detection stripped.
     #[deprecated(note = "use cel_goal_runner::CanonicalGoalRunner::run")]
-    pub async fn run(
-        &self,
-        backend: &dyn PlannerBackend,
-    ) -> Result<PlannerEvent, PlannerError> {
+    pub async fn run(&self, backend: &dyn PlannerBackend) -> Result<PlannerEvent, PlannerError> {
         let mut history = StepHistory::new();
         let mut loop_warning: Option<String> = None;
         let mut tentative_plan: Vec<PlannedStep> = Vec::new();
@@ -82,9 +78,7 @@ impl Planner {
 
         for step_index in 0..self.config.max_steps {
             // 1. OBSERVE — get context with empty-context recovery
-            let context = self
-                .get_context_with_retry(backend, step_index)
-                .await?;
+            let context = self.get_context_with_retry(backend, step_index).await?;
 
             // 2. PLAN — try tentative cache first, otherwise call LLM
             let step = if let Some(cached) = tentative_plan.first() {
@@ -95,12 +89,35 @@ impl Planner {
                     s
                 } else {
                     // Context diverged — discard plan and re-plan
-                    tracing::info!(step = step_index, "Context diverged — clearing tentative plan");
+                    tracing::info!(
+                        step = step_index,
+                        "Context diverged — clearing tentative plan"
+                    );
                     tentative_plan.clear();
-                    self.plan_step(&system, &context, &crate::signals::CortexSignals::default(), "", &history, step_index, &loop_warning, backend).await?
+                    self.plan_step(
+                        &system,
+                        &context,
+                        &crate::signals::CortexSignals::default(),
+                        "",
+                        &history,
+                        step_index,
+                        &loop_warning,
+                        backend,
+                    )
+                    .await?
                 }
             } else {
-                self.plan_step(&system, &context, &crate::signals::CortexSignals::default(), "", &history, step_index, &loop_warning, backend).await?
+                self.plan_step(
+                    &system,
+                    &context,
+                    &crate::signals::CortexSignals::default(),
+                    "",
+                    &history,
+                    step_index,
+                    &loop_warning,
+                    backend,
+                )
+                .await?
             };
 
             backend.on_event(PlannerEvent::StepPlanned {
@@ -177,8 +194,7 @@ impl Planner {
             // Loop detection is no longer this loop's concern — the
             // canonical runner surfaces stuck steps via the 3-strike
             // retry rule (see CanonicalGoalRunner).
-            {
-            }
+            {}
 
             // Brief pause to let the UI settle
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -213,11 +229,17 @@ impl Planner {
             loop_warning: loop_warning.as_deref(),
             context_detail: self.config.context_detail,
             cortex_signals: Some(signals),
-            recent_memory: if recent_memory.is_empty() { None } else { Some(recent_memory) },
+            recent_memory: if recent_memory.is_empty() {
+                None
+            } else {
+                Some(recent_memory)
+            },
             ..Default::default()
         };
         let result = prompt::build_user_prompt(&self.config.goal, context, history, &opts);
-        let mut step = self.call_llm_with_retries(system, &result.text, step_index, backend).await?;
+        let mut step = self
+            .call_llm_with_retries(system, &result.text, step_index, backend)
+            .await?;
         // Resolve numbered indices back to real element IDs for the entire step.
         // The Rust goal-runner executes primary + additional actions directly, so
         // all targets must be grounded before the step leaves the planner.
@@ -256,7 +278,11 @@ impl Planner {
             loop_warning: loop_warning.as_deref(),
             context_detail: self.config.context_detail,
             cortex_signals: Some(signals),
-            recent_memory: if recent_memory.is_empty() { None } else { Some(recent_memory) },
+            recent_memory: if recent_memory.is_empty() {
+                None
+            } else {
+                Some(recent_memory)
+            },
             ..Default::default()
         };
         let mut result = prompt::build_user_prompt(&self.config.goal, context, history, &opts);
@@ -272,7 +298,13 @@ impl Planner {
 
         let raw = self
             .llm
-            .complete_with_image(system, image_data_url, &result.text, self.config.max_tokens, None)
+            .complete_with_image(
+                system,
+                image_data_url,
+                &result.text,
+                self.config.max_tokens,
+                None,
+            )
             .await?;
 
         let cleaned = cel_llm::strip_code_fences(&raw);
@@ -297,20 +329,22 @@ impl Planner {
     fn context_matches_expectation(&self, step: &PlannedStep, context: &ScreenContext) -> bool {
         // If the step targets a specific element, check it exists and is interactable
         match &step.action {
-            PlannedAction::Click { target_id }
-            | PlannedAction::AxAction { target_id, .. } => {
+            PlannedAction::Click { target_id } | PlannedAction::AxAction { target_id, .. } => {
                 context
                     .elements
                     .iter()
                     .any(|el| el.id == *target_id && el.state.enabled && el.state.visible)
             }
-            PlannedAction::Type { target_id: Some(target_id), .. } => {
-                context
-                    .elements
-                    .iter()
-                    .any(|el| el.id == *target_id && el.state.enabled && el.state.visible)
-            }
-            PlannedAction::Type { target_id: None, .. } => true,
+            PlannedAction::Type {
+                target_id: Some(target_id),
+                ..
+            } => context
+                .elements
+                .iter()
+                .any(|el| el.id == *target_id && el.state.enabled && el.state.visible),
+            PlannedAction::Type {
+                target_id: None, ..
+            } => true,
             // Non-targeted actions (key, scroll, wait) are always compatible
             _ => true,
         }
@@ -354,11 +388,7 @@ impl Planner {
         unreachable!() // Loop always returns on last retry
     }
 
-    fn validate_grounding(
-        &self,
-        step: &PlannedStep,
-        context: &ScreenContext,
-    ) -> Option<String> {
+    fn validate_grounding(&self, step: &PlannedStep, context: &ScreenContext) -> Option<String> {
         validate_grounding(step, context)
     }
 }
@@ -389,7 +419,10 @@ pub fn validate_grounding(step: &PlannedStep, context: &ScreenContext) -> Option
                 ));
             }
         }
-        PlannedAction::Type { target_id: Some(target_id), .. } => {
+        PlannedAction::Type {
+            target_id: Some(target_id),
+            ..
+        } => {
             let exists = context.elements.iter().any(|el| el.id == *target_id);
             if !exists {
                 let available: Vec<_> = context
@@ -405,17 +438,19 @@ pub fn validate_grounding(step: &PlannedStep, context: &ScreenContext) -> Option
                 ));
             }
         }
-        PlannedAction::Type { target_id: None, .. } => {
+        PlannedAction::Type {
+            target_id: None, ..
+        } => {
             // No target_id means type into focused element — no grounding check needed
         }
-        PlannedAction::Drag { from_target_id, to_target_id } => {
+        PlannedAction::Drag {
+            from_target_id,
+            to_target_id,
+        } => {
             for tid in [from_target_id, to_target_id] {
                 let exists = context.elements.iter().any(|el| el.id == *tid);
                 if !exists {
-                    return Some(format!(
-                        "Drag target '{}' not found in context",
-                        tid,
-                    ));
+                    return Some(format!("Drag target '{}' not found in context", tid,));
                 }
             }
         }
@@ -428,10 +463,7 @@ pub fn validate_grounding(step: &PlannedStep, context: &ScreenContext) -> Option
             }
             for eid in evidence_ids {
                 if !context.elements.iter().any(|el| el.id == *eid) {
-                    return Some(format!(
-                        "Evidence element '{}' not found in context",
-                        eid
-                    ));
+                    return Some(format!("Evidence element '{}' not found in context", eid));
                 }
             }
         }
@@ -445,11 +477,7 @@ pub fn find_blocking_error(context: &ScreenContext) -> Option<String> {
     for event in &context.http_events {
         if let Some(code) = event.status_code {
             if code >= 400 {
-                return Some(format!(
-                    "HTTP {} on {}",
-                    code,
-                    truncate_str(&event.url, 50)
-                ));
+                return Some(format!("HTTP {} on {}", code, truncate_str(&event.url, 50)));
             }
         }
     }
@@ -468,7 +496,6 @@ pub fn find_blocking_error(context: &ScreenContext) -> Option<String> {
 }
 
 impl Planner {
-
     /// Call the LLM with retry logic for parse failures.
     async fn call_llm_with_retries(
         &self,
@@ -482,7 +509,8 @@ impl Planner {
         for attempt in 0..self.config.max_retries {
             // Use temperature 0 on retries for deterministic output
             let raw = if attempt > 0 {
-                self.llm.with_temperature(0.0)
+                self.llm
+                    .with_temperature(0.0)
                     .complete(system_prompt, user_prompt, self.config.max_tokens)
                     .await?
             } else {
@@ -494,17 +522,16 @@ impl Planner {
             let cleaned = cel_llm::strip_code_fences(&raw);
 
             // Try direct parse first, then try to extract JSON from mixed content
-            let parse_result = serde_json::from_str::<PlannedStep>(cleaned)
-                .or_else(|_| {
-                    // Try to find a JSON object within the response
-                    if let Some(start) = cleaned.find('{') {
-                        if let Some(end) = cleaned.rfind('}') {
-                            let json_slice = &cleaned[start..=end];
-                            return serde_json::from_str::<PlannedStep>(json_slice);
-                        }
+            let parse_result = serde_json::from_str::<PlannedStep>(cleaned).or_else(|_| {
+                // Try to find a JSON object within the response
+                if let Some(start) = cleaned.find('{') {
+                    if let Some(end) = cleaned.rfind('}') {
+                        let json_slice = &cleaned[start..=end];
+                        return serde_json::from_str::<PlannedStep>(json_slice);
                     }
-                    serde_json::from_str::<PlannedStep>(cleaned) // return original error
-                });
+                }
+                serde_json::from_str::<PlannedStep>(cleaned) // return original error
+            });
 
             match parse_result {
                 Ok(step) => return Ok(step),
@@ -632,14 +659,18 @@ mod tests {
     #[test]
     fn test_grounding_accepts_valid_click() {
         let ctx = make_context(vec![make_element("btn1", "button", "Submit")]);
-        let step = make_step(PlannedAction::Click { target_id: "btn1".into() });
+        let step = make_step(PlannedAction::Click {
+            target_id: "btn1".into(),
+        });
         assert!(validate_grounding(&step, &ctx).is_none());
     }
 
     #[test]
     fn test_grounding_rejects_missing_click_target() {
         let ctx = make_context(vec![make_element("btn1", "button", "Submit")]);
-        let step = make_step(PlannedAction::Click { target_id: "nonexistent".into() });
+        let step = make_step(PlannedAction::Click {
+            target_id: "nonexistent".into(),
+        });
         let result = validate_grounding(&step, &ctx);
         assert!(result.is_some());
         assert!(result.unwrap().contains("not found in context"));
@@ -690,9 +721,7 @@ mod tests {
 
     #[test]
     fn test_grounding_rejects_done_with_error_element() {
-        let ctx = make_context(vec![
-            make_element("err", "text", "Error: Login failed"),
-        ]);
+        let ctx = make_context(vec![make_element("err", "text", "Error: Login failed")]);
         let step = make_step(PlannedAction::Done {
             summary: "Logged in".into(),
             evidence_ids: vec![],
@@ -707,13 +736,16 @@ mod tests {
         let ctx = make_context(vec![]);
         // Key, scroll, wait don't need target validation
         assert!(validate_grounding(
-            &make_step(PlannedAction::Key { key: "Enter".into() }),
+            &make_step(PlannedAction::Key {
+                key: "Enter".into()
+            }),
             &ctx,
-        ).is_none());
-        assert!(validate_grounding(
-            &make_step(PlannedAction::Scroll { dx: 0, dy: -3 }),
-            &ctx,
-        ).is_none());
+        )
+        .is_none());
+        assert!(
+            validate_grounding(&make_step(PlannedAction::Scroll { dx: 0, dy: -3 }), &ctx,)
+                .is_none()
+        );
     }
 
     // --- Blocking error detection ---
@@ -738,9 +770,7 @@ mod tests {
 
     #[test]
     fn test_find_blocking_error_label() {
-        let ctx = make_context(vec![
-            make_element("err", "div", "Access Denied"),
-        ]);
+        let ctx = make_context(vec![make_element("err", "div", "Access Denied")]);
         let result = find_blocking_error(&ctx);
         assert!(result.is_some());
         assert!(result.unwrap().contains("Access Denied"));
@@ -748,9 +778,7 @@ mod tests {
 
     #[test]
     fn test_no_blocking_error_on_clean_context() {
-        let mut ctx = make_context(vec![
-            make_element("btn", "button", "Submit"),
-        ]);
+        let mut ctx = make_context(vec![make_element("btn", "button", "Submit")]);
         ctx.http_events = vec![HttpEvent {
             url: "https://api.example.com/data".into(),
             method: "GET".into(),

--- a/cel/cel-planner/src/prompt.rs
+++ b/cel/cel-planner/src/prompt.rs
@@ -10,7 +10,6 @@
 /// - Visibility filtering (hidden elements omitted)
 /// - Compact/ActionableOnly context modes
 /// - Loop warning injection
-
 use cel_context::ScreenContext;
 
 use crate::history::StepHistory;
@@ -40,12 +39,12 @@ const DEFAULT_MAX_HISTORY_STEPS: usize = 25;
 /// Task type classification for prompt section selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskType {
-    Navigation,     // "go to", "open", "navigate"
-    Extraction,     // "find", "extract", "what is", "how many", "list"
-    Comparison,     // "compare", "difference", "pricing", "vs"
-    FormFill,       // "fill", "enter", "submit", "register", "sign up"
-    BrowserSearch,  // "search for", "look up", "google", "stock price", URL patterns
-    General,        // everything else
+    Navigation,    // "go to", "open", "navigate"
+    Extraction,    // "find", "extract", "what is", "how many", "list"
+    Comparison,    // "compare", "difference", "pricing", "vs"
+    FormFill,      // "fill", "enter", "submit", "register", "sign up"
+    BrowserSearch, // "search for", "look up", "google", "stock price", URL patterns
+    General,       // everything else
 }
 
 /// Context about the current page state for action filtering.
@@ -53,7 +52,7 @@ pub struct PageState {
     pub has_inputs: bool,
     pub has_links: bool,
     pub has_buttons: bool,
-    pub is_data_page: bool,  // page-text has substantial content
+    pub is_data_page: bool, // page-text has substantial content
     pub element_count: usize,
 }
 
@@ -63,30 +62,60 @@ pub fn detect_task_type(goal: &str) -> TaskType {
 
     // BrowserSearch: goals involving web search, URL navigation, or looking things up online.
     // Must be checked before Extraction (which also matches "find", "what is", etc.).
-    let has_browser_signal = lower.contains("google") || lower.contains("search for")
-        || lower.contains("look up") || lower.contains("stock price")
-        || lower.contains("website") || lower.contains("browse")
-        || lower.contains(".com") || lower.contains(".org") || lower.contains(".gr")
-        || lower.contains(".io") || lower.contains("http");
-    let has_search_intent = lower.contains("search") || lower.contains("find")
-        || lower.contains("what is") || lower.contains("how much")
-        || lower.contains("get the") || lower.contains("show me")
+    let has_browser_signal = lower.contains("google")
+        || lower.contains("search for")
+        || lower.contains("look up")
+        || lower.contains("stock price")
+        || lower.contains("website")
+        || lower.contains("browse")
+        || lower.contains(".com")
+        || lower.contains(".org")
+        || lower.contains(".gr")
+        || lower.contains(".io")
+        || lower.contains("http");
+    let has_search_intent = lower.contains("search")
+        || lower.contains("find")
+        || lower.contains("what is")
+        || lower.contains("how much")
+        || lower.contains("get the")
+        || lower.contains("show me")
         || lower.contains("look up");
     if has_browser_signal && has_search_intent {
         return TaskType::BrowserSearch;
     }
     // Also catch direct URL navigation + extraction patterns
-    if has_browser_signal && (lower.contains("navigate") || lower.contains("go to") || lower.contains("open")) {
+    if has_browser_signal
+        && (lower.contains("navigate") || lower.contains("go to") || lower.contains("open"))
+    {
         return TaskType::BrowserSearch;
     }
 
-    if lower.contains("compare") || lower.contains("difference") || lower.contains("pricing") || lower.contains(" vs ") || lower.contains("versus") {
+    if lower.contains("compare")
+        || lower.contains("difference")
+        || lower.contains("pricing")
+        || lower.contains(" vs ")
+        || lower.contains("versus")
+    {
         TaskType::Comparison
-    } else if lower.contains("fill") || lower.contains("enter") || lower.contains("submit") || lower.contains("register") || lower.contains("sign up") || lower.contains("log in") {
+    } else if lower.contains("fill")
+        || lower.contains("enter")
+        || lower.contains("submit")
+        || lower.contains("register")
+        || lower.contains("sign up")
+        || lower.contains("log in")
+    {
         TaskType::FormFill
     } else if lower.contains("navigate") || lower.contains("go to") || lower.contains("open ") {
         TaskType::Navigation
-    } else if lower.contains("find") || lower.contains("extract") || lower.contains("what is") || lower.contains("how many") || lower.contains("how much") || lower.contains("list ") || lower.contains("show ") || lower.contains("get ") {
+    } else if lower.contains("find")
+        || lower.contains("extract")
+        || lower.contains("what is")
+        || lower.contains("how many")
+        || lower.contains("how much")
+        || lower.contains("list ")
+        || lower.contains("show ")
+        || lower.contains("get ")
+    {
         TaskType::Extraction
     } else {
         TaskType::General
@@ -399,7 +428,9 @@ pub fn build_composable_system_prompt_with_adapters(
     // === [ACTIONS] Section — filtered by page state ===
     prompt.push_str("\n\n## Actions\n");
     // Always include these
-    prompt.push_str("- {\"type\": \"scroll\", \"dx\": 0, \"dy\": -3} — Scroll (negative dy = down)\n");
+    prompt.push_str(
+        "- {\"type\": \"scroll\", \"dx\": 0, \"dy\": -3} — Scroll (negative dy = down)\n",
+    );
     prompt.push_str("- {\"type\": \"done\", \"summary\": \"<ACTUAL DATA from the page>\"} — Task complete. Summary MUST contain the real answer (prices, names, dates, numbers). Never write just \"achieved\".\n");
     prompt.push_str("- {\"type\": \"fail\", \"reason\": \"...\"} — Cannot proceed\n");
     // Browser navigation goes through cdp_eval (set window.location.href).
@@ -408,20 +439,26 @@ pub fn build_composable_system_prompt_with_adapters(
     // cdp_eval for navigation and dropdown selection.
 
     // Conditional actions based on page state
-    let show_click = page_state.map_or(true, |ps| ps.has_links || ps.has_buttons || ps.element_count > 0);
+    let show_click = page_state.map_or(true, |ps| {
+        ps.has_links || ps.has_buttons || ps.element_count > 0
+    });
     let show_type = page_state.map_or(true, |ps| ps.has_inputs || ps.element_count > 0);
-    let show_extract = page_state.map_or(true, |ps| ps.is_data_page) || task_type == TaskType::Extraction;
+    let show_extract =
+        page_state.map_or(true, |ps| ps.is_data_page) || task_type == TaskType::Extraction;
 
     if show_click {
         prompt.push_str("- {\"type\": \"click\", \"target_id\": \"3\"} — Click element [3]\n");
     }
     if show_type {
         prompt.push_str("- {\"type\": \"type\", \"target_id\": \"5\", \"text\": \"hello\"} — Click element then type\n");
-        prompt.push_str("- {\"type\": \"type\", \"text\": \"hello\"} — Type into focused element\n");
+        prompt
+            .push_str("- {\"type\": \"type\", \"text\": \"hello\"} — Type into focused element\n");
         prompt.push_str("- {\"type\": \"set_value\", \"target_id\": \"5\", \"value\": \"Technical Support\"} — Set a text input (when settable=true) OR pick a <select> option. For <select>, `value` may be either the option's underlying value attribute (e.g. \"support\") OR its visible text (e.g. \"Technical Support\"); both are matched case-insensitively. Do NOT click-and-type a select.\n");
     }
     prompt.push_str("- {\"type\": \"key\", \"key\": \"Enter\"} — Press key\n");
-    prompt.push_str("- {\"type\": \"key_combo\", \"keys\": [\"Control\", \"a\"]} — Key combination\n");
+    prompt.push_str(
+        "- {\"type\": \"key_combo\", \"keys\": [\"Control\", \"a\"]} — Key combination\n",
+    );
     if show_extract {
         prompt.push_str("- {\"type\": \"extract\", \"goal\": \"what to read\", \"data\": \"the extracted text as a single string\"} — Extract data from current page. \"data\" MUST be a plain string, never a JSON object or array.\n");
     }
@@ -494,7 +531,8 @@ pub fn system_prompt() -> String {
 /// System prompt for blind mode — no screen context available.
 /// The planner must rely on goal, history, and device baseline alone.
 pub fn system_prompt_blind(device_baseline: &str) -> String {
-    format!(r#"You are a UI automation agent controlling a computer desktop.
+    format!(
+        r#"You are a UI automation agent controlling a computer desktop.
 You do NOT have screen context for this step. Decide your action based on
 the goal, your step history, and the device information below.
 
@@ -542,15 +580,13 @@ CRITICAL: ALWAYS use the EXACT keyboard shortcuts from the Device Baseline above
 PERFORMANCE: Prefer "batch" whenever you have a predictable sequence of 2+ actions. It's MUCH faster.
 Example: {{"type": "batch", "actions": [{{"type": "key_combo", "keys": ["Control", "Space"]}}, {{"type": "type", "text": "Finder"}}, {{"type": "key", "key": "Enter"}}]}}
 
-Respond ONLY with valid JSON."#, device_baseline)
+Respond ONLY with valid JSON."#,
+        device_baseline
+    )
 }
 
 /// Build user prompt for blind mode (no elements table).
-pub fn build_user_prompt_blind(
-    goal: &str,
-    history: &StepHistory,
-    opts: &PromptOptions,
-) -> String {
+pub fn build_user_prompt_blind(goal: &str, history: &StepHistory, opts: &PromptOptions) -> String {
     let mut prompt = String::with_capacity(1024);
 
     // Goal
@@ -561,7 +597,9 @@ pub fn build_user_prompt_blind(
         let remaining = opts.max_steps.saturating_sub(opts.step_index + 1);
         prompt.push_str(&format!(
             "## Budget\nStep {} of {}. {} steps remaining.\n\n",
-            opts.step_index + 1, opts.max_steps, remaining,
+            opts.step_index + 1,
+            opts.max_steps,
+            remaining,
         ));
     }
 
@@ -571,14 +609,23 @@ pub fn build_user_prompt_blind(
     }
 
     // History (recent steps only)
-    let max_hist = if opts.max_history_steps > 0 { opts.max_history_steps } else { DEFAULT_MAX_HISTORY_STEPS };
+    let max_hist = if opts.max_history_steps > 0 {
+        opts.max_history_steps
+    } else {
+        DEFAULT_MAX_HISTORY_STEPS
+    };
     let recent = history.recent(max_hist);
     if !recent.is_empty() {
         prompt.push_str("## Recent Steps\n");
         for entry in recent {
             let status = if entry.success { "OK" } else { "FAILED" };
             let action_json = serde_json::to_string(&entry.action).unwrap_or_default();
-            prompt.push_str(&format!("Step {}: [{}] {}", entry.step_index + 1, status, action_json));
+            prompt.push_str(&format!(
+                "Step {}: [{}] {}",
+                entry.step_index + 1,
+                status,
+                action_json
+            ));
             if let Some(err) = &entry.error {
                 prompt.push_str(&format!(" — Error: {}", err));
             }
@@ -612,7 +659,6 @@ pub struct PromptOptions<'a> {
     pub max_network_events: usize,
 
     // ── Cognitive loop extensions ──────────────────────────────────────
-
     /// Notebook context one-liner (e.g. "SAVED DATA: cheapest=$149, dates=Mar15-17").
     /// Injected after the goal. Empty string = no notebook data.
     pub notebook_context: Option<&'a str>,
@@ -624,7 +670,6 @@ pub struct PromptOptions<'a> {
     pub trail_context: Option<&'a str>,
 
     // ── Phase 3A: Cortex perception signals ────────────────────────────
-
     /// Cortex-derived perception signals (stability, anomalies, vision hint,
     /// model confidence). Surfaces as a "## Perception signals" section when
     /// at least one field is populated. `None` or all-empty → section is
@@ -632,7 +677,6 @@ pub struct PromptOptions<'a> {
     pub cortex_signals: Option<&'a crate::signals::CortexSignals>,
 
     // ── Phase 3B: Cross-goal rolling memory ────────────────────────────
-
     /// Pre-rendered "## Recent runs" block from the runner. Runner builds
     /// this from cel-cortex's `MemoryLenses` (three views: same cortex,
     /// same machine, similar goal_type), so the planner crate stays
@@ -711,7 +755,11 @@ pub fn build_user_prompt(
             opts.max_steps,
             remaining,
         ));
-        let used_pct = if opts.max_steps > 0 { ((opts.step_index + 1) as f64 / opts.max_steps as f64 * 100.0) as u32 } else { 0 };
+        let used_pct = if opts.max_steps > 0 {
+            ((opts.step_index + 1) as f64 / opts.max_steps as f64 * 100.0) as u32
+        } else {
+            0
+        };
         if remaining < 5 {
             prompt.push_str(
                 " URGENT: Running low on steps. Complete the goal now or fail gracefully.",
@@ -764,7 +812,11 @@ pub fn build_user_prompt(
     }
     if let Some(ref audio) = context.audio {
         let muted = if audio.is_muted { ", muted" } else { "" };
-        env_lines.push(format!("Audio: volume {}%{}", (audio.volume * 100.0) as u32, muted));
+        env_lines.push(format!(
+            "Audio: volume {}%{}",
+            (audio.volume * 100.0) as u32,
+            muted
+        ));
     }
     if let Some(ref power) = context.power {
         if let Some(level) = power.battery_level {
@@ -791,9 +843,21 @@ pub fn build_user_prompt(
     }
 
     // Resolve configurable limits (0 = use defaults)
-    let max_elements = if opts.max_elements > 0 { opts.max_elements } else { DEFAULT_MAX_ELEMENTS };
-    let max_history = if opts.max_history_steps > 0 { opts.max_history_steps } else { DEFAULT_MAX_HISTORY_STEPS };
-    let max_network = if opts.max_network_events > 0 { opts.max_network_events } else { 5 };
+    let max_elements = if opts.max_elements > 0 {
+        opts.max_elements
+    } else {
+        DEFAULT_MAX_ELEMENTS
+    };
+    let max_history = if opts.max_history_steps > 0 {
+        opts.max_history_steps
+    } else {
+        DEFAULT_MAX_HISTORY_STEPS
+    };
+    let max_network = if opts.max_network_events > 0 {
+        opts.max_network_events
+    } else {
+        5
+    };
 
     // Separate page-text elements from regular UI elements.
     // Page-text contains the full visible text of the page (up to 4K chars)
@@ -808,7 +872,9 @@ pub fn build_user_prompt(
             if !el.state.visible {
                 // Keep hidden elements that have a description (menu items, dropdowns)
                 // so the LLM knows they exist and can click a trigger to reveal them
-                if el.description.as_deref().unwrap_or("").is_empty() { return false; }
+                if el.description.as_deref().unwrap_or("").is_empty() {
+                    return false;
+                }
             }
             // Extract page-text into separate section — don't include in element table
             if el.id.contains("page-text") || el.id.contains("page_text") {
@@ -845,7 +911,11 @@ pub fn build_user_prompt(
         _ => visible.into_iter().take(max_elements).collect(),
     };
 
-    let total_visible = context.elements.iter().filter(|el| el.state.visible).count();
+    let total_visible = context
+        .elements
+        .iter()
+        .filter(|el| el.state.visible)
+        .count();
 
     // Page statistics summary (inspired by browser-use)
     let mut input_count = 0;
@@ -933,7 +1003,9 @@ pub fn build_user_prompt(
                 children_map: &HashMap<&str, Vec<&str>>,
                 depth: usize,
             ) {
-                let Some(el) = element_map.get(id) else { return };
+                let Some(el) = element_map.get(id) else {
+                    return;
+                };
                 let indent = "\t".repeat(depth);
                 let label = el.label.as_deref().unwrap_or("");
                 let has_actions = !el.actions.is_empty();
@@ -976,22 +1048,36 @@ pub fn build_user_prompt(
                             "input_type" => {
                                 // Show input subtype so LLM knows to click radio/checkbox vs type in text
                                 attrs.push_str(&format!(" type=\"{}\"", val));
-                            },
+                            }
                             "settable" => {
-                                if val == "true" { attrs.push_str(" settable"); }
-                            },
-                            "placeholder" => attrs.push_str(&format!(" placeholder=\"{}\"", truncate(val, 30))),
-                            "label_for" => attrs.push_str(&format!(" for=\"{}\"", truncate(val, 30))),
+                                if val == "true" {
+                                    attrs.push_str(" settable");
+                                }
+                            }
+                            "placeholder" => {
+                                attrs.push_str(&format!(" placeholder=\"{}\"", truncate(val, 30)))
+                            }
+                            "label_for" => {
+                                attrs.push_str(&format!(" for=\"{}\"", truncate(val, 30)))
+                            }
                             "url" => attrs.push_str(&format!(" href=\"{}\"", truncate(val, 50))),
                             "required" => attrs.push_str(" required"),
                             "invalid" => attrs.push_str(" invalid"),
-                            "char_count" => if val != "0" { attrs.push_str(&format!(" chars={}", val)) },
+                            "char_count" => {
+                                if val != "0" {
+                                    attrs.push_str(&format!(" chars={}", val))
+                                }
+                            }
                             "has_popup" => attrs.push_str(" has-popup"),
-                            "role_desc" => attrs.push_str(&format!(" role-desc=\"{}\"", truncate(val, 20))),
+                            "role_desc" => {
+                                attrs.push_str(&format!(" role-desc=\"{}\"", truncate(val, 20)))
+                            }
                             "min_value" => attrs.push_str(&format!(" min=\"{}\"", val)),
                             "max_value" => attrs.push_str(&format!(" max=\"{}\"", val)),
                             "orientation" => attrs.push_str(&format!(" orient=\"{}\"", val)),
-                            "column_headers" => attrs.push_str(&format!(" headers=\"{}\"", truncate(val, 60))),
+                            "column_headers" => {
+                                attrs.push_str(&format!(" headers=\"{}\"", truncate(val, 60)))
+                            }
                             "column_count" => attrs.push_str(&format!(" cols={}", val)),
                             "row_count" => attrs.push_str(&format!(" rows={}", val)),
                             _ => {} // dom_id, document, etc. omitted to save tokens
@@ -1006,7 +1092,9 @@ pub fn build_user_prompt(
                     if !label.is_empty() && label.len() > 2 {
                         prompt.push_str(&format!(
                             "{}<{} label=\"{}\" />\n",
-                            indent, el.element_type, truncate(label, 80)
+                            indent,
+                            el.element_type,
+                            truncate(label, 80)
                         ));
                     }
                 }
@@ -1020,7 +1108,14 @@ pub fn build_user_prompt(
             }
 
             for root_id in &root_ids {
-                render_tree(&mut prompt, &mut index_map, root_id, &element_map, &children_map, 0);
+                render_tree(
+                    &mut prompt,
+                    &mut index_map,
+                    root_id,
+                    &element_map,
+                    &children_map,
+                    0,
+                );
             }
         }
         ContextDetail::Full => {
@@ -1101,16 +1196,29 @@ pub fn build_user_prompt(
                     };
                     prompt.push_str(&format!(
                         "  F{}: [{}] <{}> \"{}\" current=\"{}\" {}\n",
-                        field_idx, i + 1, el.element_type, truncate(label, 40), truncate(current, 20), hint
+                        field_idx,
+                        i + 1,
+                        el.element_type,
+                        truncate(label, 40),
+                        truncate(current, 20),
+                        hint
                     ));
                 }
                 "checkbox" | "radio" | "radio_button" => {
                     field_idx += 1;
                     let label = el.label.as_deref().unwrap_or("(unlabeled)");
-                    let checked = if el.state.checked.unwrap_or(false) { "checked" } else { "unchecked" };
+                    let checked = if el.state.checked.unwrap_or(false) {
+                        "checked"
+                    } else {
+                        "unchecked"
+                    };
                     prompt.push_str(&format!(
                         "  F{}: [{}] <{}> \"{}\" {} → use click\n",
-                        field_idx, i + 1, el.element_type, truncate(label, 40), checked
+                        field_idx,
+                        i + 1,
+                        el.element_type,
+                        truncate(label, 40),
+                        checked
                     ));
                 }
                 _ => {}
@@ -1192,7 +1300,8 @@ pub fn build_user_prompt(
         prompt.push_str("## Previous Steps\n");
         for step in recent {
             let status = if step.success { "OK" } else { "FAILED" };
-            let action_summary = summarize_action_with_label(&step.action, step.element_label.as_deref());
+            let action_summary =
+                summarize_action_with_label(&step.action, step.element_label.as_deref());
             let err = step.error.as_deref().unwrap_or("");
             prompt.push_str(&format!(
                 "{}. [{}] {}",
@@ -1225,7 +1334,10 @@ pub fn build_user_prompt(
     }
 
     prompt.push_str("## Your Next Step\nRespond with ONE action as JSON.\n");
-    PromptResult { text: prompt, index_map }
+    PromptResult {
+        text: prompt,
+        index_map,
+    }
 }
 
 /// Resolve a numbered target_id from an LLM response back to the real element ID.
@@ -1267,7 +1379,10 @@ pub fn resolve_action_indices(action: &mut PlannedAction, index_map: &[String]) 
                 }
             }
         }
-        PlannedAction::Drag { from_target_id, to_target_id } => {
+        PlannedAction::Drag {
+            from_target_id,
+            to_target_id,
+        } => {
             if let Some(real_id) = resolve_index(index_map, from_target_id) {
                 *from_target_id = real_id;
             }
@@ -1342,9 +1457,7 @@ fn render_cortex_signals(s: &crate::signals::CortexSignals) -> String {
         }
     }
     if s.vision_needed {
-        out.push_str(
-            "- Cortex flagged context as sparse — vision fallback may be invoked\n",
-        );
+        out.push_str("- Cortex flagged context as sparse — vision fallback may be invoked\n");
     }
     out
 }
@@ -1380,7 +1493,24 @@ fn format_state(state: &cel_context::ElementState) -> String {
 fn format_properties(props: &std::collections::HashMap<String, String>) -> String {
     let mut parts = Vec::new();
     // Show the most useful properties first, truncated
-    for key in &["placeholder", "label_for", "url", "required", "invalid", "input_type", "settable", "char_count", "has_popup", "role_desc", "min_value", "max_value", "orientation", "column_count", "row_count", "column_headers"] {
+    for key in &[
+        "placeholder",
+        "label_for",
+        "url",
+        "required",
+        "invalid",
+        "input_type",
+        "settable",
+        "char_count",
+        "has_popup",
+        "role_desc",
+        "min_value",
+        "max_value",
+        "orientation",
+        "column_count",
+        "row_count",
+        "column_headers",
+    ] {
         if let Some(val) = props.get(*key) {
             if val == "true" {
                 parts.push(key.to_string());
@@ -1428,31 +1558,52 @@ fn summarize_action_with_label(action: &PlannedAction, label: Option<&str>) -> S
         PlannedAction::SetValue { target_id, value } => {
             format!("set_value {} = {}", lbl(target_id), truncate(value, 20))
         }
-        PlannedAction::Drag { from_target_id, to_target_id } => {
+        PlannedAction::Drag {
+            from_target_id,
+            to_target_id,
+        } => {
             format!("drag {} → {}", from_target_id, to_target_id)
         }
         PlannedAction::Scroll { dx, dy } => format!("scroll({},{})", dx, dy),
         PlannedAction::Wait { ms } => format!("wait({}ms)", ms),
-        PlannedAction::Custom { adapter, action, .. } => {
+        PlannedAction::Custom {
+            adapter, action, ..
+        } => {
             format!("custom({}.{})", adapter, action)
         }
-        PlannedAction::Extract { goal, data } => format!("extract({}): {}", truncate(goal, 20), truncate(data, 40)),
+        PlannedAction::Extract { goal, data } => {
+            format!("extract({}): {}", truncate(goal, 20), truncate(data, 40))
+        }
         PlannedAction::Done { summary, .. } => format!("DONE: {}", truncate(summary, 40)),
         PlannedAction::Fail { reason } => format!("FAIL: {}", truncate(reason, 40)),
         PlannedAction::Act { instruction } => format!("act(\"{}\")", truncate(instruction, 40)),
         PlannedAction::Batch { actions } => {
-            let parts: Vec<String> = actions.iter().map(|a| summarize_action_with_label(a, None)).collect();
+            let parts: Vec<String> = actions
+                .iter()
+                .map(|a| summarize_action_with_label(a, None))
+                .collect();
             format!("batch[{}]", parts.join(", "))
         }
-        PlannedAction::AxAction { target_id, action, .. } => {
+        PlannedAction::AxAction {
+            target_id, action, ..
+        } => {
             format!("ax_action {} ({})", lbl(target_id), action)
         }
         PlannedAction::ActivateApp { app_name } => format!("activate_app({})", app_name),
-        PlannedAction::Select { from_x, from_y, to_x, to_y } => {
+        PlannedAction::Select {
+            from_x,
+            from_y,
+            to_x,
+            to_y,
+        } => {
             format!("select({},{})→({},{})", from_x, from_y, to_x, to_y)
         }
         PlannedAction::CdpEval { expression } => {
-            let expr = if expression.len() > 40 { &expression[..40] } else { expression };
+            let expr = if expression.len() > 40 {
+                &expression[..40]
+            } else {
+                expression
+            };
             format!("cdp_eval(\"{}…\")", expr)
         }
         PlannedAction::Navigate { url } => format!("navigate({})", url),
@@ -1463,7 +1614,9 @@ fn summarize_action_with_label(action: &PlannedAction, label: Option<&str>) -> S
         PlannedAction::ReadCells { app, cell_refs, .. } => {
             format!("read_cells({}, {} cells)", app, cell_refs.len())
         }
-        PlannedAction::ExtractWithFallback { name, selectors, .. } => {
+        PlannedAction::ExtractWithFallback {
+            name, selectors, ..
+        } => {
             format!("extract({}, {} selectors)", name, selectors.len())
         }
     }
@@ -1556,24 +1709,63 @@ mod tests {
 
     #[test]
     fn test_detect_task_type() {
-        assert_eq!(detect_task_type("Compare plans on GitHub"), TaskType::Comparison);
-        assert_eq!(detect_task_type("Compare the price vs competitors"), TaskType::Comparison);
-        assert_eq!(detect_task_type("Fill the registration form"), TaskType::FormFill);
-        assert_eq!(detect_task_type("Submit the contact form"), TaskType::FormFill);
-        assert_eq!(detect_task_type("Navigate to the about page"), TaskType::Navigation);
+        assert_eq!(
+            detect_task_type("Compare plans on GitHub"),
+            TaskType::Comparison
+        );
+        assert_eq!(
+            detect_task_type("Compare the price vs competitors"),
+            TaskType::Comparison
+        );
+        assert_eq!(
+            detect_task_type("Fill the registration form"),
+            TaskType::FormFill
+        );
+        assert_eq!(
+            detect_task_type("Submit the contact form"),
+            TaskType::FormFill
+        );
+        assert_eq!(
+            detect_task_type("Navigate to the about page"),
+            TaskType::Navigation
+        );
         assert_eq!(detect_task_type("Go to settings"), TaskType::Navigation);
         assert_eq!(detect_task_type("Open the dashboard"), TaskType::Navigation);
         assert_eq!(detect_task_type("Find the CEO name"), TaskType::Extraction);
-        assert_eq!(detect_task_type("What is the pricing?"), TaskType::Comparison); // "pricing" triggers Comparison
-        assert_eq!(detect_task_type("What is the CEO's email?"), TaskType::Extraction);
-        assert_eq!(detect_task_type("How many items are listed?"), TaskType::Extraction);
+        assert_eq!(
+            detect_task_type("What is the pricing?"),
+            TaskType::Comparison
+        ); // "pricing" triggers Comparison
+        assert_eq!(
+            detect_task_type("What is the CEO's email?"),
+            TaskType::Extraction
+        );
+        assert_eq!(
+            detect_task_type("How many items are listed?"),
+            TaskType::Extraction
+        );
         assert_eq!(detect_task_type("Do something cool"), TaskType::General);
         // BrowserSearch detection
-        assert_eq!(detect_task_type("Search Google for Apple stock price"), TaskType::BrowserSearch);
-        assert_eq!(detect_task_type("Go to capital.gr and find the stock price"), TaskType::BrowserSearch);
-        assert_eq!(detect_task_type("Look up weather on weather.com"), TaskType::BrowserSearch);
-        assert_eq!(detect_task_type("Search for flights on google.com"), TaskType::BrowserSearch);
-        assert_eq!(detect_task_type("Open https://example.com and get the title"), TaskType::BrowserSearch);
+        assert_eq!(
+            detect_task_type("Search Google for Apple stock price"),
+            TaskType::BrowserSearch
+        );
+        assert_eq!(
+            detect_task_type("Go to capital.gr and find the stock price"),
+            TaskType::BrowserSearch
+        );
+        assert_eq!(
+            detect_task_type("Look up weather on weather.com"),
+            TaskType::BrowserSearch
+        );
+        assert_eq!(
+            detect_task_type("Search for flights on google.com"),
+            TaskType::BrowserSearch
+        );
+        assert_eq!(
+            detect_task_type("Open https://example.com and get the title"),
+            TaskType::BrowserSearch
+        );
     }
 
     #[test]
@@ -1629,11 +1821,8 @@ mod tests {
 
     #[test]
     fn test_composable_prompt_includes_baseline() {
-        let prompt = build_composable_system_prompt(
-            Some("{\"os\": \"macOS\"}"),
-            TaskType::General,
-            None,
-        );
+        let prompt =
+            build_composable_system_prompt(Some("{\"os\": \"macOS\"}"), TaskType::General, None);
         assert!(prompt.contains("## Device Baseline"));
         assert!(prompt.contains("{\"os\": \"macOS\"}"));
     }
@@ -1682,8 +1871,14 @@ mod tests {
 
     #[test]
     fn test_index_resolution() {
-        assert_eq!(resolve_index(&["a".into(), "b".into()], "1"), Some("a".into()));
-        assert_eq!(resolve_index(&["a".into(), "b".into()], "2"), Some("b".into()));
+        assert_eq!(
+            resolve_index(&["a".into(), "b".into()], "1"),
+            Some("a".into())
+        );
+        assert_eq!(
+            resolve_index(&["a".into(), "b".into()], "2"),
+            Some("b".into())
+        );
         assert_eq!(resolve_index(&["a".into()], "3"), None); // Out of range
         assert_eq!(resolve_index(&["a".into()], "0"), None); // 0 is invalid (1-based)
         assert_eq!(resolve_index(&["a".into()], "a11y:19"), None); // Non-numeric fallback
@@ -1692,17 +1887,25 @@ mod tests {
     #[test]
     fn test_resolve_action_indices() {
         let map = vec!["dom:btn1".into(), "dom:input1".into()];
-        let mut action = PlannedAction::Click { target_id: "1".into() };
+        let mut action = PlannedAction::Click {
+            target_id: "1".into(),
+        };
         resolve_action_indices(&mut action, &map);
         match &action {
             PlannedAction::Click { target_id } => assert_eq!(target_id, "dom:btn1"),
             _ => panic!("Wrong variant"),
         }
 
-        let mut type_action = PlannedAction::Type { target_id: Some("2".into()), text: "hi".into() };
+        let mut type_action = PlannedAction::Type {
+            target_id: Some("2".into()),
+            text: "hi".into(),
+        };
         resolve_action_indices(&mut type_action, &map);
         match &type_action {
-            PlannedAction::Type { target_id: Some(tid), .. } => assert_eq!(tid, "dom:input1"),
+            PlannedAction::Type {
+                target_id: Some(tid),
+                ..
+            } => assert_eq!(tid, "dom:input1"),
             _ => panic!("Wrong variant"),
         }
     }
@@ -1823,9 +2026,7 @@ mod tests {
 
     #[test]
     fn test_compact_mode() {
-        let context = make_context(vec![
-            make_element("btn1", "button", "Submit"),
-        ]);
+        let context = make_context(vec![make_element("btn1", "button", "Submit")]);
         let history = StepHistory::new();
         let opts = PromptOptions {
             context_detail: ContextDetail::Compact,
@@ -1900,11 +2101,15 @@ mod tests {
     fn test_summarize_action_variants() {
         // Without label
         assert_eq!(
-            summarize_action(&PlannedAction::Click { target_id: "btn".into() }),
+            summarize_action(&PlannedAction::Click {
+                target_id: "btn".into()
+            }),
             "click btn"
         );
         assert_eq!(
-            summarize_action(&PlannedAction::Key { key: "Enter".into() }),
+            summarize_action(&PlannedAction::Key {
+                key: "Enter".into()
+            }),
             "key(Enter)"
         );
         assert_eq!(
@@ -1917,14 +2122,19 @@ mod tests {
         // With label
         assert_eq!(
             summarize_action_with_label(
-                &PlannedAction::Click { target_id: "btn".into() },
+                &PlannedAction::Click {
+                    target_id: "btn".into()
+                },
                 Some("Submit"),
             ),
             "click 'Submit' (btn)"
         );
         assert_eq!(
             summarize_action_with_label(
-                &PlannedAction::Type { target_id: Some("inp".into()), text: "hello".into() },
+                &PlannedAction::Type {
+                    target_id: Some("inp".into()),
+                    text: "hello".into()
+                },
                 Some("Username"),
             ),
             "type 'Username' (inp) = \"hello\""

--- a/cel/cel-planner/src/prompt.rs
+++ b/cel/cel-planner/src/prompt.rs
@@ -417,7 +417,7 @@ pub fn build_composable_system_prompt_with_adapters(
     prompt.push_str(CORE_SECTION);
 
     // === [DESKTOP] Section — included on macOS ===
-    let is_macos = device_baseline.map_or(false, |b| {
+    let is_macos = device_baseline.is_some_and(|b| {
         let lower = b.to_lowercase();
         lower.contains("macos") || lower.contains("darwin") || lower.contains("mac os")
     });
@@ -439,12 +439,11 @@ pub fn build_composable_system_prompt_with_adapters(
     // cdp_eval for navigation and dropdown selection.
 
     // Conditional actions based on page state
-    let show_click = page_state.map_or(true, |ps| {
-        ps.has_links || ps.has_buttons || ps.element_count > 0
-    });
-    let show_type = page_state.map_or(true, |ps| ps.has_inputs || ps.element_count > 0);
+    let show_click =
+        page_state.is_none_or(|ps| ps.has_links || ps.has_buttons || ps.element_count > 0);
+    let show_type = page_state.is_none_or(|ps| ps.has_inputs || ps.element_count > 0);
     let show_extract =
-        page_state.map_or(true, |ps| ps.is_data_page) || task_type == TaskType::Extraction;
+        page_state.is_none_or(|ps| ps.is_data_page) || task_type == TaskType::Extraction;
 
     if show_click {
         prompt.push_str("- {\"type\": \"click\", \"target_id\": \"3\"} — Click element [3]\n");
@@ -1049,10 +1048,8 @@ pub fn build_user_prompt(
                                 // Show input subtype so LLM knows to click radio/checkbox vs type in text
                                 attrs.push_str(&format!(" type=\"{}\"", val));
                             }
-                            "settable" => {
-                                if val == "true" {
-                                    attrs.push_str(" settable");
-                                }
+                            "settable" if val == "true" => {
+                                attrs.push_str(" settable");
                             }
                             "placeholder" => {
                                 attrs.push_str(&format!(" placeholder=\"{}\"", truncate(val, 30)))
@@ -1063,10 +1060,8 @@ pub fn build_user_prompt(
                             "url" => attrs.push_str(&format!(" href=\"{}\"", truncate(val, 50))),
                             "required" => attrs.push_str(" required"),
                             "invalid" => attrs.push_str(" invalid"),
-                            "char_count" => {
-                                if val != "0" {
-                                    attrs.push_str(&format!(" chars={}", val))
-                                }
+                            "char_count" if val != "0" => {
+                                attrs.push_str(&format!(" chars={}", val))
                             }
                             "has_popup" => attrs.push_str(" has-popup"),
                             "role_desc" => {
@@ -1372,13 +1367,17 @@ pub fn resolve_action_indices(action: &mut PlannedAction, index_map: &[String]) 
                 *target_id = real_id;
             }
         }
-        PlannedAction::Type { target_id, .. } => {
-            if let Some(tid) = target_id {
-                if let Some(real_id) = resolve_index(index_map, tid) {
-                    *tid = real_id;
-                }
+        PlannedAction::Type {
+            target_id: Some(tid),
+            ..
+        } => {
+            if let Some(real_id) = resolve_index(index_map, tid) {
+                *tid = real_id;
             }
         }
+        PlannedAction::Type {
+            target_id: None, ..
+        } => {}
         PlannedAction::Drag {
             from_target_id,
             to_target_id,

--- a/cel/cel-planner/src/types.rs
+++ b/cel/cel-planner/src/types.rs
@@ -256,9 +256,9 @@ where
     match value {
         serde_json::Value::Array(arr) => Ok(arr
             .into_iter()
-            .filter_map(|v| match v {
-                serde_json::Value::String(s) => Some(s),
-                other => Some(other.to_string()),
+            .map(|v| match v {
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
             })
             .collect()),
         serde_json::Value::String(s) => Ok(s
@@ -737,6 +737,7 @@ mod target_ids_tests {
 
 /// Events emitted during the planning loop for observability.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum PlannerEvent {
     /// A step was planned.
     StepPlanned { step_index: u32, step: PlannedStep },

--- a/cel/cel-planner/src/types.rs
+++ b/cel/cel-planner/src/types.rs
@@ -1,5 +1,4 @@
 /// Core types for the CEL planner.
-
 use serde::{Deserialize, Deserializer, Serialize};
 
 // ─── Cognitive Loop Extensions ──────────────────────────────────────────────
@@ -130,7 +129,6 @@ pub struct PlannedStep {
     pub context_tier: ContextTier,
 
     // ── Cognitive loop extensions ──────────────────────────────────────────
-
     /// Free-form internal monologue. Replaces evaluation+memory+reasoning
     /// when present. Contains the LLM's narration of what it sees and why.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -256,15 +254,18 @@ where
 {
     let value = serde_json::Value::deserialize(deserializer)?;
     match value {
-        serde_json::Value::Array(arr) => {
-            Ok(arr.into_iter().filter_map(|v| match v {
+        serde_json::Value::Array(arr) => Ok(arr
+            .into_iter()
+            .filter_map(|v| match v {
                 serde_json::Value::String(s) => Some(s),
                 other => Some(other.to_string()),
-            }).collect())
-        }
-        serde_json::Value::String(s) => {
-            Ok(s.lines().map(|l| l.trim().to_string()).filter(|l| !l.is_empty()).collect())
-        }
+            })
+            .collect()),
+        serde_json::Value::String(s) => Ok(s
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect()),
         serde_json::Value::Null => Ok(vec![]),
         _ => Ok(vec![value.to_string()]),
     }
@@ -560,16 +561,19 @@ impl PlannedAction {
             Self::Click { target_id }
             | Self::SetValue { target_id, .. }
             | Self::AxAction { target_id, .. } => vec![target_id.as_str()],
-            Self::Type { target_id: Some(id), .. } => vec![id.as_str()],
+            Self::Type {
+                target_id: Some(id),
+                ..
+            } => vec![id.as_str()],
             Self::Drag {
                 from_target_id,
                 to_target_id,
             } => vec![from_target_id.as_str(), to_target_id.as_str()],
-            Self::Batch { actions } => {
-                actions.iter().flat_map(|a| a.target_ids()).collect()
-            }
+            Self::Batch { actions } => actions.iter().flat_map(|a| a.target_ids()).collect(),
             // No element-level targets:
-            Self::Type { target_id: None, .. }
+            Self::Type {
+                target_id: None, ..
+            }
             | Self::Key { .. }
             | Self::KeyCombo { .. }
             | Self::Scroll { .. }
@@ -625,7 +629,9 @@ mod target_ids_tests {
     fn batch_flattens_sub_action_targets() {
         let a = PlannedAction::Batch {
             actions: vec![
-                PlannedAction::CdpEval { expression: "1".into() },
+                PlannedAction::CdpEval {
+                    expression: "1".into(),
+                },
                 PlannedAction::Click {
                     target_id: "a11y:ghost".into(),
                 },
@@ -652,9 +658,11 @@ mod target_ids_tests {
 
     #[test]
     fn cdp_eval_and_terminals_have_no_targets() {
-        assert!(PlannedAction::CdpEval { expression: "x".into() }
-            .target_ids()
-            .is_empty());
+        assert!(PlannedAction::CdpEval {
+            expression: "x".into()
+        }
+        .target_ids()
+        .is_empty());
         assert!(PlannedAction::Done {
             summary: "ok".into(),
             evidence_ids: vec![]
@@ -672,7 +680,11 @@ mod target_ids_tests {
             "parse_as":"float"}"#;
         let a: PlannedAction = serde_json::from_str(raw).unwrap();
         match &a {
-            PlannedAction::ExtractWithFallback { name, selectors, parse_as } => {
+            PlannedAction::ExtractWithFallback {
+                name,
+                selectors,
+                parse_as,
+            } => {
                 assert_eq!(name, "btc_price");
                 assert_eq!(selectors.len(), 2);
                 assert_eq!(parse_as, "float");
@@ -727,10 +739,7 @@ mod target_ids_tests {
 #[derive(Debug, Clone)]
 pub enum PlannerEvent {
     /// A step was planned.
-    StepPlanned {
-        step_index: u32,
-        step: PlannedStep,
-    },
+    StepPlanned { step_index: u32, step: PlannedStep },
     /// A step was executed (caller reports success/failure).
     StepExecuted {
         step_index: u32,
@@ -738,15 +747,9 @@ pub enum PlannerEvent {
         error: Option<String>,
     },
     /// The goal was achieved.
-    GoalAchieved {
-        summary: String,
-        total_steps: u32,
-    },
+    GoalAchieved { summary: String, total_steps: u32 },
     /// The planner failed to achieve the goal.
-    GoalFailed {
-        reason: String,
-        total_steps: u32,
-    },
+    GoalFailed { reason: String, total_steps: u32 },
     /// LLM returned unparseable output (will retry).
     ParseRetry {
         step_index: u32,
@@ -760,15 +763,9 @@ pub enum PlannerEvent {
         retry_attempt: u32,
     },
     /// Grounding validation failed (element ID not in context or blocking error).
-    GroundingRejected {
-        step_index: u32,
-        reason: String,
-    },
+    GroundingRejected { step_index: u32, reason: String },
     /// Loop detected in agent behaviour.
-    LoopDetected {
-        step_index: u32,
-        signal: String,
-    },
+    LoopDetected { step_index: u32, signal: String },
 }
 
 /// Result of a single step in the history.
@@ -832,7 +829,10 @@ mod tests {
         let json = serde_json::to_string(&action).unwrap();
         let parsed: PlannedAction = serde_json::from_str(&json).unwrap();
         match parsed {
-            PlannedAction::Done { summary, evidence_ids } => {
+            PlannedAction::Done {
+                summary,
+                evidence_ids,
+            } => {
                 assert_eq!(summary, "Login successful");
                 assert_eq!(evidence_ids, vec!["dom:welcome-banner"]);
             }
@@ -846,7 +846,10 @@ mod tests {
         let json = r#"{"type":"done","summary":"All done"}"#;
         let parsed: PlannedAction = serde_json::from_str(json).unwrap();
         match parsed {
-            PlannedAction::Done { summary, evidence_ids } => {
+            PlannedAction::Done {
+                summary,
+                evidence_ids,
+            } => {
                 assert_eq!(summary, "All done");
                 assert!(evidence_ids.is_empty());
             }
@@ -904,10 +907,19 @@ mod tests {
     #[test]
     fn test_all_action_variants_serialize() {
         let actions = vec![
-            PlannedAction::Click { target_id: "btn".into() },
-            PlannedAction::Type { target_id: Some("inp".into()), text: "hi".into() },
-            PlannedAction::Key { key: "Enter".into() },
-            PlannedAction::KeyCombo { keys: vec!["Ctrl".into(), "S".into()] },
+            PlannedAction::Click {
+                target_id: "btn".into(),
+            },
+            PlannedAction::Type {
+                target_id: Some("inp".into()),
+                text: "hi".into(),
+            },
+            PlannedAction::Key {
+                key: "Enter".into(),
+            },
+            PlannedAction::KeyCombo {
+                keys: vec!["Ctrl".into(), "S".into()],
+            },
             PlannedAction::Scroll { dx: 0, dy: -3 },
             PlannedAction::Wait { ms: 1000 },
             PlannedAction::Custom {
@@ -915,9 +927,16 @@ mod tests {
                 action: "navigate".into(),
                 params: serde_json::json!({"url": "https://example.com"}),
             },
-            PlannedAction::Act { instruction: "click the search button".into() },
-            PlannedAction::Done { summary: "Done!".into(), evidence_ids: vec!["el1".into()] },
-            PlannedAction::Fail { reason: "Not found".into() },
+            PlannedAction::Act {
+                instruction: "click the search button".into(),
+            },
+            PlannedAction::Done {
+                summary: "Done!".into(),
+                evidence_ids: vec!["el1".into()],
+            },
+            PlannedAction::Fail {
+                reason: "Not found".into(),
+            },
         ];
 
         for action in actions {
@@ -925,7 +944,11 @@ mod tests {
             let parsed: PlannedAction = serde_json::from_str(&json).unwrap();
             // Verify type field is present in JSON
             let obj: serde_json::Value = serde_json::from_str(&json).unwrap();
-            assert!(obj.get("type").is_some(), "Missing 'type' field in: {}", json);
+            assert!(
+                obj.get("type").is_some(),
+                "Missing 'type' field in: {}",
+                json
+            );
             // Verify roundtrip doesn't panic
             let _ = serde_json::to_string(&parsed).unwrap();
         }
@@ -938,7 +961,11 @@ mod tests {
         let json = r#"{"type":"notebook_writes","key":"price","value":"$149","category":"data"}"#;
         let parsed: PlannedAction = serde_json::from_str(json).unwrap();
         match parsed {
-            PlannedAction::NotebookWrites { key, value, category } => {
+            PlannedAction::NotebookWrites {
+                key,
+                value,
+                category,
+            } => {
                 assert_eq!(key, "price");
                 assert_eq!(value, "$149");
                 assert_eq!(category, "data");
@@ -961,7 +988,10 @@ mod tests {
             "batch_next": true
         }"#;
         let step: PlannedStep = serde_json::from_str(json).unwrap();
-        assert_eq!(step.thinking.as_deref(), Some("I see a search form with destination and date fields."));
+        assert_eq!(
+            step.thinking.as_deref(),
+            Some("I see a search form with destination and date fields.")
+        );
         assert_eq!(step.progress.as_deref(), Some("on_track"));
         assert_eq!(step.notebook_writes.len(), 1);
         assert_eq!(step.notebook_writes[0].key, "destination");

--- a/cel/cel-planner/tests/planner_integration.rs
+++ b/cel/cel-planner/tests/planner_integration.rs
@@ -3,6 +3,7 @@
 //! These tests verify the full parse→plan→step pipeline without network calls.
 //! The mock LLM returns canned JSON responses, exercising the real prompt
 //! builder, JSON parser, and step validator.
+#![allow(deprecated)]
 
 use async_trait::async_trait;
 use cel_context::ScreenContext;

--- a/cel/cel-planner/tests/planner_integration.rs
+++ b/cel/cel-planner/tests/planner_integration.rs
@@ -4,10 +4,10 @@
 //! The mock LLM returns canned JSON responses, exercising the real prompt
 //! builder, JSON parser, and step validator.
 
-use cel_llm::LlmClient;
-use cel_planner::{GoalConfig, Planner, PlannerBackend, PlannerError, PlannerEvent, PlannedAction};
-use cel_context::ScreenContext;
 use async_trait::async_trait;
+use cel_context::ScreenContext;
+use cel_llm::LlmClient;
+use cel_planner::{GoalConfig, PlannedAction, Planner, PlannerBackend, PlannerError, PlannerEvent};
 
 // ─── Minimal PlannerBackend for tests ────────────────────────────────────────
 
@@ -81,7 +81,8 @@ async fn test_planner_mock_done_immediately() {
     let result = planner.run(&backend).await.unwrap();
     assert!(
         matches!(result, PlannerEvent::GoalAchieved { .. }),
-        "expected GoalAchieved, got {:?}", result
+        "expected GoalAchieved, got {:?}",
+        result
     );
 }
 

--- a/cel/cel-planner/tests/prompt_capture.rs
+++ b/cel/cel-planner/tests/prompt_capture.rs
@@ -77,10 +77,7 @@ impl PlannerBackend for NoopBackend {
     async fn get_context(&self) -> Result<ScreenContext, PlannerError> {
         Ok(empty_context())
     }
-    async fn execute(
-        &self,
-        _action: &cel_planner::PlannedAction,
-    ) -> Result<bool, PlannerError> {
+    async fn execute(&self, _action: &cel_planner::PlannedAction) -> Result<bool, PlannerError> {
         Ok(true)
     }
     fn on_event(&self, _event: PlannerEvent) {}
@@ -292,10 +289,14 @@ async fn vision_path_sends_image_and_ground_truth_hint() {
         .expect("expected user-role message");
 
     // (a) image part survived
-    let has_image = user_msg.content.iter().any(|p| {
-        matches!(p, ContentPart::ImageUrl { image_url } if image_url.url == fake_image)
-    });
-    assert!(has_image, "expected ImageUrl ContentPart with the supplied data URL");
+    let has_image = user_msg
+        .content
+        .iter()
+        .any(|p| matches!(p, ContentPart::ImageUrl { image_url } if image_url.url == fake_image));
+    assert!(
+        has_image,
+        "expected ImageUrl ContentPart with the supplied data URL"
+    );
 
     // (b) text part carries the ground-truth hint
     let text_body = user_msg

--- a/cel/cel-signals/src/active_app.rs
+++ b/cel/cel-signals/src/active_app.rs
@@ -69,7 +69,9 @@ fn get_active_window_name() -> Option<String> {
     if !wid_output.status.success() {
         return None;
     }
-    let wid = String::from_utf8_lossy(&wid_output.stdout).trim().to_string();
+    let wid = String::from_utf8_lossy(&wid_output.stdout)
+        .trim()
+        .to_string();
     if wid.is_empty() {
         return None;
     }
@@ -101,7 +103,9 @@ fn get_active_window_name() -> Option<String> {
         .output()
         .ok()?;
     if name_output.status.success() {
-        let name = String::from_utf8_lossy(&name_output.stdout).trim().to_string();
+        let name = String::from_utf8_lossy(&name_output.stdout)
+            .trim()
+            .to_string();
         if !name.is_empty() {
             return Some(name);
         }
@@ -180,12 +184,10 @@ fn list_apps_xdotool() -> Option<Vec<RunningApp>> {
             .output()
             .ok();
         let pid: u32 = match pid_output {
-            Some(o) if o.status.success() => {
-                String::from_utf8_lossy(&o.stdout)
-                    .trim()
-                    .parse()
-                    .unwrap_or(0)
-            }
+            Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .parse()
+                .unwrap_or(0),
             _ => 0,
         };
 
@@ -224,7 +226,9 @@ fn list_apps_xdotool() -> Option<Vec<RunningApp>> {
 fn list_running_apps_macos() -> Vec<RunningApp> {
     // Get app names and frontmost status in a single osascript call
     let output = std::process::Command::new("osascript")
-        .args(["-e", r#"
+        .args([
+            "-e",
+            r#"
             tell application "System Events"
                 set frontName to name of first process whose frontmost is true
                 set appNames to name of every process whose background only is false
@@ -234,7 +238,8 @@ fn list_running_apps_macos() -> Vec<RunningApp> {
                 end repeat
                 return output
             end tell
-        "#])
+        "#,
+        ])
         .output()
         .ok();
 
@@ -248,7 +253,9 @@ fn list_running_apps_macos() -> Vec<RunningApp> {
             let parts: Vec<&str> = line.split("||").collect();
             if parts.len() >= 2 {
                 let name = parts[0].trim().to_string();
-                if name.is_empty() { return None; }
+                if name.is_empty() {
+                    return None;
+                }
                 Some(RunningApp {
                     name,
                     is_frontmost: parts[1].trim() == "true",

--- a/cel/cel-signals/src/audio.rs
+++ b/cel/cel-signals/src/audio.rs
@@ -108,7 +108,10 @@ mod tests {
 
     #[test]
     fn test_audio_state_serialization() {
-        let state = AudioState { volume: 0.75, is_muted: false };
+        let state = AudioState {
+            volume: 0.75,
+            is_muted: false,
+        };
         let json = serde_json::to_string(&state).unwrap();
         let back: AudioState = serde_json::from_str(&json).unwrap();
         assert!((back.volume - 0.75).abs() < 0.01);

--- a/cel/cel-signals/src/clipboard.rs
+++ b/cel/cel-signals/src/clipboard.rs
@@ -62,7 +62,10 @@ fn read_clipboard_macos() -> Option<ClipboardState> {
 
     // Check for image/file types via osascript (lightweight check)
     let type_check = std::process::Command::new("osascript")
-        .args(["-e", "tell application \"System Events\" to return (the clipboard info)"])
+        .args([
+            "-e",
+            "tell application \"System Events\" to return (the clipboard info)",
+        ])
         .output()
         .ok();
 
@@ -77,7 +80,8 @@ fn read_clipboard_macos() -> Option<ClipboardState> {
         })
         .unwrap_or_default();
 
-    let has_image = info_str.contains("tiff") || info_str.contains("png") || info_str.contains("jpeg");
+    let has_image =
+        info_str.contains("tiff") || info_str.contains("png") || info_str.contains("jpeg");
     let has_files = info_str.contains("file url");
 
     Some(ClipboardState {
@@ -90,32 +94,34 @@ fn read_clipboard_macos() -> Option<ClipboardState> {
 #[cfg(target_os = "linux")]
 fn read_clipboard_linux() -> Option<ClipboardState> {
     // Try xclip first, then xsel, then wl-paste (Wayland)
-    let text = ["xclip", "xsel", "wl-paste"]
-        .iter()
-        .find_map(|cmd| {
-            let mut command = std::process::Command::new(cmd);
-            if *cmd == "xclip" {
-                command.args(["-selection", "clipboard", "-o"]);
-            } else if *cmd == "xsel" {
-                command.args(["--clipboard", "--output"]);
-            }
-            command.output().ok().and_then(|out| {
-                if out.status.success() {
-                    let s = String::from_utf8_lossy(&out.stdout).to_string();
-                    if s.is_empty() { None } else {
-                        Some(if s.len() > 500 {
-                            let mut end = 500;
-                            while end > 0 && !s.is_char_boundary(end) { end -= 1; }
-                            format!("{}...", &s[..end])
-                        } else {
-                            s
-                        })
-                    }
-                } else {
+    let text = ["xclip", "xsel", "wl-paste"].iter().find_map(|cmd| {
+        let mut command = std::process::Command::new(cmd);
+        if *cmd == "xclip" {
+            command.args(["-selection", "clipboard", "-o"]);
+        } else if *cmd == "xsel" {
+            command.args(["--clipboard", "--output"]);
+        }
+        command.output().ok().and_then(|out| {
+            if out.status.success() {
+                let s = String::from_utf8_lossy(&out.stdout).to_string();
+                if s.is_empty() {
                     None
+                } else {
+                    Some(if s.len() > 500 {
+                        let mut end = 500;
+                        while end > 0 && !s.is_char_boundary(end) {
+                            end -= 1;
+                        }
+                        format!("{}...", &s[..end])
+                    } else {
+                        s
+                    })
                 }
-            })
-        });
+            } else {
+                None
+            }
+        })
+    });
 
     Some(ClipboardState {
         text,

--- a/cel/cel-signals/src/gesture.rs
+++ b/cel/cel-signals/src/gesture.rs
@@ -74,7 +74,8 @@ impl GestureObserver {
     pub fn stop(&self) {
         #[cfg(target_os = "macos")]
         {
-            self.running.store(false, std::sync::atomic::Ordering::Relaxed);
+            self.running
+                .store(false, std::sync::atomic::Ordering::Relaxed);
         }
     }
 }
@@ -118,9 +119,9 @@ mod macos_ffi {
     #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {
         pub fn CGEventTapCreate(
-            tap: u32,          // CGEventTapLocation
-            place: u32,        // CGEventTapPlacement
-            options: u32,      // CGEventTapOptions
+            tap: u32,     // CGEventTapLocation
+            place: u32,   // CGEventTapPlacement
+            options: u32, // CGEventTapOptions
             events_of_interest: CGEventMask,
             callback: CGEventTapCallBack,
             user_info: *mut c_void,
@@ -178,7 +179,9 @@ unsafe extern "C" fn gesture_callback(
         }
         K_CG_EVENT_ROTATE => {
             let angle = CGEventGetDoubleValueField(event, K_CG_GESTURE_ROTATION);
-            Some(GestureEvent::Rotate { angle_degrees: angle })
+            Some(GestureEvent::Rotate {
+                angle_degrees: angle,
+            })
         }
         K_CG_EVENT_SMART_MAGNIFY => Some(GestureEvent::SmartZoom),
         _ => None,
@@ -197,10 +200,7 @@ unsafe extern "C" fn gesture_callback(
 }
 
 #[cfg(target_os = "macos")]
-fn macos_gesture_tap(
-    buffer: GestureBuffer,
-    running: Arc<std::sync::atomic::AtomicBool>,
-) {
+fn macos_gesture_tap(buffer: GestureBuffer, running: Arc<std::sync::atomic::AtomicBool>) {
     use macos_ffi::*;
     use std::ffi::c_void;
 
@@ -216,9 +216,9 @@ fn macos_gesture_tap(
 
     let tap = unsafe {
         CGEventTapCreate(
-            0,  // kCGSessionEventTap
-            0,  // kCGHeadInsertEventTap
-            1,  // kCGEventTapOptionListenOnly (passive — don't modify events)
+            0, // kCGSessionEventTap
+            0, // kCGHeadInsertEventTap
+            1, // kCGEventTapOptionListenOnly (passive — don't modify events)
             mask,
             gesture_callback,
             buffer_ptr,
@@ -228,7 +228,9 @@ fn macos_gesture_tap(
     if tap.is_null() {
         tracing::warn!("Failed to create gesture event tap — need accessibility permission");
         // Reclaim the leaked Arc
-        unsafe { let _ = Arc::from_raw(buffer_ptr as *const Mutex<Vec<GestureEvent>>); }
+        unsafe {
+            let _ = Arc::from_raw(buffer_ptr as *const Mutex<Vec<GestureEvent>>);
+        }
         return;
     }
 
@@ -267,10 +269,18 @@ mod tests {
     fn test_gesture_event_serialization() {
         let events = vec![
             GestureEvent::PinchZoom { scale: 1.5 },
-            GestureEvent::Swipe { direction: "left".into(), finger_count: 2 },
-            GestureEvent::Rotate { angle_degrees: 45.0 },
+            GestureEvent::Swipe {
+                direction: "left".into(),
+                finger_count: 2,
+            },
+            GestureEvent::Rotate {
+                angle_degrees: 45.0,
+            },
             GestureEvent::SmartZoom,
-            GestureEvent::MomentumScroll { dx: 0.0, dy: -120.0 },
+            GestureEvent::MomentumScroll {
+                dx: 0.0,
+                dy: -120.0,
+            },
         ];
         for event in &events {
             let json = serde_json::to_string(event).unwrap();

--- a/cel/cel-signals/src/power.rs
+++ b/cel/cel-signals/src/power.rs
@@ -51,21 +51,19 @@ fn read_power_macos() -> Option<PowerState> {
         .lines()
         .find(|l| l.contains("InternalBattery"))
         .and_then(|line| {
-            line.split('%')
-                .next()
-                .and_then(|before_pct| {
-                    before_pct
-                        .chars()
-                        .rev()
-                        .take_while(|c| c.is_ascii_digit())
-                        .collect::<String>()
-                        .chars()
-                        .rev()
-                        .collect::<String>()
-                        .parse::<f32>()
-                        .ok()
-                        .map(|v| v / 100.0)
-                })
+            line.split('%').next().and_then(|before_pct| {
+                before_pct
+                    .chars()
+                    .rev()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect::<String>()
+                    .chars()
+                    .rev()
+                    .collect::<String>()
+                    .parse::<f32>()
+                    .ok()
+                    .map(|v| v / 100.0)
+            })
         });
 
     let is_charging = text.contains("charging") && !text.contains("discharging");

--- a/cel/cel-signals/src/window_list.rs
+++ b/cel/cel-signals/src/window_list.rs
@@ -144,9 +144,7 @@ fn list_windows_xdotool() -> Option<Vec<WindowState>> {
             .output()
             .ok();
         let title = match name_output {
-            Some(o) if o.status.success() => {
-                String::from_utf8_lossy(&o.stdout).trim().to_string()
-            }
+            Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
             _ => String::new(),
         };
 
@@ -156,12 +154,10 @@ fn list_windows_xdotool() -> Option<Vec<WindowState>> {
             .output()
             .ok();
         let pid: u32 = match pid_output {
-            Some(o) if o.status.success() => {
-                String::from_utf8_lossy(&o.stdout)
-                    .trim()
-                    .parse()
-                    .unwrap_or(0)
-            }
+            Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .parse()
+                .unwrap_or(0),
             _ => 0,
         };
 
@@ -195,13 +191,13 @@ fn list_windows_xdotool() -> Option<Vec<WindowState>> {
 
 #[cfg(target_os = "macos")]
 fn list_windows_macos() -> Vec<WindowState> {
+    use core_foundation::array::CFArray;
+    use core_foundation::base::TCFType;
+    use core_foundation::dictionary::CFDictionary;
     use core_graphics::display::{
         kCGNullWindowID, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly,
         CGWindowListCopyWindowInfo,
     };
-    use core_foundation::array::CFArray;
-    use core_foundation::base::TCFType;
-    use core_foundation::dictionary::CFDictionary;
 
     let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
     let window_list = unsafe { CGWindowListCopyWindowInfo(options, kCGNullWindowID) };
@@ -220,9 +216,7 @@ fn list_windows_macos() -> Vec<WindowState> {
         if ptr.is_null() {
             continue;
         }
-        let dict: CFDictionary = unsafe {
-            CFDictionary::wrap_under_get_rule(ptr as *const _)
-        };
+        let dict: CFDictionary = unsafe { CFDictionary::wrap_under_get_rule(ptr as *const _) };
 
         let app_name = get_dict_string(&dict, "kCGWindowOwnerName").unwrap_or_default();
         let title = get_dict_string(&dict, "kCGWindowName").unwrap_or_default();
@@ -231,8 +225,8 @@ fn list_windows_macos() -> Vec<WindowState> {
         let on_screen = get_dict_i32(&dict, "kCGWindowIsOnscreen").unwrap_or(0) != 0;
 
         // Get bounds from kCGWindowBounds dictionary
-        let (x, y, width, height) = get_dict_bounds(&dict, "kCGWindowBounds")
-            .unwrap_or((0, 0, 0, 0));
+        let (x, y, width, height) =
+            get_dict_bounds(&dict, "kCGWindowBounds").unwrap_or((0, 0, 0, 0));
 
         // Skip windows with no name and no meaningful bounds (menu bar items, system UI)
         if app_name.is_empty() && title.is_empty() {
@@ -259,10 +253,7 @@ fn list_windows_macos() -> Vec<WindowState> {
 }
 
 #[cfg(target_os = "macos")]
-fn get_dict_string(
-    dict: &core_foundation::dictionary::CFDictionary,
-    key: &str,
-) -> Option<String> {
+fn get_dict_string(dict: &core_foundation::dictionary::CFDictionary, key: &str) -> Option<String> {
     use core_foundation::base::TCFType;
     use core_foundation::string::CFString;
 
@@ -279,17 +270,18 @@ fn get_dict_string(
             CFString::wrap_under_get_rule(cf_ref as core_foundation::string::CFStringRef)
         };
         let result = s.to_string();
-        if result.is_empty() { None } else { Some(result) }
+        if result.is_empty() {
+            None
+        } else {
+            Some(result)
+        }
     } else {
         None
     }
 }
 
 #[cfg(target_os = "macos")]
-fn get_dict_i32(
-    dict: &core_foundation::dictionary::CFDictionary,
-    key: &str,
-) -> Option<i32> {
+fn get_dict_i32(dict: &core_foundation::dictionary::CFDictionary, key: &str) -> Option<i32> {
     use core_foundation::base::TCFType;
     use core_foundation::number::CFNumber;
     use core_foundation::string::CFString;
@@ -328,9 +320,8 @@ fn get_dict_bounds(
         return None;
     }
 
-    let bounds_dict: CFDictionary = unsafe {
-        CFDictionary::wrap_under_get_rule(cf_ref as *const _)
-    };
+    let bounds_dict: CFDictionary =
+        unsafe { CFDictionary::wrap_under_get_rule(cf_ref as *const _) };
 
     let x = get_dict_i32(&bounds_dict, "X").unwrap_or(0);
     let y = get_dict_i32(&bounds_dict, "Y").unwrap_or(0);

--- a/cel/cel-store/src/filesystem.rs
+++ b/cel/cel-store/src/filesystem.rs
@@ -104,11 +104,7 @@ impl FsStore {
     }
 
     /// Load a screenshot for a specific run step.
-    pub fn load_screenshot(
-        &self,
-        run_id: i64,
-        step_index: u32,
-    ) -> Result<Vec<u8>, StoreError> {
+    pub fn load_screenshot(&self, run_id: i64, step_index: u32) -> Result<Vec<u8>, StoreError> {
         let path = self
             .base_dir
             .join("captures")
@@ -294,7 +290,10 @@ mod tests {
 
         let entries = store.read_transcript(1).unwrap();
         assert_eq!(entries.len(), 2);
-        assert!(matches!(entries[0].entry_type, TranscriptEntryType::RunStart));
+        assert!(matches!(
+            entries[0].entry_type,
+            TranscriptEntryType::RunStart
+        ));
         assert_eq!(entries[1].step_index, Some(0));
     }
 

--- a/cel/cel-store/src/memory.rs
+++ b/cel/cel-store/src/memory.rs
@@ -261,25 +261,28 @@ impl crate::CelStore {
                  created_at DESC
              LIMIT ?2",
         )?;
-        let rows = stmt.query_map(rusqlite::params![workflow_name, limit], |row: &rusqlite::Row| {
-            let priority_str: String = row.get(3)?;
-            let priority = match priority_str.as_str() {
-                "high" => ObservationPriority::High,
-                "low" => ObservationPriority::Low,
-                _ => ObservationPriority::Medium,
-            };
-            Ok(Observation {
-                id: row.get(0)?,
-                workflow_name: row.get(1)?,
-                content: row.get(2)?,
-                priority,
-                source_run_ids: row.get(4)?,
-                observed_at: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                referenced_at: row.get(6)?,
-                superseded_by: row.get(7)?,
-                created_at: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
-            })
-        })?;
+        let rows = stmt.query_map(
+            rusqlite::params![workflow_name, limit],
+            |row: &rusqlite::Row| {
+                let priority_str: String = row.get(3)?;
+                let priority = match priority_str.as_str() {
+                    "high" => ObservationPriority::High,
+                    "low" => ObservationPriority::Low,
+                    _ => ObservationPriority::Medium,
+                };
+                Ok(Observation {
+                    id: row.get(0)?,
+                    workflow_name: row.get(1)?,
+                    content: row.get(2)?,
+                    priority,
+                    source_run_ids: row.get(4)?,
+                    observed_at: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+                    referenced_at: row.get(6)?,
+                    superseded_by: row.get(7)?,
+                    created_at: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
+                })
+            },
+        )?;
         let mut records = Vec::new();
         for row in rows {
             records.push(row?);
@@ -288,11 +291,7 @@ impl crate::CelStore {
     }
 
     /// Supersede an observation (mark it as replaced by a newer one).
-    pub fn supersede_observation(
-        &self,
-        old_id: i64,
-        new_id: i64,
-    ) -> Result<(), StoreError> {
+    pub fn supersede_observation(&self, old_id: i64, new_id: i64) -> Result<(), StoreError> {
         self.conn.execute(
             "UPDATE observations SET superseded_by = ?1 WHERE id = ?2",
             rusqlite::params![new_id, old_id],
@@ -321,7 +320,11 @@ impl crate::CelStore {
 
     /// Delete observations older than `days` for a workflow.
     /// Returns number of deleted rows.
-    pub fn evict_old_observations(&self, workflow_name: &str, days: u32) -> Result<usize, StoreError> {
+    pub fn evict_old_observations(
+        &self,
+        workflow_name: &str,
+        days: u32,
+    ) -> Result<usize, StoreError> {
         let affected = self.conn.execute(
             "DELETE FROM observations WHERE workflow_name = ?1 AND created_at < datetime('now', ?2)",
             rusqlite::params![workflow_name, format!("-{} days", days)],
@@ -341,7 +344,11 @@ impl crate::CelStore {
 
     /// Cap observations per workflow, keeping the most recent by priority.
     /// Returns number of deleted rows.
-    pub fn cap_observations(&self, workflow_name: &str, max_count: u32) -> Result<usize, StoreError> {
+    pub fn cap_observations(
+        &self,
+        workflow_name: &str,
+        max_count: u32,
+    ) -> Result<usize, StoreError> {
         let affected = self.conn.execute(
             "DELETE FROM observations WHERE workflow_name = ?1 AND id NOT IN (
                 SELECT id FROM observations WHERE workflow_name = ?1 AND superseded_by IS NULL
@@ -470,7 +477,9 @@ mod tests {
     #[test]
     fn test_working_memory_update() {
         let store = CelStore::open_memory().unwrap();
-        store.update_working_memory("daily-po", "# Field Mappings\n- Vendor X → 10045").unwrap();
+        store
+            .update_working_memory("daily-po", "# Field Mappings\n- Vendor X → 10045")
+            .unwrap();
         let wm = store.get_working_memory("daily-po").unwrap();
         assert!(wm.content.contains("Vendor X"));
     }
@@ -496,21 +505,36 @@ mod tests {
     #[test]
     fn test_add_and_get_observations() {
         let store = CelStore::open_memory().unwrap();
-        store.add_observation(
-            "daily-po", "Vendor X always maps to code 10045",
-            &ObservationPriority::High, &[1, 2, 3],
-            Some("2024-06-15"), None,
-        ).unwrap();
-        store.add_observation(
-            "daily-po", "SAP dialog takes ~3s after Submit click",
-            &ObservationPriority::Medium, &[2, 3],
-            None, None,
-        ).unwrap();
-        store.add_observation(
-            "other-wf", "Should not appear",
-            &ObservationPriority::Low, &[99],
-            None, None,
-        ).unwrap();
+        store
+            .add_observation(
+                "daily-po",
+                "Vendor X always maps to code 10045",
+                &ObservationPriority::High,
+                &[1, 2, 3],
+                Some("2024-06-15"),
+                None,
+            )
+            .unwrap();
+        store
+            .add_observation(
+                "daily-po",
+                "SAP dialog takes ~3s after Submit click",
+                &ObservationPriority::Medium,
+                &[2, 3],
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .add_observation(
+                "other-wf",
+                "Should not appear",
+                &ObservationPriority::Low,
+                &[99],
+                None,
+                None,
+            )
+            .unwrap();
 
         let obs = store.get_observations("daily-po", 10).unwrap();
         assert_eq!(obs.len(), 2);
@@ -522,14 +546,26 @@ mod tests {
     #[test]
     fn test_observation_supersede() {
         let store = CelStore::open_memory().unwrap();
-        let old_id = store.add_observation(
-            "wf", "Vendor X → code 10045",
-            &ObservationPriority::High, &[1], None, None,
-        ).unwrap();
-        let new_id = store.add_observation(
-            "wf", "Vendor X → code 10046 (updated Jan 2025)",
-            &ObservationPriority::High, &[1, 5], None, None,
-        ).unwrap();
+        let old_id = store
+            .add_observation(
+                "wf",
+                "Vendor X → code 10045",
+                &ObservationPriority::High,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
+        let new_id = store
+            .add_observation(
+                "wf",
+                "Vendor X → code 10046 (updated Jan 2025)",
+                &ObservationPriority::High,
+                &[1, 5],
+                None,
+                None,
+            )
+            .unwrap();
         store.supersede_observation(old_id, new_id).unwrap();
 
         let obs = store.get_observations("wf", 10).unwrap();
@@ -540,18 +576,30 @@ mod tests {
     #[test]
     fn test_scoped_knowledge_fts5_search() {
         let store = CelStore::open_memory().unwrap();
-        store.add_scoped_knowledge(
-            "Vendor X maps to code 10045 in the SAP system",
-            "learned", Some("daily-po"), Some("sap,vendor"),
-        ).unwrap();
-        store.add_scoped_knowledge(
-            "Bloomberg terminal requires F10 to confirm trades",
-            "manual", Some("trade-wf"), Some("bloomberg"),
-        ).unwrap();
-        store.add_scoped_knowledge(
-            "Always check for stale prices before submitting",
-            "learned", None, Some("trading,risk"),
-        ).unwrap();
+        store
+            .add_scoped_knowledge(
+                "Vendor X maps to code 10045 in the SAP system",
+                "learned",
+                Some("daily-po"),
+                Some("sap,vendor"),
+            )
+            .unwrap();
+        store
+            .add_scoped_knowledge(
+                "Bloomberg terminal requires F10 to confirm trades",
+                "manual",
+                Some("trade-wf"),
+                Some("bloomberg"),
+            )
+            .unwrap();
+        store
+            .add_scoped_knowledge(
+                "Always check for stale prices before submitting",
+                "learned",
+                None,
+                Some("trading,risk"),
+            )
+            .unwrap();
 
         // Search for "vendor" — should find the SAP entry
         let results = store.search_knowledge("vendor", None, 10).unwrap();
@@ -559,14 +607,18 @@ mod tests {
         assert!(results[0].content.contains("Vendor X"));
 
         // Scoped search — only daily-po and global
-        let results = store.search_knowledge("SAP OR stale", Some("daily-po"), 10).unwrap();
+        let results = store
+            .search_knowledge("SAP OR stale", Some("daily-po"), 10)
+            .unwrap();
         assert!(results.len() >= 1);
     }
 
     #[test]
     fn test_knowledge_fts5_no_results() {
         let store = CelStore::open_memory().unwrap();
-        store.add_scoped_knowledge("Hello world", "test", None, None).unwrap();
+        store
+            .add_scoped_knowledge("Hello world", "test", None, None)
+            .unwrap();
         let results = store.search_knowledge("nonexistent_xyz", None, 10).unwrap();
         assert!(results.is_empty());
     }
@@ -574,9 +626,15 @@ mod tests {
     #[test]
     fn test_knowledge_score_ranking() {
         let store = CelStore::open_memory().unwrap();
-        store.add_scoped_knowledge("Excel cell A1 contains revenue data", "test", None, None).unwrap();
-        store.add_scoped_knowledge("Revenue report Excel macro runs weekly", "test", None, None).unwrap();
-        store.add_scoped_knowledge("Something unrelated about weather", "test", None, None).unwrap();
+        store
+            .add_scoped_knowledge("Excel cell A1 contains revenue data", "test", None, None)
+            .unwrap();
+        store
+            .add_scoped_knowledge("Revenue report Excel macro runs weekly", "test", None, None)
+            .unwrap();
+        store
+            .add_scoped_knowledge("Something unrelated about weather", "test", None, None)
+            .unwrap();
 
         let results = store.search_knowledge("Excel revenue", None, 10).unwrap();
         assert!(results.len() >= 2);
@@ -589,9 +647,36 @@ mod tests {
     #[test]
     fn test_observation_priority_ordering() {
         let store = CelStore::open_memory().unwrap();
-        store.add_observation("wf", "Low fact", &ObservationPriority::Low, &[1], None, None).unwrap();
-        store.add_observation("wf", "High fact", &ObservationPriority::High, &[1], None, None).unwrap();
-        store.add_observation("wf", "Medium fact", &ObservationPriority::Medium, &[1], None, None).unwrap();
+        store
+            .add_observation(
+                "wf",
+                "Low fact",
+                &ObservationPriority::Low,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .add_observation(
+                "wf",
+                "High fact",
+                &ObservationPriority::High,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .add_observation(
+                "wf",
+                "Medium fact",
+                &ObservationPriority::Medium,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
 
         let obs = store.get_observations("wf", 10).unwrap();
         assert_eq!(obs[0].priority, ObservationPriority::High);
@@ -602,8 +687,12 @@ mod tests {
     #[test]
     fn test_evict_superseded_observations() {
         let store = CelStore::open_memory().unwrap();
-        let old_id = store.add_observation("wf", "old", &ObservationPriority::High, &[1], None, None).unwrap();
-        let new_id = store.add_observation("wf", "new", &ObservationPriority::High, &[2], None, None).unwrap();
+        let old_id = store
+            .add_observation("wf", "old", &ObservationPriority::High, &[1], None, None)
+            .unwrap();
+        let new_id = store
+            .add_observation("wf", "new", &ObservationPriority::High, &[2], None, None)
+            .unwrap();
         store.supersede_observation(old_id, new_id).unwrap();
 
         let deleted = store.evict_superseded_observations().unwrap();
@@ -618,9 +707,27 @@ mod tests {
     fn test_cap_observations() {
         let store = CelStore::open_memory().unwrap();
         for i in 0..10 {
-            store.add_observation("wf", &format!("obs {}", i), &ObservationPriority::Low, &[1], None, None).unwrap();
+            store
+                .add_observation(
+                    "wf",
+                    &format!("obs {}", i),
+                    &ObservationPriority::Low,
+                    &[1],
+                    None,
+                    None,
+                )
+                .unwrap();
         }
-        store.add_observation("wf", "important", &ObservationPriority::High, &[1], None, None).unwrap();
+        store
+            .add_observation(
+                "wf",
+                "important",
+                &ObservationPriority::High,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
 
         let deleted = store.cap_observations("wf", 3).unwrap();
         assert!(deleted > 0);
@@ -666,7 +773,16 @@ mod tests {
             [],
         ).unwrap();
         let old_id = store.conn.last_insert_rowid();
-        let new_id = store.add_observation("wf", "new obs", &ObservationPriority::High, &[1], None, None).unwrap();
+        let new_id = store
+            .add_observation(
+                "wf",
+                "new obs",
+                &ObservationPriority::High,
+                &[1],
+                None,
+                None,
+            )
+            .unwrap();
         store.supersede_observation(old_id, new_id).unwrap();
 
         store.conn.execute(

--- a/cel/cel-store/src/memory.rs
+++ b/cel/cel-store/src/memory.rs
@@ -399,13 +399,11 @@ impl crate::CelStore {
 
     /// Run all eviction policies. Returns total rows deleted.
     pub fn run_eviction(&self, config: &EvictionConfig) -> Result<EvictionResult, StoreError> {
-        let mut result = EvictionResult::default();
-
-        result.superseded_observations = self.evict_superseded_observations()?;
-        result.old_runs = self.evict_old_runs(config.run_retention_days)?;
-        result.old_knowledge = self.evict_old_knowledge(config.knowledge_retention_days)?;
-
-        Ok(result)
+        Ok(EvictionResult {
+            superseded_observations: self.evict_superseded_observations()?,
+            old_runs: self.evict_old_runs(config.run_retention_days)?,
+            old_knowledge: self.evict_old_knowledge(config.knowledge_retention_days)?,
+        })
     }
 
     /// Search knowledge using FTS5 full-text search.
@@ -610,7 +608,7 @@ mod tests {
         let results = store
             .search_knowledge("SAP OR stale", Some("daily-po"), 10)
             .unwrap();
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
     }
 
     #[test]

--- a/cel/cel-store/src/schema.rs
+++ b/cel/cel-store/src/schema.rs
@@ -276,7 +276,9 @@ impl CelStore {
         })();
         match &result {
             Ok(_) => self.conn.execute_batch("COMMIT")?,
-            Err(_) => { let _ = self.conn.execute_batch("ROLLBACK"); }
+            Err(_) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+            }
         }
         result
     }
@@ -361,14 +363,20 @@ mod tests {
     fn test_store_open_and_migrate() {
         let store = CelStore::open_memory().expect("Failed to open in-memory store");
         // Verify tables exist by inserting
-        store.add_knowledge("test fact", "test").expect("Failed to add knowledge");
+        store
+            .add_knowledge("test fact", "test")
+            .expect("Failed to add knowledge");
     }
 
     #[test]
     fn test_knowledge_roundtrip() {
         let store = CelStore::open_memory().unwrap();
-        store.add_knowledge("Vendor X maps to code 10045", "manual").unwrap();
-        store.add_knowledge("Vendor Y requires approval over 50000", "learned").unwrap();
+        store
+            .add_knowledge("Vendor X maps to code 10045", "manual")
+            .unwrap();
+        store
+            .add_knowledge("Vendor Y requires approval over 50000", "learned")
+            .unwrap();
 
         let results = store.query_knowledge("Vendor").unwrap();
         assert_eq!(results.len(), 2);
@@ -388,9 +396,42 @@ mod tests {
         let store = CelStore::open_memory().unwrap();
         let run_id = store.start_run("test-wf", 3).unwrap();
 
-        store.log_step(run_id, 0, "step-1", r#"{"type":"click"}"#, true, 0.95, Some(r#"{"app":"Excel"}"#), None).unwrap();
-        store.log_step(run_id, 1, "step-2", r#"{"type":"type"}"#, true, 0.88, None, None).unwrap();
-        store.log_step(run_id, 2, "step-3", r#"{"type":"key"}"#, false, 0.45, None, Some("Element not found")).unwrap();
+        store
+            .log_step(
+                run_id,
+                0,
+                "step-1",
+                r#"{"type":"click"}"#,
+                true,
+                0.95,
+                Some(r#"{"app":"Excel"}"#),
+                None,
+            )
+            .unwrap();
+        store
+            .log_step(
+                run_id,
+                1,
+                "step-2",
+                r#"{"type":"type"}"#,
+                true,
+                0.88,
+                None,
+                None,
+            )
+            .unwrap();
+        store
+            .log_step(
+                run_id,
+                2,
+                "step-3",
+                r#"{"type":"key"}"#,
+                false,
+                0.45,
+                None,
+                Some("Element not found"),
+            )
+            .unwrap();
 
         let steps = store.get_step_results(run_id).unwrap();
         assert_eq!(steps.len(), 3);
@@ -407,9 +448,15 @@ mod tests {
         let store = CelStore::open_memory().unwrap();
         let run_id = store.start_run("test-wf", 3).unwrap();
 
-        store.log_step(run_id, 0, "s1", "{}", true, 0.9, None, None).unwrap();
-        store.log_step(run_id, 1, "s2", "{}", true, 0.9, None, None).unwrap();
-        store.log_step(run_id, 2, "s3", "{}", false, 0.4, None, Some("fail")).unwrap();
+        store
+            .log_step(run_id, 0, "s1", "{}", true, 0.9, None, None)
+            .unwrap();
+        store
+            .log_step(run_id, 1, "s2", "{}", true, 0.9, None, None)
+            .unwrap();
+        store
+            .log_step(run_id, 2, "s3", "{}", false, 0.4, None, Some("fail"))
+            .unwrap();
 
         let history = store.get_run_history(10).unwrap();
         assert_eq!(history.len(), 1);
@@ -435,12 +482,15 @@ mod tests {
         let store = CelStore::open_memory().unwrap();
         let run_id = store.start_run("test-wf", 3).unwrap();
 
-        let id = store.record_intervention(
-            run_id, 1,
-            r#"{"elements":[]}"#,
-            r#"{"type":"click","x":100,"y":200}"#,
-            Some(r#"{"type":"click","target":"submit-btn"}"#),
-        ).unwrap();
+        let id = store
+            .record_intervention(
+                run_id,
+                1,
+                r#"{"elements":[]}"#,
+                r#"{"type":"click","x":100,"y":200}"#,
+                Some(r#"{"type":"click","target":"submit-btn"}"#),
+            )
+            .unwrap();
         assert!(id > 0);
 
         let history = store.get_run_history(10).unwrap();

--- a/cel/cel-store/src/schema.rs
+++ b/cel/cel-store/src/schema.rs
@@ -250,6 +250,7 @@ impl CelStore {
     }
 
     /// Log a step result during a workflow run.
+    #[allow(clippy::too_many_arguments)]
     pub fn log_step(
         &self,
         run_id: i64,

--- a/cel/cel-store/tests/integration.rs
+++ b/cel/cel-store/tests/integration.rs
@@ -9,9 +9,15 @@ use cel_store::CelStore;
 fn test_store_lifecycle() {
     let store = CelStore::open_memory().expect("Failed to open in-memory store");
 
-    store.add_knowledge("Ctrl+S saves the file in Excel", "excel").unwrap();
-    store.add_knowledge("Ctrl+Z undoes the last action in Excel", "excel").unwrap();
-    store.add_knowledge("Use T-code VA01 for sales orders", "sap").unwrap();
+    store
+        .add_knowledge("Ctrl+S saves the file in Excel", "excel")
+        .unwrap();
+    store
+        .add_knowledge("Ctrl+Z undoes the last action in Excel", "excel")
+        .unwrap();
+    store
+        .add_knowledge("Use T-code VA01 for sales orders", "sap")
+        .unwrap();
 
     let results = store.query_knowledge("Ctrl").unwrap();
     assert_eq!(results.len(), 2);
@@ -53,12 +59,19 @@ fn test_independent_stores() {
 fn test_knowledge_search_is_case_insensitive_substring() {
     let store = CelStore::open_memory().unwrap();
 
-    store.add_knowledge("Press Ctrl+C to copy text", "general").unwrap();
-    store.add_knowledge("Use CTRL+V to paste", "general").unwrap();
+    store
+        .add_knowledge("Press Ctrl+C to copy text", "general")
+        .unwrap();
+    store
+        .add_knowledge("Use CTRL+V to paste", "general")
+        .unwrap();
 
     // Should match both regardless of case
     let results = store.query_knowledge("ctrl").unwrap();
-    assert!(results.len() >= 1, "Case-insensitive search should find 'ctrl' in 'Ctrl+C'");
+    assert!(
+        results.len() >= 1,
+        "Case-insensitive search should find 'ctrl' in 'Ctrl+C'"
+    );
 
     let results = store.query_knowledge("COPY").unwrap();
     // Depends on LIKE behavior — at minimum shouldn't crash
@@ -68,10 +81,15 @@ fn test_knowledge_search_is_case_insensitive_substring() {
 #[test]
 fn test_knowledge_query_no_match_returns_empty() {
     let store = CelStore::open_memory().unwrap();
-    store.add_knowledge("Something about Excel", "excel").unwrap();
+    store
+        .add_knowledge("Something about Excel", "excel")
+        .unwrap();
 
     let results = store.query_knowledge("nonexistent_term_xyz").unwrap();
-    assert!(results.is_empty(), "Query with no matches should return empty vec");
+    assert!(
+        results.is_empty(),
+        "Query with no matches should return empty vec"
+    );
 }
 
 #[test]
@@ -85,9 +103,15 @@ fn test_knowledge_with_special_characters() {
     // subject (we're verifying parameterization defends against it) — it is
     // never executed as SQL. The DB is `open_memory()` so even a regression
     // could only touch the test-scoped in-memory DB, never any real data.
-    store.add_knowledge("Use ' single quotes ' carefully", "sql").unwrap();
-    store.add_knowledge("Path: C:\\Users\\admin\\file.txt", "windows").unwrap();
-    store.add_knowledge("SELECT * FROM users WHERE id = 1; DROP TABLE--", "security").unwrap();
+    store
+        .add_knowledge("Use ' single quotes ' carefully", "sql")
+        .unwrap();
+    store
+        .add_knowledge("Path: C:\\Users\\admin\\file.txt", "windows")
+        .unwrap();
+    store
+        .add_knowledge("SELECT * FROM users WHERE id = 1; DROP TABLE--", "security")
+        .unwrap();
 
     // Should not crash or SQL-inject
     let results = store.query_knowledge("single quotes").unwrap();
@@ -103,9 +127,15 @@ fn test_knowledge_with_special_characters() {
 fn test_knowledge_with_unicode() {
     let store = CelStore::open_memory().unwrap();
 
-    store.add_knowledge("日本語テスト: ボタンをクリック", "japanese").unwrap();
-    store.add_knowledge("Emoji test: 🎉 click the 🔘 button", "emoji").unwrap();
-    store.add_knowledge("Ñoño: señor González", "spanish").unwrap();
+    store
+        .add_knowledge("日本語テスト: ボタンをクリック", "japanese")
+        .unwrap();
+    store
+        .add_knowledge("Emoji test: 🎉 click the 🔘 button", "emoji")
+        .unwrap();
+    store
+        .add_knowledge("Ñoño: señor González", "spanish")
+        .unwrap();
 
     let results = store.query_knowledge("クリック").unwrap();
     assert_eq!(results.len(), 1);
@@ -138,15 +168,21 @@ fn test_many_knowledge_entries() {
 
     // Insert 500 entries
     for i in 0..500 {
-        store.add_knowledge(
-            &format!("Knowledge item {} about topic-{}", i, i % 10),
-            &format!("source-{}", i % 5),
-        ).unwrap();
+        store
+            .add_knowledge(
+                &format!("Knowledge item {} about topic-{}", i, i % 10),
+                &format!("source-{}", i % 5),
+            )
+            .unwrap();
     }
 
     // Search should still work efficiently
     let results = store.query_knowledge("topic-3").unwrap();
-    assert_eq!(results.len(), 50, "Should find 50 entries for topic-3 (500/10)");
+    assert_eq!(
+        results.len(),
+        50,
+        "Should find 50 entries for topic-3 (500/10)"
+    );
 
     let results = store.query_knowledge("Knowledge item 42").unwrap();
     assert!(results.len() >= 1, "Should find specific item");
@@ -187,9 +223,13 @@ fn test_run_tracking_finish_nonexistent() {
 fn test_knowledge_source_filtering() {
     let store = CelStore::open_memory().unwrap();
 
-    store.add_knowledge("Excel shortcut: Ctrl+Home", "excel").unwrap();
+    store
+        .add_knowledge("Excel shortcut: Ctrl+Home", "excel")
+        .unwrap();
     store.add_knowledge("SAP transaction: VA01", "sap").unwrap();
-    store.add_knowledge("Excel formula: =SUM(A1:A10)", "excel").unwrap();
+    store
+        .add_knowledge("Excel formula: =SUM(A1:A10)", "excel")
+        .unwrap();
 
     // Query by content, then verify source is preserved
     let results = store.query_knowledge("Excel").unwrap();

--- a/cel/cel-store/tests/integration.rs
+++ b/cel/cel-store/tests/integration.rs
@@ -69,7 +69,7 @@ fn test_knowledge_search_is_case_insensitive_substring() {
     // Should match both regardless of case
     let results = store.query_knowledge("ctrl").unwrap();
     assert!(
-        results.len() >= 1,
+        !results.is_empty(),
         "Case-insensitive search should find 'ctrl' in 'Ctrl+C'"
     );
 
@@ -185,7 +185,7 @@ fn test_many_knowledge_entries() {
     );
 
     let results = store.query_knowledge("Knowledge item 42").unwrap();
-    assert!(results.len() >= 1, "Should find specific item");
+    assert!(!results.is_empty(), "Should find specific item");
     assert!(results[0].content.contains("42"));
 }
 

--- a/cel/cel-vision/src/lib.rs
+++ b/cel/cel-vision/src/lib.rs
@@ -16,9 +16,7 @@ pub use openai_compat::OpenAICompatProvider;
 pub use provider::{VisionBounds, VisionElement, VisionError, VisionProvider};
 
 /// Create a vision provider from configuration.
-pub fn create_provider(
-    config: LlmProviderConfig,
-) -> Result<Box<dyn VisionProvider>, VisionError> {
+pub fn create_provider(config: LlmProviderConfig) -> Result<Box<dyn VisionProvider>, VisionError> {
     // All known providers use the OpenAI-compatible chat completions protocol.
     Ok(Box::new(OpenAICompatProvider::new(config)?))
 }
@@ -28,7 +26,6 @@ pub fn create_provider(
 /// Reads `CEL_LLM_PROVIDER`, `CEL_LLM_API_KEY`, etc. See
 /// [`LlmProviderConfig::from_env`] for full documentation.
 pub fn create_provider_from_env() -> Result<Box<dyn VisionProvider>, VisionError> {
-    let config = LlmProviderConfig::from_env()
-        .ok_or(VisionError::NotConfigured)?;
+    let config = LlmProviderConfig::from_env().ok_or(VisionError::NotConfigured)?;
     create_provider(config)
 }

--- a/cel/cel-vision/src/openai_compat.rs
+++ b/cel/cel-vision/src/openai_compat.rs
@@ -195,12 +195,7 @@ impl VisionProvider for OpenAICompatProvider {
 
         let answer = self
             .client
-            .complete_with_images(
-                system,
-                &[&before_url, &after_url],
-                question,
-                1024,
-            )
+            .complete_with_images(system, &[&before_url, &after_url], question, 1024)
             .await?;
 
         Ok(answer)

--- a/cel/cel-vision/src/provider.rs
+++ b/cel/cel-vision/src/provider.rs
@@ -64,7 +64,9 @@ pub trait VisionProvider: Send + Sync {
     ) -> Result<String, VisionError> {
         // Default: not supported — returns error.
         let _ = (frame, question, detail);
-        Err(VisionError::ApiFailed("ask() not supported by this provider".into()))
+        Err(VisionError::ApiFailed(
+            "ask() not supported by this provider".into(),
+        ))
     }
 
     /// Compare two screenshots and describe what changed.
@@ -76,7 +78,9 @@ pub trait VisionProvider: Send + Sync {
         question: &str,
     ) -> Result<String, VisionError> {
         let _ = (before, after, question);
-        Err(VisionError::ApiFailed("compare() not supported by this provider".into()))
+        Err(VisionError::ApiFailed(
+            "compare() not supported by this provider".into(),
+        ))
     }
 
     /// Provider name for logging.

--- a/cellar-worker/src/client.rs
+++ b/cellar-worker/src/client.rs
@@ -4,9 +4,7 @@
 //! this client to dispatch goals to a worker. Kept in the same crate as the
 //! server so the wire types stay in lockstep.
 
-use crate::protocol::{
-    HealthResponse, JobDetails, SubmitGoalRequest, SubmitGoalResponse,
-};
+use crate::protocol::{HealthResponse, JobDetails, SubmitGoalRequest, SubmitGoalResponse};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {

--- a/cellar-worker/src/server.rs
+++ b/cellar-worker/src/server.rs
@@ -233,11 +233,12 @@ fn merge_goal_config(
     config_override: Option<serde_json::Value>,
 ) -> cel_goal_runner::GoalConfig {
     let mut config = match config_override {
-        Some(value) => serde_json::from_value::<cel_goal_runner::GoalConfig>(value)
-            .unwrap_or_else(|e| {
+        Some(value) => {
+            serde_json::from_value::<cel_goal_runner::GoalConfig>(value).unwrap_or_else(|e| {
                 tracing::warn!("submitted `config` failed to parse as GoalConfig: {e}");
                 cel_goal_runner::GoalConfig::default()
-            }),
+            })
+        }
         None => cel_goal_runner::GoalConfig::default(),
     };
     config.goal = goal;

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -45,7 +45,7 @@
     "prepack": "pnpm build",
     "build": "pnpm --filter @cellar/agent build && pnpm --filter @cellar/adapter-browser build && tsc && pnpm bundle",
     "bundle": "node esbuild.config.mjs",
-    "test": "node ../tests/cortex/mcp-protocol.mjs",
+    "test:integration": "node ../tests/cortex/mcp-protocol.mjs",
     "lint": "tsc --noEmit"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3876,7 +3876,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.9.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4252,7 +4252,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3876,7 +3876,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.9.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4252,7 +4252,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
## Summary

Mirrors [cellar-private#13](https://github.com/dimpagk92/cellar-private/pull/13). Replaces the monolithic CI workflow with path-filtered, well-structured jobs that only run when relevant files change.

### What was wrong

| Problem | Impact |
|---------|--------|
| Windows in Rust matrix | Builds fail — Windows support is planned, not implemented |
| `continue-on-error: true` on TS lint | Lint errors silently ignored |
| No path filtering | Rust CI runs on TS-only PRs and vice versa (~15 min wasted) |
| TS matrix: Windows + macOS | Zero platform-specific TS code — 2x wasted compute |
| No concurrency control | Stale PR runs pile up |
| Manual cargo cache | Suboptimal hit rates; `Swatinem/rust-cache` is significantly better |
| `dtolnay/rust-action/setup@v1` | Non-canonical action; `dtolnay/rust-toolchain` is the standard |

### What's new

- **Path-based change detection** via `dorny/paths-filter` — Rust, TS, E2E, and NAPI/Cortex jobs only run when their source files change
- **Concurrency groups** that cancel in-progress runs for the same PR
- **Rust pipeline**: fast-fail `cargo fmt` check → parallel clippy + tests on Linux + macOS
- **TS pipeline**: build + typecheck → unit tests (Linux only — no platform-specific code)
- **E2E**: scoped to standard Playwright projects (excludes `real-extraction`)
- **Cortex integration**: macOS-only job for NAPI build + smoke tests + MCP protocol tests
- **`ci-ok` gate job**: single required status check for branch protection — handles skipped jobs from path filtering correctly
- **`Swatinem/rust-cache`** for Rust, **`setup-node` cache: pnpm** for TS
- **PR auto-labeler** based on paths changed (`rust`, `typescript`, `cortex`, `mcp`, `adapters`, `e2e`, `ci`, `docs`)
- **Makefile**: split `lint-rust` into `lint-rust-fmt` + `lint-rust-clippy` sub-targets so CI can fast-fail on format independently

### Branch protection recommendation

After merging, set **`CI ✓`** as the only required status check. The gate job depends on all CI jobs and passes when everything succeeds or is skipped (due to path filtering).

## Test plan

- [ ] Verify CI runs on this PR itself (the `ci` path filter matches `.github/workflows/ci.yml`)
- [ ] Confirm Rust jobs trigger
- [ ] Confirm TS jobs trigger
- [ ] Confirm `ci-ok` gate passes when upstream jobs succeed or are skipped
- [ ] Verify labels are applied on this PR