### PR TITLE
refactor(cel): finish cel-contracts scope — migrate cellar-worker boundary types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "axum",
  "cel-accessibility",
  "cel-context",
+ "cel-contracts",
  "cel-cortex",
  "cel-goal-runner",
  "cel-llm",

--- a/cel/cel-goal-runner/src/canonical_runner.rs
+++ b/cel/cel-goal-runner/src/canonical_runner.rs
@@ -171,7 +171,7 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
                         );
                         let activate_step = Step {
                             purpose: format!("phase_gate_auto_activate:{term}"),
-                            kind: cel_planner::StepKind::Deterministic,
+                            kind: cel_contracts::StepKind::Deterministic,
                             action: PlannedAction::ActivateApp {
                                 app_name: term.to_string(),
                             },

--- a/cellar-worker/Cargo.toml
+++ b/cellar-worker/Cargo.toml
@@ -25,6 +25,7 @@ axum = "0.8"
 
 # CEL runtime — for real goal execution on the worker host.
 cel-goal-runner = { workspace = true }
+cel-contracts = { workspace = true }
 cel-planner = { workspace = true }
 cel-llm = { workspace = true }
 cel-cortex = { workspace = true }

--- a/cellar-worker/src/server.rs
+++ b/cellar-worker/src/server.rs
@@ -169,7 +169,7 @@ fn spawn_real_execution(
         store.update_status(&job_id, JobStatus::Running, None, None);
 
         let config = merge_goal_config(goal.clone(), config_override);
-        let limits = cel_planner::RunLimits {
+        let limits = cel_contracts::RunLimits {
             max_steps: config.max_steps,
             timeout_ms: config.timeout_ms,
             max_step_retries: 3,
@@ -210,8 +210,8 @@ fn spawn_real_execution(
 
         // Canonical GoalOutcome → worker JobStatus.
         let (job_status, error) = match &outcome {
-            cel_planner::GoalOutcome::Succeeded { .. } => (JobStatus::Succeeded, None),
-            cel_planner::GoalOutcome::Failed(report) => (
+            cel_contracts::GoalOutcome::Succeeded { .. } => (JobStatus::Succeeded, None),
+            cel_contracts::GoalOutcome::Failed(report) => (
                 JobStatus::Failed,
                 Some(format!(
                     "{}/{}: {}",


### PR DESCRIPTION
refactor(cel): finish cel-contracts scope — migrate cellar-worker + cel-eval

Follow-up to #19. The original PR1a.0 said "update cel-cortex /
cel-goal-runner / cel-napi imports" but missed two more workspace
crates that also use boundary types via the legacy cel_planner path:

  - cellar-worker: imported cel_planner::{RunLimits, GoalOutcome}
  - cel-eval:      imported cel_planner::{GoalOutcome, RunLimits}
                   in tests; doc comment referenced cel_planner::RunLimits

Plus one stray inline reference inside cel-goal-runner's own
canonical_runner.rs that I missed:

  - canonical_runner.rs L174: cel_planner::StepKind::Deterministic
                               -> cel_contracts::StepKind::Deterministic

These all worked before this PR because cel-planner re-exports the
moved types via `pub use cel_contracts::{...}` for backward compat —
nothing was broken. But the stated PR1a.0 goal was to update direct
boundary-type consumers to import from cel-contracts, and these were
missed.

Now every workspace crate that consumes boundary types imports them
from cel-contracts. cel-planner's re-exports still cover the few
remaining indirect callers (planner-internal tests, legacy paths) so
no one has to migrate in one go — but the workspace-internal usage
is consistent.

Tests: full workspace `cargo test --workspace` passes (all crates,
zero failures). cargo fmt --all -- --check clean.

Boundary-type audit (after this PR):
  $ grep -rnE "cel_planner::(PlannedAction|CellWrite|Step|StepKind|\
    StepResult|RuntimeCaps|RunLimits|NextMove|AttemptRecord|\
    GoalOutcome|FailureReport|PlanProducer|DoneVerdict)" \
    cel/ cellar-worker/ adapters/ \
    | grep -v cel-planner/

  cel/cel-planner/tests/prompt_capture.rs:80: cel_planner::PlannedAction
    (planner-internal test using its own re-export — fine)

  cel/cel-napi/src/planner.rs (StepRecord refs):
    StepRecord is a planner-internal type, intentionally stays in
    cel-planner. Not a boundary type.

So no remaining boundary-type leaks outside cel-planner itself.

(cel-eval lives in private only and is not synced to OSS — its part of this commit applied in private but does not surface here.)