### PR TITLE
feat(cel): PlanningView for all planner surfaces (PR1b)

### DIFF
--- a/agent/src/cel-bindings.ts
+++ b/agent/src/cel-bindings.ts
@@ -34,6 +34,8 @@ import type {
   DoneVerdict,
   NextMove,
   PerceptionFrame,
+  PlanningBudget,
+  PlanningView,
   RuntimeCaps,
 } from "./langgraph/canonical.js";
 
@@ -221,19 +223,29 @@ export interface CelNative {
   cortexRefreshNow(timeoutMs?: number): Promise<number>;
   runGoalRust(configJson: string): Promise<string>;
   canonicalPerceive(captureScreenshot?: boolean): Promise<string>;
-  canonicalDecideNext(
+  /**
+   * Build a budgeted PlanningView via the cortex-side selector.
+   * Stateful when perceptionJson + capsJson are omitted (uses booted cortex);
+   * stateless when both are provided. budgetJson is optional.
+   */
+  canonicalBuildPlanningView(
     goal: string,
+    budgetJson?: string | null,
+    perceptionJson?: string | null,
+    capsJson?: string | null,
+  ): Promise<string>;
+  /** PR1b: signature changed to take view JSON instead of perception+caps. */
+  canonicalDecideNext(
+    viewJson: string,
     historyJson: string,
     sharedMemoryJson: string,
-    perceptionJson: string,
     screenshotBase64?: string | null,
-    capsJson?: string,
   ): Promise<string>;
+  /** PR1b: signature changed to take view JSON instead of perception. */
   canonicalVerifyDone(
-    goal: string,
+    viewJson: string,
     summary: string,
     sharedMemoryJson: string,
-    perceptionJson: string,
     screenshotBase64?: string | null,
   ): Promise<string>;
   canonicalExecuteStep(stepJson: string): Promise<string>;
@@ -1151,36 +1163,84 @@ export class Cel implements
     return JSON.parse(await this.native.canonicalPerceive(captureScreenshot));
   }
 
-  /** Ask the Rust canonical planner for the next move. */
-  async canonicalDecideNext(
+  /**
+   * Build a budgeted PlanningView via the cortex-side deterministic
+   * selector. Two modes:
+   *
+   *  - **Stateful** (default): both `perception` and `caps` are `undefined`.
+   *    Uses the booted Cortex internally to read fresh perception + caps,
+   *    then builds the view. Errors if the cortex isn't running.
+   *
+   *  - **Stateless**: caller supplies both `perception` and `caps`. Skips
+   *    the cortex; useful for the eval harness, replay tooling, or any
+   *    caller that already has a perception snapshot.
+   *
+   * `budget` is optional; defaults sized to keep prompts under common
+   * LLM context windows.
+   */
+  async canonicalBuildPlanningView(
     goal: string,
+    options: {
+      budget?: PlanningBudget;
+      perception?: ScreenContext;
+      caps?: RuntimeCaps;
+    } = {},
+  ): Promise<PlanningView> {
+    if (!this.native) {
+      throw new Error("Native CEL module not available");
+    }
+    const { budget, perception, caps } = options;
+    if ((perception && !caps) || (!perception && caps)) {
+      throw new Error(
+        "canonicalBuildPlanningView: stateless mode requires BOTH perception and caps (or pass neither for stateful mode)",
+      );
+    }
+    return JSON.parse(
+      await this.native.canonicalBuildPlanningView(
+        goal,
+        budget ? JSON.stringify(budget) : null,
+        perception ? JSON.stringify(sanitizeContextForRust(perception)) : null,
+        caps ? JSON.stringify(caps) : null,
+      ),
+    );
+  }
+
+  /**
+   * Ask the Rust canonical planner for the next move.
+   *
+   * **PR1b: signature changed.** Now takes a `PlanningView` instead of
+   * raw perception + caps. Build the view first via
+   * `canonicalBuildPlanningView`.
+   */
+  async canonicalDecideNext(
+    view: PlanningView,
     history: AttemptRecord[],
     sharedMemory: unknown,
-    perception: ScreenContext,
     screenshotBase64: string | null,
-    caps: RuntimeCaps,
   ): Promise<NextMove> {
     if (!this.native) {
       throw new Error("Native CEL module not available");
     }
     return JSON.parse(
       await this.native.canonicalDecideNext(
-        goal,
+        JSON.stringify(view),
         JSON.stringify(history),
         JSON.stringify(sharedMemory ?? {}),
-        JSON.stringify(sanitizeContextForRust(perception)),
         screenshotBase64,
-        JSON.stringify(caps ?? {}),
       ),
     );
   }
 
-  /** Validate a Done claim against fresh Rust-side verification rules. */
+  /**
+   * Validate a Done claim against fresh Rust-side verification rules.
+   *
+   * **PR1b: signature changed.** Now takes a `PlanningView` instead of
+   * raw perception. Build the view first via `canonicalBuildPlanningView`.
+   */
   async canonicalVerifyDone(
-    goal: string,
+    view: PlanningView,
     summary: string,
     sharedMemory: unknown,
-    perception: ScreenContext,
     screenshotBase64: string | null,
   ): Promise<DoneVerdict> {
     if (!this.native) {
@@ -1188,10 +1248,9 @@ export class Cel implements
     }
     return JSON.parse(
       await this.native.canonicalVerifyDone(
-        goal,
+        JSON.stringify(view),
         summary,
         JSON.stringify(sharedMemory ?? {}),
-        JSON.stringify(sanitizeContextForRust(perception)),
         screenshotBase64,
       ),
     );

--- a/agent/src/langgraph/canonical.ts
+++ b/agent/src/langgraph/canonical.ts
@@ -110,6 +110,125 @@ export interface PerceptionFrame {
   caps: RuntimeCaps;
 }
 
+// ─── PlanningView (PR1a contract) ────────────────────────────────────────────
+//
+// Mirrors `cel_contracts::PlanningView`. The cortex builds it; planners
+// consume it. Lets every planner runtime — canonical Rust, LangGraph,
+// future external — speak the same compact context contract.
+
+export interface PlanningBudget {
+  max_tokens: number;
+  max_elements: number;
+  max_memories: number;
+  max_adapter_facts: number;
+}
+
+export interface PlanningScreen {
+  active_app: string;
+  window?: string;
+  summary?: string | null;
+  url?: string | null;
+}
+
+export interface PlanningElementState {
+  focused: boolean;
+  selected: boolean;
+  enabled: boolean;
+  checked: boolean;
+  expanded: boolean;
+}
+
+export interface PlanningElement {
+  id: string;
+  element_type: string;
+  label?: string | null;
+  value?: string | null;
+  state: PlanningElementState;
+  clickable?: boolean;
+  settable?: boolean;
+}
+
+export interface RunProgress {
+  steps_used: number;
+  max_steps: number;
+}
+
+export interface CapabilityRef {
+  id: string;
+  detail?: string | null;
+}
+
+export interface MemoryRef {
+  id: number;
+  kind: string;
+  summary: string;
+  content: unknown;
+  created_at?: string | null;
+}
+
+export interface KnowledgeRef {
+  id: number;
+  source: string;
+  content: string;
+  tags?: string[];
+}
+
+export interface AdapterFactRef {
+  adapter: string;
+  kind: string;
+  payload: unknown;
+}
+
+export interface EventRef {
+  id: string;
+  kind: string;
+  summary: string;
+  at?: string | null;
+}
+
+export interface EvidenceRef {
+  source: string;
+  id: string;
+  summary: string;
+}
+
+export interface AnomalyRef {
+  kind: string;
+  description: string;
+}
+
+export interface Blocker {
+  kind: string;
+  description: string;
+  element_id?: string | null;
+}
+
+export interface OmittedCounts {
+  elements: number;
+  memories: number;
+  knowledge: number;
+  adapter_facts: number;
+  recent_events: number;
+}
+
+export interface PlanningView {
+  goal: string;
+  budget: PlanningBudget;
+  screen: PlanningScreen;
+  elements: PlanningElement[];
+  adapter_facts: AdapterFactRef[];
+  capabilities: CapabilityRef[];
+  run_progress: RunProgress;
+  memories: MemoryRef[];
+  knowledge: KnowledgeRef[];
+  recent_events: EventRef[];
+  blockers: Blocker[];
+  anomalies: AnomalyRef[];
+  evidence: EvidenceRef[];
+  selection_rationale?: string | null;
+  omitted_counts: OmittedCounts;
+}
+
 export interface ReviewDecision {
   approved: boolean;
   edited_step?: CanonicalStep;

--- a/agent/src/langgraph/llm-planner.test.ts
+++ b/agent/src/langgraph/llm-planner.test.ts
@@ -1,28 +1,60 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { CelLlmPlanner } from "./llm-planner.js";
+import { CelLlmPlanner, type PlannerSurface } from "./llm-planner.js";
+import type { NextMove, PlanningView } from "./canonical.js";
+
+function makeFakeView(goal: string): PlanningView {
+  return {
+    goal,
+    budget: {
+      max_tokens: 8000,
+      max_elements: 80,
+      max_memories: 8,
+      max_adapter_facts: 12,
+    },
+    screen: { active_app: "Test App" },
+    elements: [],
+    adapter_facts: [],
+    capabilities: [],
+    run_progress: { steps_used: 0, max_steps: 80 },
+    memories: [],
+    knowledge: [],
+    recent_events: [],
+    blockers: [],
+    anomalies: [],
+    evidence: [],
+    omitted_counts: {
+      elements: 0,
+      memories: 0,
+      knowledge: 0,
+      adapter_facts: 0,
+      recent_events: 0,
+    },
+  };
+}
 
 describe("CelLlmPlanner", () => {
-  it("resolves indexed target ids into real context ids", async () => {
-    const planner = new CelLlmPlanner({
-      llmCompleteWithRole: vi.fn(async () => JSON.stringify({
-        kind: "batch",
-        purpose: "click the button",
-        steps: [
-          {
-            purpose: "click submit",
-            kind: "deterministic",
-            action: {
-              type: "click",
-              target_id: "1",
-            },
-          },
-        ],
-      })),
-      llmCompleteWithImage: vi.fn(async () => {
-        throw new Error("unexpected image call");
-      }),
-    }, { maxSteps: 10 });
+  it("delegates decideNext to the canonical Rust planner via N-API", async () => {
+    const expected: NextMove = {
+      kind: "batch",
+      purpose: "click the button",
+      steps: [
+        {
+          purpose: "click submit",
+          kind: "deterministic",
+          action: { type: "click", target_id: "ax:submit" },
+        },
+      ],
+    };
+    const buildView = vi.fn(async (goal: string) => makeFakeView(goal));
+    const decideNext = vi.fn(async () => expected);
+    const verifyDone = vi.fn(async () => ({ verified: true, reason: "" }));
+    const cel: PlannerSurface = {
+      canonicalBuildPlanningView: buildView,
+      canonicalDecideNext: decideNext,
+      canonicalVerifyDone: verifyDone,
+    };
+    const planner = new CelLlmPlanner(cel);
 
     const move = await planner.decideNext({
       goal: "click submit",
@@ -33,22 +65,7 @@ describe("CelLlmPlanner", () => {
           app: "Test App",
           window: "Dialog",
           timestamp_ms: Date.now(),
-          elements: [
-            {
-              id: "ax:submit",
-              label: "Submit",
-              element_type: "button",
-              state: {
-                focused: false,
-                enabled: true,
-                visible: true,
-                selected: false,
-              },
-              confidence: 1,
-              source: "accessibility_tree",
-              actions: ["click"],
-            },
-          ],
+          elements: [],
         },
         screenshot_base64: null,
         caps: {
@@ -60,13 +77,95 @@ describe("CelLlmPlanner", () => {
       },
     });
 
-    expect(move.kind).toBe("batch");
-    if (move.kind !== "batch") {
-      throw new Error("expected batch");
-    }
-    expect(move.steps[0].action).toEqual({
-      type: "click",
-      target_id: "ax:submit",
+    expect(buildView).toHaveBeenCalledTimes(1);
+    expect(decideNext).toHaveBeenCalledTimes(1);
+    expect(move).toEqual(expected);
+  });
+
+  it("short-circuits with Fail when history exceeds maxSteps", async () => {
+    const buildView = vi.fn();
+    const decideNext = vi.fn();
+    const cel: PlannerSurface = {
+      canonicalBuildPlanningView: buildView,
+      canonicalDecideNext: decideNext,
+      canonicalVerifyDone: vi.fn(),
+    };
+    const planner = new CelLlmPlanner(cel, { maxSteps: 2 });
+
+    const move = await planner.decideNext({
+      goal: "anything",
+      history: [
+        {
+          step_purpose: "a",
+          action: { type: "wait", ms: 1 },
+          succeeded: true,
+          data: null,
+        },
+        {
+          step_purpose: "b",
+          action: { type: "wait", ms: 1 },
+          succeeded: true,
+          data: null,
+        },
+      ],
+      sharedMemory: {},
+      frame: {
+        perception: {
+          app: "x",
+          window: "y",
+          timestamp_ms: 0,
+          elements: [],
+        },
+        screenshot_base64: null,
+        caps: {
+          cdp_bound: false,
+          native_input: false,
+          steps_used: 0,
+          max_steps: 0,
+        },
+      },
     });
+
+    expect(move.kind).toBe("fail");
+    // Did NOT touch the cortex when the budget is exhausted.
+    expect(buildView).not.toHaveBeenCalled();
+    expect(decideNext).not.toHaveBeenCalled();
+  });
+
+  it("delegates verifyDone to the canonical Rust planner via N-API", async () => {
+    const expected = { verified: false, reason: "missing evidence" };
+    const buildView = vi.fn(async (goal: string) => makeFakeView(goal));
+    const verifyDone = vi.fn(async () => expected);
+    const cel: PlannerSurface = {
+      canonicalBuildPlanningView: buildView,
+      canonicalDecideNext: vi.fn(),
+      canonicalVerifyDone: verifyDone,
+    };
+    const planner = new CelLlmPlanner(cel);
+
+    const verdict = await planner.verifyDone({
+      goal: "any",
+      summary: "claimed done",
+      sharedMemory: {},
+      frame: {
+        perception: {
+          app: "x",
+          window: "y",
+          timestamp_ms: 0,
+          elements: [],
+        },
+        screenshot_base64: null,
+        caps: {
+          cdp_bound: false,
+          native_input: false,
+          steps_used: 0,
+          max_steps: 0,
+        },
+      },
+    });
+
+    expect(buildView).toHaveBeenCalledTimes(1);
+    expect(verifyDone).toHaveBeenCalledTimes(1);
+    expect(verdict).toEqual(expected);
   });
 });

--- a/agent/src/langgraph/llm-planner.ts
+++ b/agent/src/langgraph/llm-planner.ts
@@ -1,111 +1,57 @@
-import { compressContext } from "../context-compressor.js";
-import { serializeContextForLLM } from "../context-serializer.js";
 import type { Cel } from "../cel-bindings.js";
 import type {
   AttemptRecord,
-  CanonicalAction,
-  CanonicalStep,
   DoneVerdict,
   NextMove,
   PerceptionFrame,
+  PlanningBudget,
 } from "./canonical.js";
 import type { CellarLangGraphPlanner } from "./planner.js";
 
-const NEXT_MOVE_SYSTEM_PROMPT = `
-You are the planning runtime for a desktop and browser automation agent.
-
-Return ONLY raw JSON with exactly one of these shapes:
-
-1. Batch
-{
-  "kind": "batch",
-  "purpose": "short batch intent",
-  "steps": [
-    {
-      "purpose": "what this step does",
-      "kind": "deterministic" | "llm_assisted",
-      "action": { ... }
-    }
-  ]
-}
-
-2. Done
-{
-  "kind": "done",
-  "summary": "what was completed",
-  "extracted_data": { ... }
-}
-
-3. Fail
-{
-  "kind": "fail",
-  "reason": "why the goal cannot continue"
-}
-
-Allowed action shapes:
-- {"type":"click","target_id":"12"}
-- {"type":"type","target_id":"12","text":"hello"}
-- {"type":"type","target_id":null,"text":"hello"}
-- {"type":"set_value","target_id":"12","value":"hello"}
-- {"type":"key","key":"Return"}
-- {"type":"key_combo","keys":["Cmd","L"]}
-- {"type":"scroll","dx":0,"dy":400}
-- {"type":"wait","ms":800}
-- {"type":"ax_action","target_id":"12","action":"click"}
-- {"type":"activate_app","app_name":"Numbers"}
-- {"type":"cdp_eval","expression":"document.body.innerText.slice(0,1000)"}
-- {"type":"navigate","url":"https://example.com"}
-- {"type":"extract_with_fallback","name":"price","selectors":[".price","[data-test='price']"],"parse_as":"float"}
-- {"type":"write_cells","app":"Numbers","writes":[{"ref":"A1","value":"Ticker"},{"ref":"B1","value":"Price"}],"verify":true}
-
-Rules:
-- Keep batches small: usually 1-3 steps.
-- Use the numbered element indices from the context as target_id values. Do not invent ids.
-- If the app is a browser and CDP is available, prefer navigate and cdp_eval for in-page work.
-- If the app is a desktop app, prefer ax_action, click, set_value, key, or activate_app.
-- Only emit done when the current context or screenshot supports the claim.
-- If unsure, do more work instead of declaring done.
-- If genuinely blocked, emit fail with a concrete reason.
-- Return JSON only. No markdown fences. No prose.
-`.trim();
-
-const VERIFY_DONE_SYSTEM_PROMPT = `
-You are a strict completion checker for an automation agent.
-
-Return ONLY raw JSON:
-{
-  "verified": true | false,
-  "reason": "brief explanation"
-}
-
-Rules:
-- verified=true only when the current context or screenshot clearly supports the claimed completion.
-- If there is any important missing evidence, return verified=false.
-- Be strict about partial completion.
-- Return JSON only.
-`.trim();
+/**
+ * LangGraph-facing planner that delegates to the canonical Rust planner
+ * via the CEL N-API surface.
+ *
+ * **PR1b: now a thin shim over `cel.canonicalBuildPlanningView` +
+ * `cel.canonicalDecideNext` / `canonicalVerifyDone`.** Previously held its
+ * own TS-side prompt + context-compression logic, which forked off the
+ * Rust planner and caused planner fragmentation. Now the cortex builds
+ * one PlanningView per turn and the Rust planner consumes it; this class
+ * just bridges that into the LangGraph graph contract.
+ *
+ * The LLM client is the Rust-side one (configured via `CEL_LLM_PROVIDER`
+ * or `~/.cellar/config.toml`). The TS-side `LlmSurface` dependency is
+ * gone — there's nothing left for the TS layer to do during planning.
+ */
 
 export interface CelLlmPlannerOptions {
+  /** Hard cap on planner turns. Used to short-circuit before the LLM call. */
   maxSteps?: number;
-  maxTokens?: number;
-  maxHistoryItems?: number;
-  maxContextChars?: number;
+  /** Optional planning budget overriding `cel-cortex` defaults. */
+  budget?: PlanningBudget;
 }
 
-type LlmSurface = Pick<Cel, "llmCompleteWithRole" | "llmCompleteWithImage">;
-
-const DEFAULT_OPTIONS: Required<CelLlmPlannerOptions> = {
+const DEFAULT_OPTIONS: Required<Omit<CelLlmPlannerOptions, "budget">> & {
+  budget: PlanningBudget | undefined;
+} = {
   maxSteps: 80,
-  maxTokens: 4096,
-  maxHistoryItems: 12,
-  maxContextChars: 12000,
+  budget: undefined,
 };
 
+/**
+ * Subset of [`Cel`] that this planner needs. Lets tests mock the
+ * canonical helpers without standing up the full native module.
+ */
+export type PlannerSurface = Pick<
+  Cel,
+  "canonicalBuildPlanningView" | "canonicalDecideNext" | "canonicalVerifyDone"
+>;
+
 export class CelLlmPlanner implements CellarLangGraphPlanner {
-  private readonly options: Required<CelLlmPlannerOptions>;
+  private readonly options: typeof DEFAULT_OPTIONS;
 
   constructor(
-    private readonly llm: LlmSurface,
+    private readonly cel: PlannerSurface,
     options: CelLlmPlannerOptions = {},
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
@@ -123,15 +69,17 @@ export class CelLlmPlanner implements CellarLangGraphPlanner {
         reason: `max_steps budget exhausted after ${input.history.length} executed steps`,
       };
     }
-
-    const { prompt, indexMap } = this.buildNextMovePrompt(input);
-    const raw = await this.complete(
-      NEXT_MOVE_SYSTEM_PROMPT,
-      prompt,
+    const view = await this.cel.canonicalBuildPlanningView(input.goal, {
+      budget: this.options.budget,
+      perception: input.frame.perception,
+      caps: input.frame.caps,
+    });
+    return this.cel.canonicalDecideNext(
+      view,
+      input.history,
+      input.sharedMemory,
       input.frame.screenshot_base64 ?? null,
     );
-    const parsed = parseJsonLoose(raw);
-    return normalizeNextMove(parsed, indexMap);
   }
 
   async verifyDone(input: {
@@ -140,270 +88,16 @@ export class CelLlmPlanner implements CellarLangGraphPlanner {
     sharedMemory: unknown;
     frame: PerceptionFrame;
   }): Promise<DoneVerdict> {
-    const prompt = buildVerifyDonePrompt(input, this.options.maxContextChars);
-    const raw = await this.complete(
-      VERIFY_DONE_SYSTEM_PROMPT,
-      prompt,
+    const view = await this.cel.canonicalBuildPlanningView(input.goal, {
+      budget: this.options.budget,
+      perception: input.frame.perception,
+      caps: input.frame.caps,
+    });
+    return this.cel.canonicalVerifyDone(
+      view,
+      input.summary,
+      input.sharedMemory,
       input.frame.screenshot_base64 ?? null,
     );
-    const parsed = parseJsonLoose(raw) as Partial<DoneVerdict>;
-    return {
-      verified: parsed.verified === true,
-      reason: typeof parsed.reason === "string" ? parsed.reason : "",
-    };
   }
-
-  private async complete(
-    systemPrompt: string,
-    userPrompt: string,
-    screenshotBase64: string | null,
-  ): Promise<string> {
-    if (screenshotBase64) {
-      return this.llm.llmCompleteWithImage(
-        systemPrompt,
-        screenshotBase64,
-        userPrompt,
-        this.options.maxTokens,
-      );
-    }
-    return this.llm.llmCompleteWithRole(
-      systemPrompt,
-      userPrompt,
-      "planner",
-      this.options.maxTokens,
-    );
-  }
-
-  private buildNextMovePrompt(input: {
-    goal: string;
-    history: AttemptRecord[];
-    sharedMemory: unknown;
-    frame: PerceptionFrame;
-  }): { prompt: string; indexMap: Map<number, string> } {
-    const compressed = compressContext(input.frame.perception).context;
-    const serialized = serializeContextForLLM(compressed);
-    const historyText = formatHistory(input.history, this.options.maxHistoryItems);
-    const contextText = truncate(serialized.text, this.options.maxContextChars);
-
-    const prompt = [
-      `GOAL`,
-      input.goal,
-      ``,
-      `BUDGET`,
-      `steps_used=${input.history.length}`,
-      `max_steps=${this.options.maxSteps}`,
-      ``,
-      `RUNTIME CAPS`,
-      safeJson({
-        ...input.frame.caps,
-        steps_used: input.history.length,
-        max_steps: this.options.maxSteps,
-      }),
-      ``,
-      `SHARED MEMORY`,
-      safeJson(input.sharedMemory),
-      ``,
-      `RECENT HISTORY`,
-      historyText,
-      ``,
-      `CURRENT CONTEXT`,
-      contextText,
-      ``,
-      `IMPORTANT`,
-      `Use the numeric element indices shown in CURRENT CONTEXT as target_id values.`,
-      `If a screenshot is attached, use it as extra evidence for overlays, dialogs, and visual state.`,
-    ].join("\n");
-
-    return {
-      prompt,
-      indexMap: serialized.indexMap,
-    };
-  }
-}
-
-function buildVerifyDonePrompt(
-  input: {
-    goal: string;
-    summary: string;
-    sharedMemory: unknown;
-    frame: PerceptionFrame;
-  },
-  maxContextChars: number,
-): string {
-  const compressed = compressContext(input.frame.perception).context;
-  const serialized = serializeContextForLLM(compressed);
-  return [
-    `GOAL`,
-    input.goal,
-    ``,
-    `CLAIMED SUMMARY`,
-    input.summary,
-    ``,
-    `SHARED MEMORY`,
-    safeJson(input.sharedMemory),
-    ``,
-    `RUNTIME CAPS`,
-    safeJson(input.frame.caps),
-    ``,
-    `CURRENT CONTEXT`,
-    truncate(serialized.text, maxContextChars),
-    ``,
-    `QUESTION`,
-    `Does the current state prove the goal is complete?`,
-  ].join("\n");
-}
-
-function formatHistory(history: AttemptRecord[], maxItems: number): string {
-  if (history.length === 0) {
-    return `(none)`;
-  }
-  return history
-    .slice(-maxItems)
-    .map((item, idx) => {
-      const status = item.succeeded ? "ok" : `fail: ${item.error ?? "unknown"}`;
-      return `${idx + 1}. ${item.step_purpose} :: ${status} :: ${formatAction(item.action)}`;
-    })
-    .join("\n");
-}
-
-function formatAction(action: CanonicalAction): string {
-  try {
-    return JSON.stringify(action);
-  } catch {
-    return action.type;
-  }
-}
-
-function safeJson(value: unknown): string {
-  try {
-    return JSON.stringify(value ?? null, null, 2);
-  } catch {
-    return "null";
-  }
-}
-
-function truncate(text: string, maxChars: number): string {
-  return text.length > maxChars ? `${text.slice(0, maxChars)}\n...[truncated]` : text;
-}
-
-function parseJsonLoose(raw: string): unknown {
-  const cleaned = raw
-    .trim()
-    .replace(/^```json\s*/i, "")
-    .replace(/^```\s*/i, "")
-    .replace(/\s*```$/i, "")
-    .trim();
-
-  try {
-    return JSON.parse(cleaned);
-  } catch {
-    const firstBrace = cleaned.indexOf("{");
-    const lastBrace = cleaned.lastIndexOf("}");
-    if (firstBrace >= 0 && lastBrace > firstBrace) {
-      return JSON.parse(cleaned.slice(firstBrace, lastBrace + 1));
-    }
-    throw new Error(`Planner returned invalid JSON: ${raw.slice(0, 400)}`);
-  }
-}
-
-function normalizeNextMove(raw: unknown, indexMap: Map<number, string>): NextMove {
-  if (!raw || typeof raw !== "object") {
-    throw new Error("Planner returned a non-object next move");
-  }
-
-  const input = raw as Record<string, unknown>;
-  const inferredKind = typeof input.kind === "string"
-    ? input.kind
-    : inferKind(input);
-
-  if (inferredKind === "done") {
-    return {
-      kind: "done",
-      summary: typeof input.summary === "string" ? input.summary : "Goal completed",
-      extracted_data: input.extracted_data ?? null,
-    };
-  }
-
-  if (inferredKind === "fail") {
-    return {
-      kind: "fail",
-      reason: typeof input.reason === "string" ? input.reason : "Planner reported failure",
-    };
-  }
-
-  const rawSteps = Array.isArray(input.steps) ? input.steps : [];
-  if (rawSteps.length === 0) {
-    throw new Error("Planner returned a batch with no steps");
-  }
-
-  const steps = rawSteps
-    .slice(0, 5)
-    .map((step, index) => normalizeStep(step, indexMap, index));
-
-  return {
-    kind: "batch",
-    purpose: typeof input.purpose === "string" ? input.purpose : "Execute the next small batch",
-    steps,
-  };
-}
-
-function inferKind(input: Record<string, unknown>): "batch" | "done" | "fail" {
-  if ("summary" in input && !("steps" in input)) {
-    return "done";
-  }
-  if ("reason" in input && !("steps" in input)) {
-    return "fail";
-  }
-  return "batch";
-}
-
-function normalizeStep(
-  raw: unknown,
-  indexMap: Map<number, string>,
-  index: number,
-): CanonicalStep {
-  if (!raw || typeof raw !== "object") {
-    throw new Error(`Planner returned invalid step at index ${index}`);
-  }
-  const step = raw as Record<string, unknown>;
-  const action = normalizeAction(step.action, indexMap);
-  return {
-    purpose: typeof step.purpose === "string" ? step.purpose : `Execute step ${index + 1}`,
-    kind: step.kind === "llm_assisted" ? "llm_assisted" : "deterministic",
-    action,
-  };
-}
-
-function normalizeAction(raw: unknown, indexMap: Map<number, string>): CanonicalAction {
-  if (!raw || typeof raw !== "object") {
-    throw new Error("Planner returned an invalid action");
-  }
-  const action = structuredClone(raw as Record<string, unknown>) as Record<string, unknown>;
-  if (typeof action.type !== "string") {
-    throw new Error("Planner action is missing a type");
-  }
-
-  for (const field of ["target_id", "from_target_id", "to_target_id"] as const) {
-    if (field in action && action[field] != null) {
-      action[field] = resolveIndexedId(action[field], indexMap);
-    }
-  }
-
-  if (Array.isArray(action.evidence_ids)) {
-    action.evidence_ids = action.evidence_ids.map((id) => resolveIndexedId(id, indexMap));
-  }
-
-  if (Array.isArray(action.actions)) {
-    action.actions = action.actions.map((nested) => normalizeAction(nested, indexMap));
-  }
-
-  return action as CanonicalAction;
-}
-
-function resolveIndexedId(value: unknown, indexMap: Map<number, string>): string {
-  const raw = String(value);
-  if (/^\d+$/.test(raw)) {
-    return indexMap.get(Number(raw)) ?? raw;
-  }
-  return raw;
 }

--- a/cel/cel-napi/src/goal_runner.rs
+++ b/cel/cel-napi/src/goal_runner.rs
@@ -191,14 +191,96 @@ pub async fn canonical_perceive(capture_screenshot: Option<bool>) -> napi::Resul
     .map_err(|e| napi::Error::from_reason(format!("Snapshot serialization failed: {e}")))
 }
 
+/// Build a budgeted `PlanningView` from current cortex state (or from
+/// caller-provided perception + caps for stateless mode).
+///
+/// **Stateful** (default): `perception_json` and `caps_json` are `None`.
+/// Uses the booted cortex via [`canonical_perceive`] to read fresh
+/// perception + caps, then builds the view. Errors if the cortex isn't
+/// running.
+///
+/// **Stateless**: `perception_json` and `caps_json` are both provided.
+/// Skips the cortex entirely and builds the view from the caller's
+/// inputs. Useful for the eval harness, replay tooling, and any caller
+/// that already has a perception snapshot.
+///
+/// `budget_json` is an optional serialized [`PlanningBudget`]. When
+/// omitted, defaults are used (see `PlanningBudget::default`).
+#[napi]
+pub async fn canonical_build_planning_view(
+    goal: String,
+    budget_json: Option<String>,
+    perception_json: Option<String>,
+    caps_json: Option<String>,
+) -> napi::Result<String> {
+    crate::ensure_tracing_init();
+
+    let budget: PlanningBudget = budget_json
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| {
+            serde_json::from_str(s)
+                .map_err(|e| napi::Error::from_reason(format!("Invalid budget JSON: {e}")))
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let view = match (perception_json, caps_json) {
+        (Some(p_json), Some(c_json)) => {
+            // Stateless path: caller supplies the inputs.
+            let perception: cel_context::ScreenContext = serde_json::from_str(&p_json)
+                .map_err(|e| napi::Error::from_reason(format!("Invalid perception JSON: {e}")))?;
+            let caps: RuntimeCaps = parse_json_or_default(&c_json)?;
+            build_planning_view(&PlanningViewInputs {
+                goal: &goal,
+                budget: &budget,
+                perception: &perception,
+                caps: &caps,
+            })
+        }
+        (None, None) => {
+            // Stateful path: use the booted cortex.
+            let cortex = crate::cortex::get_cortex_handle().ok_or_else(|| {
+                napi::Error::from_reason(
+                    "Cortex not running — call boot_cortex() first or pass perception_json/caps_json for stateless mode",
+                )
+            })?;
+            let executor = CortexStepExecutor::new(cortex);
+            let perception = executor.perceive().await;
+            let caps = executor.capabilities().await;
+            build_planning_view(&PlanningViewInputs {
+                goal: &goal,
+                budget: &budget,
+                perception: &perception,
+                caps: &caps,
+            })
+        }
+        _ => {
+            return Err(napi::Error::from_reason(
+                "Stateless mode requires BOTH perception_json and caps_json (or pass neither for stateful mode)",
+            ));
+        }
+    };
+
+    serde_json::to_string(&view)
+        .map_err(|e| napi::Error::from_reason(format!("PlanningView serialization failed: {e}")))
+}
+
+/// Run the LLM planner's `decide_next` against a `PlanningView`.
+///
+/// Pure planner call — no cortex dependency. Caller is expected to have
+/// built the view via [`canonical_build_planning_view`] (or any other
+/// source that produces a valid `PlanningView` JSON).
+///
+/// **Signature changed in PR1b**: previously took `perception_json` +
+/// `caps_json`. Now takes `view_json`. The cortex/planner separation
+/// at the Rust contract is mirrored on the JS surface.
 #[napi]
 pub async fn canonical_decide_next(
-    goal: String,
+    view_json: String,
     history_json: String,
     shared_memory_json: String,
-    perception_json: String,
     screenshot_base64: Option<String>,
-    caps_json: String,
 ) -> napi::Result<String> {
     crate::ensure_tracing_init();
     let llm_client = cel_llm::create_client().map_err(|e| {
@@ -207,24 +289,14 @@ pub async fn canonical_decide_next(
         ))
     })?;
     let planner = LlmPlanProducer::new(Arc::new(llm_client));
+    let view: cel_contracts::PlanningView = serde_json::from_str(&view_json)
+        .map_err(|e| napi::Error::from_reason(format!("Invalid PlanningView JSON: {e}")))?;
     let history: Vec<AttemptRecord> = parse_json_or_default(&history_json)?;
     let shared_memory: serde_json::Value = parse_json_or_default(&shared_memory_json)?;
-    let perception: cel_context::ScreenContext = serde_json::from_str(&perception_json)
-        .map_err(|e| napi::Error::from_reason(format!("Invalid perception JSON: {e}")))?;
     let screenshot = parse_screenshot_base64(screenshot_base64)?;
-    let caps: RuntimeCaps = parse_json_or_default(&caps_json)?;
-    // Build the view inline so the JS surface stays the same in PR1a.
-    // PR1b will replace these N-API helpers with view-native variants.
-    let budget = PlanningBudget::default();
-    let view = build_planning_view(&PlanningViewInputs {
-        goal: &goal,
-        budget: &budget,
-        perception: &perception,
-        caps: &caps,
-    });
     let next = planner
         .decide_next(
-            &goal,
+            &view.goal,
             &history,
             &shared_memory,
             &view,
@@ -236,12 +308,16 @@ pub async fn canonical_decide_next(
         .map_err(|e| napi::Error::from_reason(format!("NextMove serialization failed: {e}")))
 }
 
+/// Run the LLM planner's `verify_done` against a `PlanningView`.
+///
+/// **Signature changed in PR1b**: previously took `perception_json`. Now
+/// takes `view_json`. Caller builds the view via
+/// [`canonical_build_planning_view`].
 #[napi]
 pub async fn canonical_verify_done(
-    goal: String,
+    view_json: String,
     summary: String,
     shared_memory_json: String,
-    perception_json: String,
     screenshot_base64: Option<String>,
 ) -> napi::Result<String> {
     crate::ensure_tracing_init();
@@ -251,23 +327,13 @@ pub async fn canonical_verify_done(
         ))
     })?;
     let planner = LlmPlanProducer::new(Arc::new(llm_client));
+    let view: cel_contracts::PlanningView = serde_json::from_str(&view_json)
+        .map_err(|e| napi::Error::from_reason(format!("Invalid PlanningView JSON: {e}")))?;
     let shared_memory: serde_json::Value = parse_json_or_default(&shared_memory_json)?;
-    let perception: cel_context::ScreenContext = serde_json::from_str(&perception_json)
-        .map_err(|e| napi::Error::from_reason(format!("Invalid perception JSON: {e}")))?;
     let screenshot = parse_screenshot_base64(screenshot_base64)?;
-    // verify_done's view doesn't need budget-tight elements — empty caps
-    // is fine for the grader path (no capability prompting in verify).
-    let budget = PlanningBudget::default();
-    let caps = RuntimeCaps::default();
-    let view = build_planning_view(&PlanningViewInputs {
-        goal: &goal,
-        budget: &budget,
-        perception: &perception,
-        caps: &caps,
-    });
     let verdict = planner
         .verify_done(
-            &goal,
+            &view.goal,
             &summary,
             &shared_memory,
             &view,

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -53,7 +53,7 @@ CEL uses four tools organized by intent:
 | **cel_see** | Read screen state | 14 modes |
 | **cel_act** | Execute actions | native input, CDP, and deterministic app actions |
 | **cel_think** | Optional built-in planning, memory, autonomous execution | 17 modes |
-| **cel_perceive** | Always-on perception (Cortex) | 7 modes |
+| **cel_perceive** | Always-on perception (Cortex) | 8 modes |
 
 Plus 5 [**prompts**](#prompts--reusable-quick-start-templates) — quick-start templates the host surfaces as commands (`cellar/setup-task`, `cellar/inspect-app`, `cellar/debug-hung-action`, `cellar/extract-table`, `cellar/run-numbers-write`).
 
@@ -342,6 +342,7 @@ Use `cel_perceive` for multi-step tasks where continuous awareness matters. Use 
 | `checkpoint` | `summary` | Summarize completed work and reset action history. Use between phases of multi-step tasks. |
 | `configure` | `goal?`, `enable_suggestions?` | Update goal or suggestion settings mid-session. |
 | `status` | — | Cortex health — confidence score, uptime, cycle count, element counts, temporal state. |
+| `plan_view` | `goal`, `budget?` | Build a budgeted `PlanningView` — the same compact context that the canonical Rust planner consumes. Standalone (no perception session needed); boots the cortex on demand. Use this when the host wants to plan with the same selected context that the in-tree planner sees. See [Planning view](#planning-view). |
 | `stop` | — | Shutdown the Cortex and get a summary. |
 
 ### Examples
@@ -375,6 +376,30 @@ Use `cel_perceive` for multi-step tasks where continuous awareness matters. Use 
 ```json
 { "mode": "stop" }
 ```
+
+### Planning view
+
+`mode: "plan_view"` returns the same `PlanningView` the canonical Rust planner consumes — current screen + goal-relevant elements + active capabilities + run progress, compressed to fit a budget. The cortex builds it via the deterministic selector; future PRs add memory-aware selection.
+
+**Build a planning view (defaults):**
+
+```json
+{ "mode": "plan_view", "goal": "Submit this invoice" }
+```
+
+**Override the budget for a wider context window:**
+
+```json
+{
+  "mode": "plan_view",
+  "goal": "Submit this invoice",
+  "budget": { "max_tokens": 16000, "max_elements": 200 }
+}
+```
+
+The response is a serialized `PlanningView` with `screen`, `elements`, `capabilities`, `run_progress`, `omitted_counts`, plus typed-but-empty `memories` / `knowledge` / `events` / `blockers` / `anomalies` / `evidence` (populated by later PRs). The `omitted_counts.elements` field tells you how many elements were dropped to fit budget — a non-zero value means the view is compressed and the host can request a larger budget if needed.
+
+**Why a separate mode rather than `read` with a flag?** `read` returns the full `MentalModel` (everything the cortex knows). `plan_view` returns a budgeted projection meant for an LLM prompt. They're different shapes for different consumers; keeping them as sibling modes avoids one tool branching across two response types.
 
 ---
 

--- a/mcp-server/src/tools/cel-perceive.ts
+++ b/mcp-server/src/tools/cel-perceive.ts
@@ -62,6 +62,27 @@ export const celPerceiveSchema = z.discriminatedUnion("mode", [
     ),
   }),
   z.object({ mode: z.literal("status") }),
+  z.object({
+    mode: z.literal("plan_view"),
+    goal: z.string().describe(
+      "Natural-language goal the planning view should be built around. The cortex selector " +
+      "uses this to score elements by relevance and to fold goal-relevant memories / knowledge / " +
+      "events (when those land in PR3). Be specific.",
+    ),
+    budget: z
+      .object({
+        max_tokens: z.number().optional(),
+        max_elements: z.number().optional(),
+        max_memories: z.number().optional(),
+        max_adapter_facts: z.number().optional(),
+      })
+      .optional()
+      .describe(
+        "Optional ceilings the cortex selector enforces — most-relevant items first, drop the rest. " +
+        "When omitted, defaults sized to keep prompts under common LLM context windows. Override " +
+        "per-call when your model has a larger context window or you're running a token-tight harness.",
+      ),
+  }),
 ]);
 
 type Input = z.infer<typeof celPerceiveSchema>;
@@ -432,6 +453,25 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           pendingAnomalies: model?.anomalyQueue?.length ?? 0,
           temporal: model?.temporal,
         });
+      }
+
+      case "plan_view": {
+        // Standalone — does not require a perception session, but does
+        // require a booted cortex (boot it on demand if needed).
+        if (!cel.isCortexRunning()) {
+          cel.bootCortex();
+        }
+        const view = await cel.canonicalBuildPlanningView(args.goal, {
+          budget: args.budget
+            ? {
+                max_tokens: args.budget.max_tokens ?? 8000,
+                max_elements: args.budget.max_elements ?? 80,
+                max_memories: args.budget.max_memories ?? 8,
+                max_adapter_facts: args.budget.max_adapter_facts ?? 12,
+              }
+            : undefined,
+        });
+        return textResult(view);
       }
     }
   } catch (err) {


### PR DESCRIPTION
feat(cel): PlanningView for all planner surfaces (PR1b)

Removes the planner fragmentation called out in COGNITION_LAYER_PLAN.md
by making every built-in planner path consume the same `PlanningView`
contract. Three surfaces migrate at once: the Rust N-API exports, the
LangGraph TS planner, and a new MCP `plan_view` mode.

What ships
==========

N-API redesign (cel-napi/src/goal_runner.rs)
--------------------------------------------
The cortex/planner separation in Rust is now mirrored on the JS surface.
Two separate exports, each with one job:

- **NEW** `canonical_build_planning_view(goal, budget?, perception?, caps?)`
  builds the budgeted view via the cortex selector.
  - **Stateful** (default): uses the booted cortex.
  - **Stateless**: caller supplies perception + caps. Useful for the eval
    harness, replay tooling, or any consumer that already has a snapshot.
- **CHANGED** `canonical_decide_next(view_json, history, sharedMemory, screenshot?)`
  is now view-native. Pure planner call, no cortex dependency.
- **CHANGED** `canonical_verify_done(view_json, summary, sharedMemory, screenshot?)`
  same shape.

The old `canonical_decide_next(perception, caps, ...)` and
`canonical_verify_done(perception, ...)` signatures are gone.
The only external TS callers of these were in cel-bindings.ts itself,
which migrates in lock-step. No deprecation period needed.

cel-bindings.ts (TS wrapper)
----------------------------
- `Cel.canonicalBuildPlanningView(goal, { budget?, perception?, caps? })`
  returns a typed `PlanningView`.
- `Cel.canonicalDecideNext(view, history, sharedMemory, screenshot?)` —
  view-typed instead of `(goal, history, shared, perception, screenshot, caps)`.
- `Cel.canonicalVerifyDone(view, summary, sharedMemory, screenshot?)` —
  same shape change.
- New TypeScript types in `agent/src/langgraph/canonical.ts`:
  `PlanningView`, `PlanningBudget`, `PlanningScreen`, `PlanningElement`,
  `PlanningElementState`, `RunProgress`, `CapabilityRef`, `MemoryRef`,
  `KnowledgeRef`, `AdapterFactRef`, `EventRef`, `EvidenceRef`, `AnomalyRef`,
  `Blocker`, `OmittedCounts`. Mirrors the Rust shapes 1:1.

LangGraph CelLlmPlanner migration (agent/src/langgraph/llm-planner.ts)
----------------------------------------------------------------------
Reduced from 280-line LLM planner to 90-line shim. Used to:
- import compressContext + serializeContextForLLM (TS-side context compression)
- build its own NEXT_MOVE_SYSTEM_PROMPT in TS
- call llmCompleteWithRole / llmCompleteWithImage directly

Now:
- builds a PlanningView via cel.canonicalBuildPlanningView()
- calls cel.canonicalDecideNext() (which dispatches to the same Rust
  LlmPlanProducer the canonical runner uses)
- never duplicates prompt logic

This is the core "planner fragmentation" fix from the design doc.
LangGraph and the canonical Rust runner now go through the same prompt
builder, consume the same view, and converge on the same behaviour for
identical inputs.

`PlannerSurface` type (Pick of Cel) lets tests mock the canonical
helpers without standing up the full native module.

The TS-side helpers (compressContext, serializeContextForLLM) stay in
their own modules — `langgraph/tools.ts` still uses them for tool
descriptions, and that's a separate cleanup.

MCP `cel_perceive { mode: "plan_view" }` (mcp-server/src/tools/cel-perceive.ts)
------------------------------------------------------------------------------
New top-level mode (8th on cel_perceive). Standalone — boots the cortex
on demand, doesn't require a perception session. Args:
- `goal: string` (required)
- `budget?: { max_tokens?, max_elements?, max_memories?, max_adapter_facts? }`

Returns the serialized PlanningView the canonical Rust planner consumes.
External agents can now request the exact same context any in-tree
planner sees.

**Why a new mode rather than `read` with a `view` flag?** `read` returns
the full MentalModel. `plan_view` returns a budgeted projection. Two
different shapes for two different consumers; keeping them as siblings
avoids one tool branching across two response types. Future view types
(debug_view, audit_view, compact_view) drop in alongside.

Tests
=====

- 3 new tests in `agent/src/langgraph/llm-planner.test.ts`:
  delegation to canonical, max_steps short-circuit, verifyDone delegation.
- All 12 existing PR1a tests in cel-cortex / cel-contracts / cel-planner
  still pass.
- 630 Rust workspace tests pass; 0 failed.
- 315 TS tests pass (excluding 2 pre-existing failure files in
  `tool-calling-model.test.ts` and `react-agent.test.ts` that fail on
  origin/main before this PR — unrelated to the migration).

Acceptance
==========

- `cargo check --workspace --all-targets` clean
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` passes
- `pnpm --filter @cellar/agent build` clean
- `pnpm --filter @dpagk/cellar-mcp build` clean

What does NOT ship in PR1b
==========================

- Cross-backend eval (canonical vs LangGraph). Both backends now go
  through the same Rust planner via N-API, so this assertion is
  structurally implied. A dedicated eval that exercises both end-to-end
  is a follow-up — defer per the plan's "small enabler if needed" note.
- `langgraph/tools.ts` migration — still uses TS-side
  `compressContext`/`serializeContextForLLM` for tool descriptions.
  Separate cleanup.
- Persistent memory (PR2). Memory / knowledge / event refs in the view
  remain typed-but-empty.
