### PR TITLE
feat(cel): PlanningView contract + cortex builder (PR1a)

### DIFF
--- a/cel/cel-contracts/src/lib.rs
+++ b/cel/cel-contracts/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod actions;
 pub mod canonical;
 pub mod producer;
+pub mod view;
 
 pub use actions::{CellWrite, PlannedAction};
 pub use canonical::{
@@ -19,3 +20,8 @@ pub use canonical::{
     StepResult,
 };
 pub use producer::{DoneVerdict, PlanProducer};
+pub use view::{
+    AdapterFactRef, AnomalyRef, Blocker, CapabilityRef, EventRef, EvidenceRef, KnowledgeRef,
+    MemoryRef, OmittedCounts, PlanningBudget, PlanningElement, PlanningElementState,
+    PlanningScreen, PlanningView, RunProgress,
+};

--- a/cel/cel-contracts/src/producer.rs
+++ b/cel/cel-contracts/src/producer.rs
@@ -9,31 +9,41 @@
 //! Codex, in-house) can implement it as a peer.
 
 use async_trait::async_trait;
-use cel_context::ScreenContext;
 use serde::{Deserialize, Serialize};
 
-use crate::canonical::{AttemptRecord, NextMove, RuntimeCaps};
+use crate::canonical::{AttemptRecord, NextMove};
+use crate::view::PlanningView;
 
 /// Decides the next thing the agent should do.
 ///
 /// Called by the canonical runner once per turn. Implementations must
 /// be safe to call repeatedly from async contexts.
+///
+/// **PR1a contract change**: takes `&PlanningView` instead of the legacy
+/// `&ScreenContext` + `&RuntimeCaps` pair. The view is built by the
+/// cortex-side planning-view builder and folds together perception,
+/// adapter facts, capabilities, and run progress in one budgeted shape.
+/// Planners are now pure consumers of this contract — they no longer own
+/// context selection logic.
 #[async_trait]
 pub trait PlanProducer: Send + Sync {
     /// Return the next move.
     ///
     /// Inputs:
     /// * `goal` — the original natural-language goal (unchanged across turns).
-    /// * `history` — every step that has run, oldest first. Contains
-    ///   the planner's own prior intents plus what actually happened
+    /// * `history` — every step that has run, oldest first. Contains the
+    ///   planner's own prior intents plus what actually happened
     ///   (success/error + any extracted data).
-    /// * `shared_memory` — free-form JSON bag of extracted data the
-    ///   runner has accumulated (e.g. prices scraped from a page).
-    /// * `perception` — fresh accessibility-tree snapshot.
-    /// * `screenshot_png` — optional PNG bytes of the current screen
-    ///   for vision-capable models. `None` on headless / no-capture
-    ///   environments; planners should still produce a reasonable
-    ///   answer from perception alone in that case.
+    /// * `shared_memory` — free-form JSON bag of extracted data the runner
+    ///   has accumulated (e.g. prices scraped from a page).
+    /// * `view` — the budgeted `PlanningView` built by `cel-cortex` from
+    ///   the current `MentalModel`. Includes the goal-relevant elements,
+    ///   adapter facts, capabilities, run progress, and (in later PRs)
+    ///   selected memories / knowledge / events.
+    /// * `screenshot_png` — optional PNG bytes of the current screen for
+    ///   vision-capable models. `None` on headless / no-capture
+    ///   environments; planners should still produce a reasonable answer
+    ///   from the view alone.
     ///
     /// On success, returns one of:
     /// * `NextMove::Batch { purpose, steps }` — run these steps in
@@ -50,28 +60,27 @@ pub trait PlanProducer: Send + Sync {
         goal: &str,
         history: &[AttemptRecord],
         shared_memory: &serde_json::Value,
-        perception: &ScreenContext,
+        view: &PlanningView,
         screenshot_png: Option<&[u8]>,
-        caps: &RuntimeCaps,
     ) -> Result<NextMove, String>;
 
-    /// Validate a `Done` claim against fresh perception + screenshot.
+    /// Validate a `Done` claim against the latest planning view + screenshot.
     ///
-    /// When the planner emits `NextMove::Done { summary, .. }`, the
-    /// runner calls this once with the current state before accepting
-    /// the terminal. A `verified = false` verdict rejects the Done —
-    /// the runner records it as a failed attempt (so the planner sees
-    /// it in history) and loops again.
+    /// When the planner emits `NextMove::Done { summary, .. }`, the runner
+    /// calls this once with the current state before accepting the
+    /// terminal. A `verified = false` verdict rejects the Done — the
+    /// runner records it as a failed attempt (so the planner sees it in
+    /// history) and loops again.
     ///
     /// Default implementation accepts any Done (`verified = true`).
-    /// Concrete producers (e.g. an LLM-backed one) override this to
-    /// make a cheap grader call against the goal.
+    /// Concrete producers (e.g. an LLM-backed one) override this to make
+    /// a cheap grader call against the goal.
     async fn verify_done(
         &self,
         _goal: &str,
         _summary: &str,
         _shared_memory: &serde_json::Value,
-        _perception: &ScreenContext,
+        _view: &PlanningView,
         _screenshot_png: Option<&[u8]>,
     ) -> Result<DoneVerdict, String> {
         Ok(DoneVerdict {

--- a/cel/cel-contracts/src/view.rs
+++ b/cel/cel-contracts/src/view.rs
@@ -1,0 +1,445 @@
+//! `PlanningView` — the budgeted, agent-facing projection of CEL state.
+//!
+//! `MentalModel` (in cel-cortex) can be rich. `PlanningView` must be small.
+//! Planners receive this, not the full mental model, so prompts stay under
+//! token budgets and the same context contract works across every planner
+//! runtime (canonical Rust runner, LangGraph, Codex, in-house).
+//!
+//! See `COGNITION_LAYER_PLAN.md` for the principle: **store broadly, select
+//! narrowly**.
+//!
+//! Memory / knowledge / event refs are typed here but populated only by
+//! later PRs (memory store + memory-aware selection). PR1a only fills
+//! `screen`, `elements`, `adapter_facts`, `capabilities`, `blockers`,
+//! `anomalies`, `evidence`, `omitted_counts`, `selection_rationale`.
+
+use serde::{Deserialize, Serialize};
+
+// ─── Top-level view ──────────────────────────────────────────────────────────
+
+/// Compact, budgeted projection of CEL state for one planner call.
+///
+/// Built by `cel-cortex`'s planning-view builder from `MentalModel` plus
+/// active adapter facts. Consumed by every planner — built-in or external —
+/// instead of raw `ScreenContext`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanningView {
+    /// The natural-language goal the planner is working on.
+    pub goal: String,
+    /// The budget the caller asked the builder to respect.
+    pub budget: PlanningBudget,
+
+    /// Current screen / app / window summary.
+    pub screen: PlanningScreen,
+    /// Selected elements relevant to the goal, after budget compression.
+    pub elements: Vec<PlanningElement>,
+    /// Active adapter-backed facts (Numbers cells, browser DOM facts, etc.).
+    /// Empty until adapters expose typed facts; in PR1a builders may leave
+    /// this empty if no adapter contributed.
+    #[serde(default)]
+    pub adapter_facts: Vec<AdapterFactRef>,
+    /// Capabilities currently wired up (CDP bound, native input enabled, …).
+    /// Folds in the boolean flags from the legacy `RuntimeCaps`.
+    #[serde(default)]
+    pub capabilities: Vec<CapabilityRef>,
+    /// Where in the run the planner is. Lets the planner pace itself —
+    /// e.g. stop polishing extraction once most of the budget is spent.
+    /// Folds in the legacy `RuntimeCaps::steps_used` / `max_steps`.
+    #[serde(default)]
+    pub run_progress: RunProgress,
+
+    /// Memories selected by the cognition layer (PR3).
+    #[serde(default)]
+    pub memories: Vec<MemoryRef>,
+    /// Knowledge records selected by the cognition layer (PR3).
+    #[serde(default)]
+    pub knowledge: Vec<KnowledgeRef>,
+    /// Recent events / actions / checkpoints relevant to the goal.
+    #[serde(default)]
+    pub recent_events: Vec<EventRef>,
+
+    /// Things actively blocking forward progress (consent walls, modal
+    /// dialogs, missing capability, etc.). Promoted to first-class so the
+    /// planner notices them even if elements are aggressively compressed.
+    #[serde(default)]
+    pub blockers: Vec<Blocker>,
+    /// Anomalies the cortex flagged (stale state, unexpected window, etc.).
+    #[serde(default)]
+    pub anomalies: Vec<AnomalyRef>,
+    /// References back to source records that explain why selection picked
+    /// what it picked. Filled when a memory / failure / prior outcome
+    /// influenced the view.
+    #[serde(default)]
+    pub evidence: Vec<EvidenceRef>,
+
+    /// One-sentence rationale explaining the selection. Optional —
+    /// deterministic selectors may leave this absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selection_rationale: Option<String>,
+    /// What the builder dropped to fit the budget. Lets the planner know
+    /// the view is compressed and how aggressively.
+    pub omitted_counts: OmittedCounts,
+}
+
+// ─── Budget ──────────────────────────────────────────────────────────────────
+
+/// Caller-provided ceilings for one planning view.
+///
+/// Builders enforce these greedily — most-relevant items first, drop the
+/// rest, count what was dropped in `OmittedCounts`. Budgets are advisory,
+/// not contractual: a planner with a 128K context window can request a
+/// larger budget; a benchmark harness can request a smaller one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanningBudget {
+    /// Soft token ceiling for the serialized view as it would appear in an
+    /// LLM prompt. Builders make best-effort decisions; the absolute cap is
+    /// the per-category limits below.
+    pub max_tokens: u32,
+    /// Maximum number of `PlanningElement` entries.
+    pub max_elements: u32,
+    /// Maximum number of `MemoryRef` entries (PR3 selector).
+    pub max_memories: u32,
+    /// Maximum number of `AdapterFactRef` entries.
+    pub max_adapter_facts: u32,
+}
+
+impl Default for PlanningBudget {
+    /// Defaults sized to keep prompts under common LLM context windows.
+    /// Planners override per-call when they know better.
+    fn default() -> Self {
+        Self {
+            max_tokens: 8000,
+            max_elements: 80,
+            max_memories: 8,
+            max_adapter_facts: 12,
+        }
+    }
+}
+
+// ─── Run progress ────────────────────────────────────────────────────────────
+
+/// How much of the run budget the planner has consumed so far.
+///
+/// Replaces the `steps_used` / `max_steps` fields of the legacy `RuntimeCaps`.
+/// Helps the planner pace itself toward the terminal phase of the goal.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunProgress {
+    /// Steps already consumed on this run (zero on the first call).
+    pub steps_used: u32,
+    /// Hard cap on total steps for this run.
+    pub max_steps: u32,
+}
+
+impl RunProgress {
+    pub fn steps_remaining(&self) -> u32 {
+        self.max_steps.saturating_sub(self.steps_used)
+    }
+}
+
+// ─── Screen summary ──────────────────────────────────────────────────────────
+
+/// Compact screen-level summary written by perception.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PlanningScreen {
+    /// Frontmost application name (e.g. "Google Chrome", "Numbers").
+    pub active_app: String,
+    /// Active window title.
+    #[serde(default)]
+    pub window: String,
+    /// One-paragraph natural-language summary of what is on screen.
+    /// Optional — builders may leave empty for the deterministic path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Current URL when the active app is a browser with CDP bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+// ─── Compact element representation ──────────────────────────────────────────
+
+/// Compressed element representation for the planner.
+///
+/// Strict subset of `cel_context::ContextElement` — drops bounds, parent_id,
+/// full action vectors, source provenance, properties HashMap. Keeps what
+/// the planner needs to identify and act on the element. Builders embed
+/// only goal-relevant elements (and nearby anchors) to fit the budget.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanningElement {
+    /// Stable element identifier the planner uses in `PlannedAction`.
+    pub id: String,
+    /// Element kind: "button", "input", "link", "checkbox", "row", etc.
+    pub element_type: String,
+    /// Human-readable label or visible text. Optional — labelless elements
+    /// may still be selected when nearby labels clarify them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Current value for inputs / selects / cells.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// State anchors the planner needs to reason about (focused, selected,
+    /// enabled, checked, expanded). Compact subset of `ElementState`.
+    pub state: PlanningElementState,
+    /// Whether this element supports a click-equivalent action.
+    #[serde(default)]
+    pub clickable: bool,
+    /// Whether this element supports `set_value` (form fields).
+    #[serde(default)]
+    pub settable: bool,
+}
+
+/// State flags that matter for planning. Strict subset of `ElementState`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PlanningElementState {
+    pub focused: bool,
+    pub selected: bool,
+    pub enabled: bool,
+    pub checked: bool,
+    pub expanded: bool,
+}
+
+// ─── References to source records ────────────────────────────────────────────
+
+/// Reference to a memory record selected for this view.
+///
+/// Hydrated by the memory-aware selector (PR3). PR1a builders leave this
+/// list empty.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryRef {
+    /// Stable id of the memory record in `cortex_memories`.
+    pub id: i64,
+    /// Memory kind: "outcome", "prior", "failure", "preference".
+    pub kind: String,
+    /// One-line summary suitable for embedding in a prompt.
+    pub summary: String,
+    /// Raw content payload (free text or structured JSON).
+    pub content: serde_json::Value,
+    /// When the memory was created (ISO-8601 string).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+/// Reference to a knowledge record selected for this view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnowledgeRef {
+    pub id: i64,
+    pub source: String,
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+/// Reference to an adapter-backed fact relevant to the goal.
+///
+/// Adapters expose typed facts (e.g. `{adapter: "numbers", kind: "table",
+/// payload: { sheet: "Sheet 1", rows: 12, cols: 8 }}`). Selectors include
+/// only facts about the active adapter for the focused app.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdapterFactRef {
+    pub adapter: String,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+/// Reference to a capability the runtime currently has wired up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityRef {
+    /// Capability identifier: "cdp_bound", "native_input", "vision",
+    /// "numbers_write_cells", etc.
+    pub id: String,
+    /// Free-form details (browser name + URL for cdp_bound, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Reference to a recent event the planner should be aware of.
+///
+/// Examples: a checkpoint summary, a recent failed action, a window
+/// activation. The full event lives in the run transcript / store; the
+/// view carries only what's needed to prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventRef {
+    /// Stable identifier or hash for cross-referencing the source record.
+    pub id: String,
+    /// Event kind: "checkpoint", "action_failed", "focus_changed", …
+    pub kind: String,
+    /// One-line natural-language description.
+    pub summary: String,
+    /// Optional ISO-8601 timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+}
+
+/// Reference to evidence that explains why selection picked something.
+///
+/// Lets a planner trace a memory or fact back to its source record without
+/// inflating the view itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    /// Where this evidence came from: "memory", "knowledge", "transcript",
+    /// "adapter_fact".
+    pub source: String,
+    /// Stable id within that source.
+    pub id: String,
+    /// One-line description suitable for inclusion in prompts.
+    pub summary: String,
+}
+
+/// Reference to an anomaly the cortex flagged that the planner should see.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnomalyRef {
+    /// Anomaly kind: "stale_state", "unexpected_window", "missing_target",
+    /// "low_confidence", …
+    pub kind: String,
+    /// Human-readable description.
+    pub description: String,
+}
+
+/// First-class blocker that should not be lost to compression.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Blocker {
+    /// Blocker kind: "consent_wall", "modal_dialog", "missing_capability",
+    /// "auth_required", …
+    pub kind: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Optional element id that represents the blocker (e.g. the consent
+    /// banner's accept button).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub element_id: Option<String>,
+}
+
+// ─── What was dropped ────────────────────────────────────────────────────────
+
+/// Counts of items the builder filtered out to fit the budget.
+///
+/// Lets the planner notice that the view is compressed and decide whether
+/// to act on what it sees, request a tier-up, or pivot.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OmittedCounts {
+    pub elements: u32,
+    pub memories: u32,
+    pub knowledge: u32,
+    pub adapter_facts: u32,
+    pub recent_events: u32,
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_default_keeps_typical_prompts_under_common_windows() {
+        // Defaults must not push a prompt over 8K tokens for typical use.
+        // Planners with bigger windows override per-call.
+        let b = PlanningBudget::default();
+        assert!(b.max_tokens <= 8000);
+        assert!(b.max_elements <= 100);
+        assert!(b.max_memories <= 16);
+    }
+
+    #[test]
+    fn empty_view_serializes_compactly() {
+        let view = PlanningView {
+            goal: "test".into(),
+            budget: PlanningBudget::default(),
+            screen: PlanningScreen {
+                active_app: "TestApp".into(),
+                window: "main".into(),
+                summary: None,
+                url: None,
+            },
+            elements: vec![],
+            adapter_facts: vec![],
+            capabilities: vec![],
+            memories: vec![],
+            knowledge: vec![],
+            recent_events: vec![],
+            blockers: vec![],
+            anomalies: vec![],
+            evidence: vec![],
+            selection_rationale: None,
+            omitted_counts: OmittedCounts::default(),
+            run_progress: RunProgress::default(),
+        };
+        let json = serde_json::to_string(&view).unwrap();
+        // Empty-list fields use `default` + `skip_serializing_if` where
+        // appropriate; sanity-check the size is small for an empty view.
+        assert!(
+            json.len() < 700,
+            "empty view should serialize compactly, got {} chars",
+            json.len()
+        );
+    }
+
+    #[test]
+    fn view_roundtrips_through_json() {
+        let view = PlanningView {
+            goal: "submit form".into(),
+            budget: PlanningBudget {
+                max_tokens: 4000,
+                max_elements: 40,
+                max_memories: 4,
+                max_adapter_facts: 6,
+            },
+            screen: PlanningScreen {
+                active_app: "Browser".into(),
+                window: "Concur — Expenses".into(),
+                summary: Some("Expense form, partially filled".into()),
+                url: Some("https://concur.example.com/expenses".into()),
+            },
+            elements: vec![PlanningElement {
+                id: "dom:submit".into(),
+                element_type: "button".into(),
+                label: Some("Submit for Approval".into()),
+                value: None,
+                state: PlanningElementState {
+                    focused: false,
+                    selected: false,
+                    enabled: true,
+                    checked: false,
+                    expanded: false,
+                },
+                clickable: true,
+                settable: false,
+            }],
+            adapter_facts: vec![],
+            capabilities: vec![CapabilityRef {
+                id: "cdp_bound".into(),
+                detail: Some("Google Chrome — concur.example.com".into()),
+            }],
+            memories: vec![],
+            knowledge: vec![],
+            recent_events: vec![],
+            blockers: vec![],
+            anomalies: vec![],
+            evidence: vec![],
+            selection_rationale: Some("Submit-related element + cdp capability".into()),
+            omitted_counts: OmittedCounts {
+                elements: 431,
+                ..Default::default()
+            },
+            run_progress: RunProgress {
+                steps_used: 7,
+                max_steps: 80,
+            },
+        };
+        let json = serde_json::to_string(&view).unwrap();
+        let back: PlanningView = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.goal, view.goal);
+        assert_eq!(back.elements.len(), 1);
+        assert_eq!(back.capabilities[0].id, "cdp_bound");
+        assert_eq!(back.omitted_counts.elements, 431);
+        assert_eq!(back.run_progress.steps_remaining(), 73);
+    }
+
+    #[test]
+    fn run_progress_remaining_saturates_at_zero() {
+        let p = RunProgress {
+            steps_used: 100,
+            max_steps: 80,
+        };
+        assert_eq!(p.steps_remaining(), 0);
+    }
+}

--- a/cel/cel-cortex/src/lib.rs
+++ b/cel/cel-cortex/src/lib.rs
@@ -41,6 +41,7 @@ pub mod differ;
 pub mod manager;
 pub mod memory;
 pub mod model;
+pub mod planning_view;
 pub mod process_driver;
 pub mod skeleton;
 
@@ -57,4 +58,5 @@ pub use model::{
     FreshnessAssessment, FreshnessState, LoadingState, MentalModel, PerceptionDiff,
     SemanticInsight, SourceSummary, StalenessCause, TaskPhase, TemporalFlags,
 };
+pub use planning_view::{build_planning_view, PlanningViewInputs};
 pub use process_driver::ProcessDriver;

--- a/cel/cel-cortex/src/planning_view.rs
+++ b/cel/cel-cortex/src/planning_view.rs
@@ -1,0 +1,521 @@
+//! Planning-view builder — projects rich Cortex state into a budgeted view.
+//!
+//! Implements the **store broadly, select narrowly** principle: the
+//! `MentalModel` (and underlying `ScreenContext`) can be 60K+ tokens of raw
+//! perception. The planner doesn't need that. This builder produces a
+//! `PlanningView` with the goal-relevant slice — current screen + selected
+//! elements + capabilities + run progress — and tracks what was dropped.
+//!
+//! In PR1a this is **deterministic only**:
+//!   - Score elements by goal-keyword + quoted-phrase + actionable-type
+//!     heuristics, drop the lowest-scoring to fit `budget.max_elements`.
+//!   - Memory / knowledge / event refs stay empty (populated by PR3).
+//!
+//! Later PRs add a memory-aware path on top of this same builder; the
+//! deterministic selector becomes the fallback when LLM-based selection is
+//! unavailable or times out.
+
+use std::collections::HashSet;
+
+use cel_context::{ContextElement, ScreenContext};
+use cel_contracts::{
+    CapabilityRef, OmittedCounts, PlanningBudget, PlanningElement, PlanningElementState,
+    PlanningScreen, PlanningView, RunProgress, RuntimeCaps,
+};
+
+/// Inputs the builder needs from the cortex / runner side.
+///
+/// Kept as a borrowed-data struct so the runner can build it once per
+/// turn from its own state without copying.
+pub struct PlanningViewInputs<'a> {
+    pub goal: &'a str,
+    pub budget: &'a PlanningBudget,
+    pub perception: &'a ScreenContext,
+    pub caps: &'a RuntimeCaps,
+}
+
+/// Build a budgeted `PlanningView` from current cortex perception + caps.
+///
+/// Deterministic — no LLM calls, no memory lookups (those land in PR3).
+/// Selects the goal-relevant elements, folds runtime capabilities into the
+/// view, fills `run_progress`, tracks omitted counts.
+pub fn build_planning_view(inputs: &PlanningViewInputs<'_>) -> PlanningView {
+    let total_elements = inputs.perception.elements.len() as u32;
+    let elements = select_elements(inputs.perception, inputs.goal, inputs.budget.max_elements);
+    let kept_elements = elements.len() as u32;
+    let omitted_elements = total_elements.saturating_sub(kept_elements);
+
+    PlanningView {
+        goal: inputs.goal.to_string(),
+        budget: inputs.budget.clone(),
+        screen: PlanningScreen {
+            active_app: inputs.perception.app.clone(),
+            window: inputs.perception.window.clone(),
+            summary: None,
+            url: inputs.caps.cdp_url.clone(),
+        },
+        elements,
+        adapter_facts: vec![],
+        capabilities: caps_to_capabilities(inputs.caps),
+        memories: vec![],
+        knowledge: vec![],
+        recent_events: vec![],
+        blockers: vec![],
+        anomalies: vec![],
+        evidence: vec![],
+        selection_rationale: None,
+        omitted_counts: OmittedCounts {
+            elements: omitted_elements,
+            ..Default::default()
+        },
+        run_progress: RunProgress {
+            steps_used: inputs.caps.steps_used,
+            max_steps: inputs.caps.max_steps,
+        },
+    }
+}
+
+// ─── Capabilities folding ────────────────────────────────────────────────────
+
+fn caps_to_capabilities(caps: &RuntimeCaps) -> Vec<CapabilityRef> {
+    let mut out = Vec::with_capacity(2);
+    if caps.cdp_bound {
+        out.push(CapabilityRef {
+            id: "cdp_bound".into(),
+            detail: caps.cdp_browser.clone(),
+        });
+    }
+    if caps.native_input {
+        out.push(CapabilityRef {
+            id: "native_input".into(),
+            detail: None,
+        });
+    }
+    out
+}
+
+// ─── Element selection (deterministic) ───────────────────────────────────────
+
+fn select_elements(context: &ScreenContext, goal: &str, max_elements: u32) -> Vec<PlanningElement> {
+    let max = max_elements as usize;
+    if max == 0 {
+        return Vec::new();
+    }
+
+    let keywords = extract_keywords(goal);
+    let quoted = extract_quoted_phrases(goal);
+    let is_extract = is_extraction_goal(goal);
+
+    let mut scored: Vec<(f64, &ContextElement)> = context
+        .elements
+        .iter()
+        .filter(|el| el.state.visible)
+        .map(|el| (score_element(el, &keywords, &quoted, is_extract), el))
+        .collect();
+
+    // Stable sort by score descending so deterministic ordering is preserved
+    // when scores tie.
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut out: Vec<PlanningElement> = scored
+        .iter()
+        .filter(|(s, _)| *s > 0.0)
+        .take(max)
+        .map(|(_, el)| compress(el))
+        .collect();
+
+    // Always include `page-text` if present and we're not at budget.
+    if out.len() < max && out.iter().all(|e| e.id != "page-text") {
+        if let Some(pt) = context.elements.iter().find(|el| el.id == "page-text") {
+            out.push(compress(pt));
+        }
+    }
+
+    out
+}
+
+fn compress(el: &ContextElement) -> PlanningElement {
+    PlanningElement {
+        id: el.id.clone(),
+        element_type: el.element_type.clone(),
+        label: el.label.clone(),
+        value: el.value.clone(),
+        state: PlanningElementState {
+            focused: el.state.focused,
+            selected: el.state.selected,
+            enabled: el.state.enabled,
+            checked: el.state.checked.unwrap_or(false),
+            expanded: el.state.expanded.unwrap_or(false),
+        },
+        clickable: !el.actions.is_empty()
+            || matches!(
+                el.element_type.as_str(),
+                "button" | "link" | "a" | "checkbox" | "radio_button" | "menu_item"
+            ),
+        settable: matches!(
+            el.element_type.as_str(),
+            "input" | "textarea" | "combobox" | "select"
+        ),
+    }
+}
+
+// ─── Scoring (ported from cel-planner/distiller.rs) ──────────────────────────
+
+const ACTIONABLE_TYPES: &[&str] = &[
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "a",
+    "link",
+    "checkbox",
+    "radio_button",
+    "combobox",
+    "slider",
+    "tab",
+    "menu_item",
+];
+
+const GENERIC_ACTION_LABELS: &[&str] = &[
+    "open",
+    "close",
+    "cancel",
+    "ok",
+    "more",
+    "menu",
+    "next",
+    "back",
+    "learn more",
+    "details",
+    "view",
+    "edit",
+    "delete",
+    "remove",
+    "select",
+    "continue",
+    "submit",
+    "save",
+    "apply",
+    "retry",
+    "dismiss",
+];
+
+const CHROME_HINT_KEYWORDS: &[&str] = &[
+    "header",
+    "nav",
+    "navbar",
+    "toolbar",
+    "menu",
+    "sidebar",
+    "breadcrumb",
+    "footer",
+    "legal",
+    "cookie",
+    "consent",
+    "account",
+    "profile",
+    "help",
+    "support",
+    "social",
+    "share",
+    "newsletter",
+    "chat",
+    "intercom",
+];
+
+const STOP_WORDS: &[&str] = &[
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "and", "or", "but", "in", "on",
+    "at", "to", "for", "of", "with", "from", "by", "as", "it", "do", "not", "this", "that", "my",
+    "me", "i", "you", "we", "can", "will", "just", "any", "all", "each", "find", "search", "open",
+    "read", "get", "show", "tell", "what", "how", "please",
+];
+
+fn is_actionable(element_type: &str) -> bool {
+    ACTIONABLE_TYPES.contains(&element_type)
+}
+
+fn is_generic_label(label: &str) -> bool {
+    GENERIC_ACTION_LABELS.contains(&label.to_lowercase().as_str())
+}
+
+fn extract_keywords(goal: &str) -> Vec<String> {
+    let stop: HashSet<&str> = STOP_WORDS.iter().copied().collect();
+    goal.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.len() > 2 && !stop.contains(w))
+        .map(|w| w.to_string())
+        .collect()
+}
+
+fn extract_quoted_phrases(goal: &str) -> Vec<String> {
+    let mut phrases = Vec::new();
+    let mut in_quote = false;
+    let mut current = String::new();
+    let mut quote_char = '"';
+
+    for ch in goal.chars() {
+        if !in_quote && (ch == '"' || ch == '\'') {
+            in_quote = true;
+            quote_char = ch;
+            current.clear();
+        } else if in_quote && ch == quote_char {
+            if current.len() > 2 {
+                phrases.push(current.to_lowercase());
+            }
+            in_quote = false;
+            current.clear();
+        } else if in_quote {
+            current.push(ch);
+        }
+    }
+    phrases
+}
+
+fn is_extraction_goal(goal: &str) -> bool {
+    let lower = goal.to_lowercase();
+    lower.contains("extract")
+        || lower.contains("read")
+        || lower.contains("what is")
+        || lower.contains("how many")
+        || lower.contains("find")
+        || lower.contains("list")
+        || lower.contains("get the")
+}
+
+fn score_element(
+    el: &ContextElement,
+    keywords: &[String],
+    quoted_phrases: &[String],
+    is_extract: bool,
+) -> f64 {
+    let mut score: f64 = 0.0;
+    let label = el.label.as_deref().unwrap_or("").to_lowercase();
+    let value = el.value.as_deref().unwrap_or("").to_lowercase();
+    let text = format!("{} {} {}", label, value, el.element_type);
+
+    for kw in keywords {
+        if text.contains(kw.as_str()) {
+            score += 2.0;
+        }
+    }
+    for phrase in quoted_phrases {
+        if label == *phrase {
+            score += 50.0;
+        }
+    }
+    if label.len() > 4 {
+        let goal_lower: String = keywords.join(" ");
+        if goal_lower.contains(&label) && label.contains(' ') {
+            score += 20.0;
+        }
+    }
+    if is_extract {
+        if matches!(el.element_type.as_str(), "text" | "heading" | "static_text") {
+            score += 3.0;
+        }
+        if el.id == "page-text" {
+            score += 50.0;
+        }
+    } else if el.id == "page-text" {
+        score += 5.0;
+    }
+    if is_actionable(&el.element_type) {
+        score += 1.0;
+    }
+    if el.state.visible && el.state.enabled {
+        score += 0.5;
+    }
+    if !el.actions.is_empty() {
+        score += 0.5;
+    }
+    let label_len = el.label.as_ref().map(|l| l.len()).unwrap_or(0);
+    if label_len > 30 {
+        score += 2.0;
+    } else if label_len > 15 {
+        score += 1.0;
+    } else if label_len <= 5 && is_actionable(&el.element_type) {
+        score -= 1.0;
+    }
+    if is_generic_label(&label) && is_actionable(&el.element_type) {
+        score -= 1.5;
+    }
+    let props_hint = el
+        .properties
+        .get("css_selector")
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    for kw in CHROME_HINT_KEYWORDS {
+        if props_hint.contains(kw) {
+            score -= 4.0;
+            break;
+        }
+    }
+
+    score
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cel_context::ElementState;
+
+    fn make_el(id: &str, ty: &str, label: Option<&str>) -> ContextElement {
+        ContextElement {
+            id: id.into(),
+            label: label.map(String::from),
+            description: None,
+            element_type: ty.into(),
+            value: None,
+            bounds: None,
+            state: ElementState {
+                visible: true,
+                enabled: true,
+                ..Default::default()
+            },
+            parent_id: None,
+            actions: vec![],
+            confidence: 1.0,
+            source: cel_context::ContextSource::AccessibilityTree,
+            content_role: cel_context::ContentRole::Interactive,
+            properties: Default::default(),
+        }
+    }
+
+    fn make_context(elements: Vec<ContextElement>) -> ScreenContext {
+        ScreenContext {
+            app: "Browser".into(),
+            window: "Test".into(),
+            elements,
+            network_events: vec![],
+            http_events: vec![],
+            timestamp_ms: 0,
+            screen_width: None,
+            screen_height: None,
+            clipboard: None,
+            window_list: vec![],
+            audio: None,
+            power: None,
+            running_apps: vec![],
+            recent_files: vec![],
+            transcripts: vec![],
+        }
+    }
+
+    #[test]
+    fn budget_caps_element_count_and_records_omitted() {
+        let elements: Vec<ContextElement> = (0..200)
+            .map(|i| make_el(&format!("e{i}"), "button", Some("Submit form")))
+            .collect();
+        let perception = make_context(elements);
+        let caps = RuntimeCaps::default();
+        let budget = PlanningBudget {
+            max_elements: 30,
+            ..Default::default()
+        };
+        let view = build_planning_view(&PlanningViewInputs {
+            goal: "submit the form",
+            budget: &budget,
+            perception: &perception,
+            caps: &caps,
+        });
+        assert_eq!(view.elements.len(), 30);
+        assert_eq!(view.omitted_counts.elements, 170);
+    }
+
+    #[test]
+    fn goal_relevant_elements_outrank_irrelevant_ones() {
+        let mut elements = Vec::new();
+        for i in 0..20 {
+            elements.push(make_el(&format!("noise{i}"), "button", Some("Open menu")));
+        }
+        elements.push(make_el("submit-1", "button", Some("Submit Invoice")));
+        elements.push(make_el("submit-2", "button", Some("Save Draft")));
+
+        let perception = make_context(elements);
+        let caps = RuntimeCaps::default();
+        let budget = PlanningBudget {
+            max_elements: 5,
+            ..Default::default()
+        };
+        let view = build_planning_view(&PlanningViewInputs {
+            goal: "submit the invoice",
+            budget: &budget,
+            perception: &perception,
+            caps: &caps,
+        });
+
+        let ids: Vec<&str> = view.elements.iter().map(|e| e.id.as_str()).collect();
+        assert!(
+            ids.contains(&"submit-1"),
+            "submit-related element should rank in top-5; got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn caps_fold_into_capabilities_and_run_progress() {
+        let perception = make_context(vec![]);
+        let caps = RuntimeCaps {
+            cdp_bound: true,
+            cdp_browser: Some("Google Chrome".into()),
+            cdp_url: Some("https://example.com".into()),
+            native_input: true,
+            steps_used: 13,
+            max_steps: 80,
+        };
+        let budget = PlanningBudget::default();
+        let view = build_planning_view(&PlanningViewInputs {
+            goal: "anything",
+            budget: &budget,
+            perception: &perception,
+            caps: &caps,
+        });
+
+        assert_eq!(view.run_progress.steps_used, 13);
+        assert_eq!(view.run_progress.max_steps, 80);
+        assert_eq!(view.run_progress.steps_remaining(), 67);
+
+        assert!(view.capabilities.iter().any(|c| c.id == "cdp_bound"));
+        assert!(view.capabilities.iter().any(|c| c.id == "native_input"));
+        assert_eq!(view.screen.url.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn empty_perception_yields_empty_view() {
+        let perception = make_context(vec![]);
+        let caps = RuntimeCaps::default();
+        let budget = PlanningBudget::default();
+        let view = build_planning_view(&PlanningViewInputs {
+            goal: "do nothing",
+            budget: &budget,
+            perception: &perception,
+            caps: &caps,
+        });
+        assert_eq!(view.elements.len(), 0);
+        assert_eq!(view.omitted_counts.elements, 0);
+        assert!(view.capabilities.is_empty());
+    }
+
+    #[test]
+    fn invisible_elements_are_filtered_before_scoring() {
+        let mut visible = make_el("visible", "button", Some("Submit"));
+        let mut hidden = make_el("hidden", "button", Some("Submit"));
+        hidden.state.visible = false;
+        visible.state.visible = true;
+
+        let perception = make_context(vec![hidden, visible]);
+        let caps = RuntimeCaps::default();
+        let budget = PlanningBudget {
+            max_elements: 10,
+            ..Default::default()
+        };
+        let view = build_planning_view(&PlanningViewInputs {
+            goal: "submit",
+            budget: &budget,
+            perception: &perception,
+            caps: &caps,
+        });
+        assert!(view.elements.iter().all(|e| e.id != "hidden"));
+    }
+}

--- a/cel/cel-goal-runner/src/canonical_runner.rs
+++ b/cel/cel-goal-runner/src/canonical_runner.rs
@@ -49,10 +49,10 @@ use tracing::{debug, info, warn};
 
 use cel_context::ScreenContext;
 use cel_contracts::{
-    AttemptRecord, FailureReport, GoalOutcome, NextMove, PlanProducer, PlannedAction, RunLimits,
-    RuntimeCaps, Step, StepResult,
+    AttemptRecord, FailureReport, GoalOutcome, NextMove, PlanProducer, PlannedAction,
+    PlanningBudget, RunLimits, RuntimeCaps, Step, StepResult,
 };
-use cel_cortex::Cortex;
+use cel_cortex::{build_planning_view, Cortex, PlanningViewInputs};
 
 use crate::outcome::ActionRecord;
 
@@ -147,6 +147,17 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
             caps.steps_used = steps_used;
             caps.max_steps = limits.max_steps;
 
+            // Build the budgeted planning view from this turn's perception +
+            // caps. Replaces the raw `&ScreenContext` + `&RuntimeCaps` pair
+            // the planner used to receive directly.
+            let planning_budget = PlanningBudget::default();
+            let view = build_planning_view(&PlanningViewInputs {
+                goal,
+                budget: &planning_budget,
+                perception: &perception,
+                caps: &caps,
+            });
+
             // Phase gate: past the budget midpoint with no terminal-
             // app work yet → inject a synthetic history record telling
             // the planner to pivot to the terminal app. Second ignore
@@ -202,14 +213,7 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
 
             let next = match self
                 .planner
-                .decide_next(
-                    goal,
-                    &history,
-                    &shared_memory,
-                    &perception,
-                    screenshot.as_deref(),
-                    &caps,
-                )
+                .decide_next(goal, &history, &shared_memory, &view, screenshot.as_deref())
                 .await
             {
                 Ok(nm) => nm,
@@ -247,13 +251,7 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
                     // more work or emits Fail with an honest reason.
                     let verdict = self
                         .planner
-                        .verify_done(
-                            goal,
-                            &summary,
-                            &shared_memory,
-                            &perception,
-                            screenshot.as_deref(),
-                        )
+                        .verify_done(goal, &summary, &shared_memory, &view, screenshot.as_deref())
                         .await;
                     match verdict {
                         Ok(v) if v.verified => {
@@ -974,9 +972,8 @@ mod tests {
             _goal: &str,
             _history: &[AttemptRecord],
             _shared: &serde_json::Value,
-            _perception: &ScreenContext,
+            _view: &cel_contracts::PlanningView,
             _shot: Option<&[u8]>,
-            _caps: &RuntimeCaps,
         ) -> Result<NextMove, String> {
             let mut g = self.moves.lock().unwrap();
             if g.len() > 1 {

--- a/cel/cel-napi/src/goal_runner.rs
+++ b/cel/cel-napi/src/goal_runner.rs
@@ -14,7 +14,10 @@
 use napi_derive::napi;
 use std::sync::Arc;
 
-use cel_contracts::{AttemptRecord, GoalOutcome, PlanProducer, RunLimits, RuntimeCaps, Step};
+use cel_contracts::{
+    AttemptRecord, GoalOutcome, PlanProducer, PlanningBudget, RunLimits, RuntimeCaps, Step,
+};
+use cel_cortex::{build_planning_view, PlanningViewInputs};
 use cel_goal_runner::{
     resolve_runtime_backend, CanonicalGoalRunner, CortexStepExecutor, GoalConfig, RuntimeBackend,
     StepExecutor,
@@ -210,14 +213,22 @@ pub async fn canonical_decide_next(
         .map_err(|e| napi::Error::from_reason(format!("Invalid perception JSON: {e}")))?;
     let screenshot = parse_screenshot_base64(screenshot_base64)?;
     let caps: RuntimeCaps = parse_json_or_default(&caps_json)?;
+    // Build the view inline so the JS surface stays the same in PR1a.
+    // PR1b will replace these N-API helpers with view-native variants.
+    let budget = PlanningBudget::default();
+    let view = build_planning_view(&PlanningViewInputs {
+        goal: &goal,
+        budget: &budget,
+        perception: &perception,
+        caps: &caps,
+    });
     let next = planner
         .decide_next(
             &goal,
             &history,
             &shared_memory,
-            &perception,
+            &view,
             screenshot.as_deref(),
-            &caps,
         )
         .await
         .map_err(napi::Error::from_reason)?;
@@ -244,12 +255,22 @@ pub async fn canonical_verify_done(
     let perception: cel_context::ScreenContext = serde_json::from_str(&perception_json)
         .map_err(|e| napi::Error::from_reason(format!("Invalid perception JSON: {e}")))?;
     let screenshot = parse_screenshot_base64(screenshot_base64)?;
+    // verify_done's view doesn't need budget-tight elements — empty caps
+    // is fine for the grader path (no capability prompting in verify).
+    let budget = PlanningBudget::default();
+    let caps = RuntimeCaps::default();
+    let view = build_planning_view(&PlanningViewInputs {
+        goal: &goal,
+        budget: &budget,
+        perception: &perception,
+        caps: &caps,
+    });
     let verdict = planner
         .verify_done(
             &goal,
             &summary,
             &shared_memory,
-            &perception,
+            &view,
             screenshot.as_deref(),
         )
         .await

--- a/cel/cel-planner/src/llm_plan_producer.rs
+++ b/cel/cel-planner/src/llm_plan_producer.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use cel_context::ScreenContext;
+use cel_contracts::PlanningView;
 use cel_llm::{ChatMessage, LlmClient, LlmError};
 
-use crate::canonical::{AttemptRecord, NextMove, RuntimeCaps};
+use crate::canonical::{AttemptRecord, NextMove};
 
 /// System prompt — reactive, not upfront.
 ///
@@ -246,11 +246,10 @@ impl crate::canonical_plan_producer::PlanProducer for LlmPlanProducer {
         goal: &str,
         history: &[AttemptRecord],
         shared_memory: &serde_json::Value,
-        perception: &ScreenContext,
+        view: &PlanningView,
         screenshot_png: Option<&[u8]>,
-        caps: &RuntimeCaps,
     ) -> Result<NextMove, String> {
-        let user = build_user_prompt(goal, history, shared_memory, perception, caps);
+        let user = build_user_prompt(goal, history, shared_memory, view);
         let raw = if let Some(png) = screenshot_png {
             let data_url = format!("data:image/png;base64,{}", cel_llm::base64_encode(png));
             self.client
@@ -282,10 +281,10 @@ impl crate::canonical_plan_producer::PlanProducer for LlmPlanProducer {
         goal: &str,
         summary: &str,
         shared_memory: &serde_json::Value,
-        perception: &ScreenContext,
+        view: &PlanningView,
         screenshot_png: Option<&[u8]>,
     ) -> Result<crate::canonical_plan_producer::DoneVerdict, String> {
-        let user = build_verify_done_user_prompt(goal, summary, shared_memory, perception);
+        let user = build_verify_done_user_prompt(goal, summary, shared_memory, view);
         let raw = if let Some(png) = screenshot_png {
             let data_url = format!("data:image/png;base64,{}", cel_llm::base64_encode(png));
             self.client
@@ -349,7 +348,7 @@ fn build_verify_done_user_prompt(
     goal: &str,
     summary: &str,
     shared_memory: &serde_json::Value,
-    perception: &ScreenContext,
+    view: &PlanningView,
 ) -> String {
     let mut out = String::new();
     out.push_str("## Goal\n");
@@ -361,8 +360,8 @@ fn build_verify_done_user_prompt(
         &serde_json::to_string(shared_memory).unwrap_or_else(|_| "{}".into()),
         1500,
     ));
-    out.push_str("\n\n## Current perception (first ~40 elements)\n");
-    for el in perception.elements.iter().take(40) {
+    out.push_str("\n\n## Current perception (selected elements)\n");
+    for el in view.elements.iter().take(40) {
         let label = el.label.clone().unwrap_or_default();
         let value = el.value.clone().unwrap_or_default();
         let line = format!(
@@ -432,8 +431,7 @@ pub fn build_user_prompt(
     goal: &str,
     history: &[AttemptRecord],
     shared_memory: &serde_json::Value,
-    perception: &ScreenContext,
-    caps: &RuntimeCaps,
+    view: &PlanningView,
 ) -> String {
     let mut out = String::with_capacity(4096);
     out.push_str("## Goal\n");
@@ -445,11 +443,13 @@ pub fn build_user_prompt(
     // of "the planner emits ax_action when only CDP is bound, or
     // switches to Safari when the CDP target is Chrome". Keep this
     // short and declarative.
+    let cdp_cap = view.capabilities.iter().find(|c| c.id == "cdp_bound");
+    let native_cap = view.capabilities.iter().find(|c| c.id == "native_input");
     out.push_str("\n## Runtime capabilities\n");
-    if caps.cdp_bound {
-        let browser = caps.cdp_browser.as_deref().unwrap_or("Chrome");
+    if let Some(cap) = cdp_cap {
+        let browser = cap.detail.as_deref().unwrap_or("Chrome");
         out.push_str(&format!("  - CDP-controlled browser: {}\n", browser));
-        if let Some(url) = &caps.cdp_url {
+        if let Some(url) = &view.screen.url {
             out.push_str(&format!("  - Current page: {}\n", url));
         }
         out.push_str(
@@ -461,7 +461,7 @@ pub fn build_user_prompt(
     } else {
         out.push_str("  - No CDP-controlled browser bound. Skip `cdp_eval` and `navigate`.\n");
     }
-    if caps.native_input {
+    if native_cap.is_some() {
         out.push_str("  - Native input (keyboard / mouse / AX / activate_app) enabled.\n");
     } else {
         out.push_str(
@@ -471,14 +471,16 @@ pub fn build_user_prompt(
         );
     }
 
-    if caps.max_steps > 0 {
-        let remaining = caps.max_steps.saturating_sub(caps.steps_used);
-        let pct_used = (caps.steps_used as f32 / caps.max_steps as f32 * 100.0).round() as u32;
+    let progress = &view.run_progress;
+    if progress.max_steps > 0 {
+        let remaining = progress.steps_remaining();
+        let pct_used =
+            (progress.steps_used as f32 / progress.max_steps as f32 * 100.0).round() as u32;
         out.push_str(&format!(
             "\n## Step budget\n  - Used {} / {} ({}%). Remaining: {}.\n",
-            caps.steps_used, caps.max_steps, pct_used, remaining
+            progress.steps_used, progress.max_steps, pct_used, remaining
         ));
-        if remaining <= caps.max_steps / 4 {
+        if remaining <= progress.max_steps / 4 {
             // Last 25% of budget — hard stop on new gathering.
             out.push_str(
                 "  - You are in the FINAL QUARTER of the budget. STOP starting\n    \
@@ -488,7 +490,7 @@ pub fn build_user_prompt(
                    if partial. Running out of steps without a terminal is a\n    \
                    worse outcome than a partial Done.\n",
             );
-        } else if remaining <= caps.max_steps / 2 {
+        } else if remaining <= progress.max_steps / 2 {
             // Midpoint — pivot away from exploration.
             out.push_str(
                 "  - You are past the midpoint. Start folding gathered data into\n    \
@@ -605,21 +607,18 @@ pub fn build_user_prompt(
     }
 
     out.push_str("\n## Live perception\n");
-    let app = if perception.app.is_empty() {
+    let app = if view.screen.active_app.is_empty() {
         "<none>"
     } else {
-        &perception.app
+        view.screen.active_app.as_str()
     };
-    out.push_str(&format!("APP: {}\nWINDOW: {}\n", app, perception.window));
-    out.push_str("Interactive elements (top 50):\n");
+    out.push_str(&format!("APP: {}\nWINDOW: {}\n", app, view.screen.window));
+    if let Some(summary) = &view.screen.summary {
+        out.push_str(&format!("SUMMARY: {}\n", summary));
+    }
+    out.push_str("Selected elements:\n");
     let mut shown = 0;
-    for el in perception.elements.iter() {
-        if shown >= 50 {
-            break;
-        }
-        if !el.state.visible || !el.state.enabled {
-            continue;
-        }
+    for el in view.elements.iter() {
         let label = el.label.as_deref().unwrap_or("");
         let value = el.value.as_deref().unwrap_or("");
         out.push_str(&format!(
@@ -629,7 +628,29 @@ pub fn build_user_prompt(
         shown += 1;
     }
     if shown == 0 {
-        out.push_str("  (no interactive elements surfaced)\n");
+        out.push_str("  (no elements selected by the planning view)\n");
+    }
+    if view.omitted_counts.elements > 0 {
+        out.push_str(&format!(
+            "  … {} more elements omitted to fit the planning budget. Re-perceive if you need them.\n",
+            view.omitted_counts.elements
+        ));
+    }
+    if !view.blockers.is_empty() {
+        out.push_str("\n## Blockers\n");
+        for b in &view.blockers {
+            out.push_str(&format!("  - [{}] {}", b.kind, b.description));
+            if let Some(eid) = &b.element_id {
+                out.push_str(&format!(" (element {})", eid));
+            }
+            out.push('\n');
+        }
+    }
+    if !view.adapter_facts.is_empty() {
+        out.push_str("\n## Adapter facts\n");
+        for f in &view.adapter_facts {
+            out.push_str(&format!("  - [{}/{}] {}\n", f.adapter, f.kind, f.payload));
+        }
     }
 
     out.push_str("\nReturn the next move (batch / done / fail) as JSON now.");
@@ -798,8 +819,7 @@ mod tests {
             "do the thing",
             std::slice::from_ref(&rec),
             &serde_json::json!({}),
-            &empty_perception(),
-            &RuntimeCaps::default(),
+            &empty_view(),
         );
         assert!(out.contains("error=\""));
         assert!(
@@ -808,24 +828,77 @@ mod tests {
         );
     }
 
-    fn empty_perception() -> ScreenContext {
-        ScreenContext {
-            app: String::new(),
-            window: String::new(),
+    fn empty_view() -> PlanningView {
+        PlanningView {
+            goal: String::new(),
+            budget: cel_contracts::PlanningBudget::default(),
+            screen: cel_contracts::PlanningScreen::default(),
             elements: vec![],
-            network_events: vec![],
-            http_events: vec![],
-            timestamp_ms: 0,
-            screen_width: None,
-            screen_height: None,
-            clipboard: None,
-            window_list: vec![],
-            audio: None,
-            power: None,
-            running_apps: vec![],
-            recent_files: vec![],
-            transcripts: vec![],
+            adapter_facts: vec![],
+            capabilities: vec![],
+            memories: vec![],
+            knowledge: vec![],
+            recent_events: vec![],
+            blockers: vec![],
+            anomalies: vec![],
+            evidence: vec![],
+            selection_rationale: None,
+            omitted_counts: cel_contracts::OmittedCounts::default(),
+            run_progress: cel_contracts::RunProgress::default(),
         }
+    }
+
+    #[test]
+    fn prompt_renders_view_capabilities_and_run_progress() {
+        let mut view = empty_view();
+        view.capabilities.push(cel_contracts::CapabilityRef {
+            id: "cdp_bound".into(),
+            detail: Some("Google Chrome".into()),
+        });
+        view.capabilities.push(cel_contracts::CapabilityRef {
+            id: "native_input".into(),
+            detail: None,
+        });
+        view.screen.url = Some("https://example.com".into());
+        view.run_progress = cel_contracts::RunProgress {
+            steps_used: 7,
+            max_steps: 80,
+        };
+        let out = build_user_prompt("any goal", &[], &serde_json::json!({}), &view);
+        assert!(out.contains("CDP-controlled browser: Google Chrome"));
+        assert!(out.contains("https://example.com"));
+        assert!(out.contains("Native input"));
+        assert!(out.contains("Used 7 / 80"));
+    }
+
+    #[test]
+    fn prompt_signals_omitted_elements_so_planner_knows_view_was_compressed() {
+        let mut view = empty_view();
+        view.omitted_counts.elements = 431;
+        let out = build_user_prompt("any goal", &[], &serde_json::json!({}), &view);
+        assert!(
+            out.contains("431 more elements omitted"),
+            "prompt must surface omitted-count so the planner knows the view is compressed"
+        );
+    }
+
+    #[test]
+    fn prompt_renders_blockers_and_adapter_facts() {
+        let mut view = empty_view();
+        view.blockers.push(cel_contracts::Blocker {
+            kind: "consent_wall".into(),
+            description: "Cookie banner blocks page".into(),
+            element_id: Some("dom:cookie-accept".into()),
+        });
+        view.adapter_facts.push(cel_contracts::AdapterFactRef {
+            adapter: "numbers".into(),
+            kind: "table".into(),
+            payload: serde_json::json!({"sheet":"Sheet 1","rows":12,"cols":8}),
+        });
+        let out = build_user_prompt("any goal", &[], &serde_json::json!({}), &view);
+        assert!(out.contains("[consent_wall]"));
+        assert!(out.contains("dom:cookie-accept"));
+        assert!(out.contains("[numbers/table]"));
     }
 
     #[test]


### PR DESCRIPTION
feat(cel): PlanningView contract + cortex builder + canonical runner consumes view (PR1a)

Lands the central contract change from COGNITION_LAYER_PLAN.md: planners
no longer receive raw `&ScreenContext` + `&RuntimeCaps`. They receive a
budgeted `PlanningView` built by `cel-cortex` from the current MentalModel
plus runtime capabilities. This is the "store broadly, select narrowly"
principle made concrete.

What ships
==========

Types (cel-contracts/src/view.rs)
---------------------------------
- `PlanningView` — top-level projection: goal, budget, screen, elements,
  capabilities, run_progress, plus typed-but-empty memories/knowledge/
  events/blockers/anomalies/evidence (populated by PR2/PR3).
- `PlanningBudget` — caller-provided ceilings (max_tokens, max_elements,
  max_memories, max_adapter_facts) with sensible defaults sized to keep
  prompts under common LLM context windows.
- `PlanningElement` + `PlanningElementState` — compressed element shape
  that drops bounds/parent_id/full action vectors/properties from
  `ContextElement`. Keeps id, type, label, value, key state flags
  (focused/selected/enabled/checked/expanded), clickable, settable.
- `PlanningScreen` — active app, window, optional summary, optional URL.
- `RunProgress` — steps_used / max_steps / steps_remaining(). Replaces
  the legacy `RuntimeCaps` pacing fields.
- Ref types for later PRs: `MemoryRef`, `KnowledgeRef`, `AdapterFactRef`,
  `CapabilityRef`, `EventRef`, `EvidenceRef`, `AnomalyRef`, `Blocker`.
- `OmittedCounts` — what the builder dropped to fit budget; surfaced in
  the prompt so the planner knows the view is compressed.

Trait change (cel-contracts/src/producer.rs)
--------------------------------------------
- `PlanProducer.decide_next` now takes `&PlanningView` instead of
  `&ScreenContext` + `&RuntimeCaps`. Same for `verify_done`. Drops the
  `caps` parameter entirely (folded into view.capabilities + run_progress).
- Single signature change (Option A in design discussion). Both in-tree
  impls — `LlmPlanProducer` and the `ScriptedPlanner` test fixture —
  updated. No backwards-compat decide_next_v2 is added.

Cortex-side builder (cel-cortex/src/planning_view.rs)
-----------------------------------------------------
- `build_planning_view(PlanningViewInputs)` — deterministic selector.
  Filters perception.elements by visibility, scores by goal-keyword +
  quoted-phrase + actionable-type heuristics (port of cel-planner's
  `distiller.rs` logic), takes top-N within `budget.max_elements`,
  always includes `page-text` if room, records omitted count.
- Folds RuntimeCaps boolean flags into `view.capabilities` and pacing
  fields into `view.run_progress`. CDP url goes to `view.screen.url`.
- Memory/knowledge/event/blocker/anomaly/evidence fields stay empty in
  PR1a — populated by PR3's memory-aware selector.
- 5 unit tests: budget enforcement, goal-relevant ranking, caps folding,
  empty input, invisible-element filtering.

Planner update (cel-planner/src/llm_plan_producer.rs)
-----------------------------------------------------
- `LlmPlanProducer.decide_next` and `verify_done` take `&PlanningView`.
- `build_user_prompt` and `build_verify_done_user_prompt` rewritten to
  read from `view.screen` / `view.capabilities` / `view.run_progress` /
  `view.elements` / `view.blockers` / `view.adapter_facts` /
  `view.omitted_counts` instead of perception+caps directly.
- Prompt also surfaces the omitted-elements count so the planner knows
  the view is compressed.
- 4 new tests cover view-driven prompt rendering: capabilities + run
  progress, omitted-elements signal, blockers + adapter facts.

Runner integration (cel-goal-runner/src/canonical_runner.rs)
------------------------------------------------------------
- `CanonicalGoalRunner` builds `PlanningView` once per turn from the
  executor's perception + caps and passes `&view` to both `decide_next`
  and `verify_done`.
- ScriptedPlanner test fixture updated to the new signature.

N-API bridge (cel-napi/src/goal_runner.rs)
------------------------------------------
- `canonical_decide_next` and `canonical_verify_done` now build the
  view inline from their existing perception + caps inputs and pass it
  to the planner. JS-facing argument shape unchanged in PR1a — PR1b
  replaces these helpers with view-native variants.

What does NOT ship in PR1a
==========================

- LangGraph TS-side migration (PR1b).
- MCP `view: "planning"` mode (PR1b).
- Adapter fact population in views (PR1b or PR4).
- Persistent memory store (PR2).
- Memory-aware selection (PR3).
- LLM-based selector (PR4).

Acceptance
==========

- `cargo check --workspace --all-targets` clean
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace`: 630 tests passed, 0 failed
- 5 new selector tests in cel-cortex; 4 new prompt-from-view tests in
  cel-planner; 3 view roundtrip tests in cel-contracts. All pass.
