### PR TITLE
ci(dependabot): split major dev-dep bumps into individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,14 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     groups:
-      dev-dependencies:
+      # Group only minor + patch dev-deps so we can rubber-stamp them.
+      # Major bumps fall through to individual PRs — they tend to break
+      # things (e.g. vitest 4 dropped CommonJS, which blocked the whole
+      # group from merging in PR #16). Splitting forces us to migrate
+      # one major at a time without holding up safe patches.
+      dev-dependencies-minor:
         dependency-type: "development"
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
## Summary

Restricts the `dev-dependencies` group to `minor` + `patch` update types so major version bumps arrive as individual PRs.

## Why

[#16](https://github.com/dimpagk92/cellar/pull/16) bundled vitest 4 (major, breaks CJS test discovery) with five safe patch/minor bumps. The whole group sat blocked until the bot/maintainer manually pinned vitest back to ^3 and force-pushed. With this change, vitest 4 would have been a separate PR we could close or migrate independently.

## Notes

- Cargo + github-actions ecosystems unchanged (no groups).
- This file is OSS-canonical (excluded from \`sync-to-oss.sh\`), so editing here is the right place.