### PR TITLE
sync: A4 memory enrichment + B1 LLM memory selector

### DIFF
--- a/COGNITION_LAYER_PLAN.md
+++ b/COGNITION_LAYER_PLAN.md
@@ -33,11 +33,11 @@
 | **WK2** | Vector embedding infrastructure (Embedder trait + storage search + selector plumbing) | 📝 PR'd (#36) — gates green, +14 tests; un-deferred 2026-05-07 as infrastructure-only (no bundled embedder); subsumes B2 |
 | **Tier A2** | Populate `PlanningView.recent_events` from cortex `observations` (priority + recency ordered, workflow-scoped) | 📝 PR'd — gates green, +7 tests, separate `RecentEventStore` trait |
 | **Tier A3** | Populate `PlanningView.blockers` + `anomalies` from cortex `MentalModel.anomaly_queue` + `freshness` (Dialog/AuthPrompt → blocker; HardStale → blocker; SoftStale → anomaly) | 📝 PR'd — gates green, +9 tests, new `StepExecutor::cortex_anomalies()` + `cortex_freshness()` methods |
-| **Recall eval** | Memory-recall eval in `cel-eval` (`recall-eval` feature) — 5 scenarios × 2 modes, baseline numbers established | 📝 PR'd — gates green, +5 tests, scenarios + IR metrics module (precision@k / recall@k / MRR), runs in CI as a regression guard |
-| ⏳ **Decision** | Decide A4 / B1 / B3 / which embedder to bundle | next — based on baseline numbers below |
-| Recall eval | Memory-recall eval in cel-eval | pending — gates A4 + B1/B3 + which embedder to bundle |
-| Tier A4 | Memory enrichment background pass | pending — eval-gated |
-| Tier B1 / B3 | LLM-based selector / cross-workflow priors | pending — eval-gated |
+| **Recall eval** | Memory-recall eval in `cel-eval` (`recall-eval` feature) — 10 scenarios × 2 modes, baseline numbers established | ✅ merged — scenarios + IR metrics (P@k / R@k / MRR), Path B added 5 harder cases |
+| **Tier A4 (infrastructure)** | `MemoryEnricher` trait + write-time hook + always-safe fallback to plain summary | ✅ merged (#41) — +4 runner tests + 3 trait tests; mirrors WK2 pattern (seam shipped, no bundled LLM impl) |
+| **Tier B1 (infrastructure)** | `MemorySelector` trait + read-time re-rank + always-safe fallback to WK1 deterministic ordering | 📝 PR'd — gates green, +4 runner tests + 3 trait tests; mirrors A4 + WK2 pattern (seam shipped, no bundled LLM impl) |
+| Tier B3 | Cross-workflow priors | deferred — needs privacy decision before code |
+| ⏳ **Next** | Production dogfooding / harder eval scenarios / platform breadth (adapters, benchmark server) | next — strategic call |
 | ~~Tier B2~~ | ~~Vector embeddings~~ | retired — subsumed by WK2 above |
 | PR4 (umbrella) | Cognition/enricher work | 🔄 reframed into Tier A/B/C — see PR4 section below |
 
@@ -894,7 +894,7 @@ Goal decomposition belongs primarily to agents. It can exist as an optional help
 |---|---|
 | Should `enable_cognition` default to true? | No for the first slice. Make planning view explicit/on-demand. Built-in runners can request it by default. |
 | Should memory be enabled by default? | Keep safe v1 default explicit/product-configured. Storage exists, but writes should be intentional. |
-| Should selection use an LLM immediately? | **No (confirmed by WK1).** FTS5 + decay + quoted-phrase + kind-bias scoring covers the common case. LLM-based selection (PR4 Tier B1) requires eval data showing the deterministic path falls short. |
+| Should selection use an LLM immediately? | **Build the seam now; the LLM-backed impl is opt-in.** B1 ships as a `MemorySelector` trait with WK1 as the always-safe fallback (mirroring WK2's embedder seam). Wiring the trait is unconditional; *bundling* a particular LLM impl is what the eval gates — not the seam itself. (Earlier "no" framing was over-conservative; reframed 2026-05-09.) |
 | Should `cel-cognition` be created immediately? | **No (confirmed by post-WK reframe).** Tier A work (fill empty PlanningView fields, memory enrichment) lives fine in `cel-cortex`. A new crate becomes worth its weight only if Tier B (LLM selector + embeddings) and richer enrichment land — and only after a recall eval shows they're needed. Until then, no crate. |
 | Should adapters register sub-agents? | Not initially. Let adapters expose facts/capabilities first; revisit if Tier A4 (memory enrichment) shows an adapter-specific gap. |
 | Where should analytics live? | Raw transcripts/eval JSONL first; DuckDB can be a later offline analytics layer, not hot-path planning storage. |
@@ -968,10 +968,11 @@ The first eval (5 scenarios) was too easy — all hand-built memories shared key
 In current cellar usage, memories are written at run-end by `canonical_runner` using a summary derived from the *goal text* itself ("Completed: submit invoice in Concur"). That construction guarantees keyword overlap on future runs of the same goal in the same workflow — so within-workflow recall will look much more like `easy_keyword_match` than `pure_semantic_gap`. The gap matters most for **cross-workflow** retrieval (memories from workflow A surfacing for goal in workflow B), which is exactly what B3 covers and what we're not building yet.
 
 **Net:** the cognition layer is in good shape. WK1+WK2-seam is sufficient for everything we can currently measure. The eval is now a *useful production tool* — when we ship and accumulate real memories, we can grade them against this scenario suite and see whether pure-semantic-gap patterns show up enough to justify B2/B3 / A4.
-- [ ] **Tier A4**: Memory enrichment background pass — only ships if a tightened recall eval shows enrichment improves hydration quality.
-- [ ] **Tier B1 / B3**: LLM-based selector / cross-workflow priors — same gate. With current baselines, both stay deferred.
-- [ ] **Tier A4** (memory enrichment) ships only if the recall eval shows enrichment improves hydration quality.
-- [ ] **Tier B** (LLM selector / embeddings / cross-workflow) ships only if the recall eval shows the deterministic path leaves real recall on the table.
+- [x] **Tier A4 (infrastructure)**: Memory enrichment seam — `MemoryEnricher` trait in `cel-llm` + `MemoryEnrichmentInput`/`Output` shapes + `with_memory_enricher` builder on `CanonicalGoalRunner` + write-time hook in `write_outcome_memory_if_enabled` with always-safe fallback (plain summary + `["canonical_runner"]` tag set on enricher absence/failure/empty-output). Mirrors WK2 pattern: ship the seam, no bundled LLM impl. *(Shipped this PR; 4 new tests pin the contract: no enricher → plain; success → enriched + merged tags; failure → plain fallback; empty-output → plain fallback. 3 stub-trait tests in cel-llm.)*
+- [x] **Tier B1 (infrastructure)**: LLM-based memory selector — `MemorySelector` trait in `cel-llm` + `MemoryRerankContext`/`MemoryRerankItem` shapes + `with_memory_selector` builder on `CanonicalGoalRunner` + read-time re-rank in `run_inner` after `build_planning_view`, with always-safe fallback (selector failure / unknown ids → WK1 ordering preserved). Mirrors A4 + WK2 pattern: ship the seam, no bundled LLM impl. *(Shipped this PR; 4 new runner tests pin the contract: no selector → WK1 order; success → re-ordered; failure → WK1 fallback; invents-ids → defensive drop. 3 stub-trait tests in cel-llm.)*
+- [ ] **Tier B3**: Cross-workflow priors — needs an explicit privacy decision before code. Stays deferred until that product call lands.
+
+**Reframe note (2026-05-09):** Earlier wording marked A4 + B1 as "eval-gated → don't build until eval forces it." That was over-conservative — the original architectural intent (visible in the PR4 reframe section above) is "build the seam, keep the deterministic path as fallback, eval validates the LLM impl's *quality*." This block of acceptance criteria now matches that intent. Only B3 stays as a true deferral (different reason — privacy boundary needs deciding first).
 
 ---
 

--- a/cel/cel-goal-runner/src/canonical_runner.rs
+++ b/cel/cel-goal-runner/src/canonical_runner.rs
@@ -130,6 +130,22 @@ pub struct CanonicalGoalRunner<P: PlanProducer, X: StepExecutor> {
     /// `None` means WK1 deterministic recall only — no embedding work
     /// done, no per-call latency or token cost.
     embedder: Option<Arc<dyn cel_llm::Embedder>>,
+    /// Tier A4: optional memory enricher. When wired, the runner calls
+    /// it once per outcome-memory write (in `write_outcome_memory_if_enabled`)
+    /// to produce a richer summary + tags before persistence. Failure
+    /// or absence falls through to the plain runner-generated summary
+    /// (current pre-A4 behaviour). One LLM call per write, amortized
+    /// across all future reads of that memory.
+    memory_enricher: Option<Arc<dyn cel_llm::MemoryEnricher>>,
+    /// Tier B1: optional LLM-based memory selector for read-time
+    /// re-ranking of WK1's shortlist. When wired, the runner takes
+    /// `view.memories` after `build_planning_view` (which already
+    /// applied WK1 deterministic ranking + cap), asks the selector to
+    /// re-rank, and reorders/filters `view.memories` per the LLM's
+    /// priority list. On selector failure or absence: WK1 ordering
+    /// stands (pre-B1 behaviour). One LLM call per turn — amortizable
+    /// across the per-turn perception + planner round-trip.
+    memory_selector: Option<Arc<dyn cel_llm::MemorySelector>>,
 }
 
 impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
@@ -138,6 +154,8 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
             planner,
             executor,
             embedder: None,
+            memory_enricher: None,
+            memory_selector: None,
         }
     }
 
@@ -148,6 +166,36 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
     /// pre-WK2 behaviour for callers who haven't wired one up.
     pub fn with_embedder(mut self, embedder: Arc<dyn cel_llm::Embedder>) -> Self {
         self.embedder = Some(embedder);
+        self
+    }
+
+    /// Tier A4: builder-style opt-in to LLM-driven memory enrichment
+    /// at write time.
+    ///
+    /// Pass `Arc::new(MyEnricher { ... })` to enable. Until called, the
+    /// runner writes the plain summary + `["canonical_runner"]` tag set
+    /// (pre-A4 behaviour). When called, each outcome-memory write runs
+    /// `enricher.enrich(...)` once; on success the enriched summary +
+    /// merged tag set are persisted; on failure the runner logs WARN
+    /// and falls through to the plain path. Never blocks the run.
+    pub fn with_memory_enricher(mut self, enricher: Arc<dyn cel_llm::MemoryEnricher>) -> Self {
+        self.memory_enricher = Some(enricher);
+        self
+    }
+
+    /// Tier B1: builder-style opt-in to LLM-based memory selector
+    /// re-ranking.
+    ///
+    /// Pass `Arc::new(MySelector { ... })` to enable. Until called, the
+    /// runner uses WK1 deterministic ordering directly (pre-B1
+    /// behaviour). When called, every turn — after `build_planning_view`
+    /// has applied WK1 ranking + cap and before `decide_next` — the
+    /// runner asks the selector to re-rank `view.memories`. On success
+    /// the LLM's order replaces WK1's. On failure (LLM error / parse
+    /// error / unknown ids) the runner logs WARN and WK1's order
+    /// stands. Always-safe: B1 never blocks the run.
+    pub fn with_memory_selector(mut self, selector: Arc<dyn cel_llm::MemorySelector>) -> Self {
+        self.memory_selector = Some(selector);
         self
     }
 
@@ -184,6 +232,7 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
         write_outcome_memory_if_enabled(
             memory_store.as_ref(),
             self.embedder.as_ref(),
+            self.memory_enricher.as_ref(),
             &limits,
             goal,
             &outcome,
@@ -284,6 +333,24 @@ impl<P: PlanProducer, X: StepExecutor> CanonicalGoalRunner<P, X> {
                 cortex_anomalies: Some(cortex_anomalies.as_slice()),
                 cortex_freshness: cortex_freshness.as_ref(),
             });
+
+            // Tier B1: LLM-based memory re-rank. Runs only when a
+            // selector is wired AND WK1 produced a non-empty shortlist
+            // (no point re-ranking 0 items). On any failure the WK1
+            // ordering already in `view.memories` stands — never blocks
+            // the run.
+            let mut view = view;
+            if let Some(selector) = self.memory_selector.as_ref() {
+                if !view.memories.is_empty() {
+                    apply_memory_selector(
+                        &mut view.memories,
+                        selector,
+                        goal,
+                        planning_budget.max_memories as usize,
+                    )
+                    .await;
+                }
+            }
 
             // Phase gate: past the budget midpoint with no terminal-
             // app work yet → inject a synthetic history record telling
@@ -731,6 +798,71 @@ fn open_memory_store_if_enabled(
 /// the run continues with the WK1 deterministic selector path
 /// (FTS5+decay only, no cosine boost). Called once per run from `run()`
 /// so the loop doesn't pay per-turn embed latency.
+/// Tier B1: re-rank `memories` (in place) using the LLM selector. On
+/// any failure path — selector errors, parse failure, all returned ids
+/// unknown to the candidate set — leaves `memories` untouched (WK1
+/// ordering preserved). Defensive: silently drops unknown ids and
+/// truncates results past `max_to_keep` rather than erroring on a
+/// chatty LLM.
+///
+/// Always-safe: on no path does this block the run, mutate state
+/// outside `memories`, or surface an error to the caller. The runner's
+/// next step (planner.decide_next) sees either re-ranked or original
+/// memories — either is a valid input.
+async fn apply_memory_selector(
+    memories: &mut Vec<cel_contracts::MemoryRef>,
+    selector: &Arc<dyn cel_llm::MemorySelector>,
+    goal: &str,
+    max_to_keep: usize,
+) {
+    let candidates: Vec<cel_llm::MemoryRerankItem> = memories
+        .iter()
+        .map(|m| cel_llm::MemoryRerankItem {
+            id: m.id,
+            kind: m.kind.clone(),
+            summary: m.summary.clone(),
+        })
+        .collect();
+    let ctx = cel_llm::MemoryRerankContext {
+        goal,
+        candidates: &candidates,
+        max_to_keep,
+    };
+    let new_order = match selector.rerank(&ctx).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "B1 memory selector errored; falling back to WK1 ordering",
+            );
+            return;
+        }
+    };
+
+    // Defensive filter: keep only ids that actually exist in the
+    // candidate set. Truncate to `max_to_keep`. Empty result is valid
+    // (selector said "nothing relevant" — runner persists that).
+    let known_ids: std::collections::HashSet<i64> = memories.iter().map(|m| m.id).collect();
+    let kept_ids: Vec<i64> = new_order
+        .into_iter()
+        .filter(|id| known_ids.contains(id))
+        .take(max_to_keep)
+        .collect();
+
+    // Reorder `memories` to match `kept_ids` priority. Build a lookup
+    // by id, then walk kept_ids in order pulling from the lookup.
+    let mut by_id: std::collections::HashMap<i64, cel_contracts::MemoryRef> =
+        memories.drain(..).map(|m| (m.id, m)).collect();
+    for id in kept_ids {
+        if let Some(m) = by_id.remove(&id) {
+            memories.push(m);
+        }
+    }
+    // Note: ids in `by_id` after this loop are dropped — that's the
+    // selector's filter behaviour. The LLM is trusted to filter as
+    // well as sort.
+}
+
 async fn compute_goal_embedding(
     embedder: Option<&Arc<dyn cel_llm::Embedder>>,
     goal: &str,
@@ -764,9 +896,17 @@ async fn compute_goal_embedding(
 /// selection (see `planning_view::score_memory`). Embed failure logs at
 /// WARN and writes the memory with `embedding: None` (still useful via
 /// FTS5+decay; the cosine path just won't fire for this entry).
+///
+/// Tier A4: also takes the optional memory enricher. When wired, the
+/// runner calls `enricher.enrich(...)` once per write to produce a
+/// richer summary + extra tags. On success the enriched values land on
+/// the persisted memory; on failure the runner logs WARN and writes
+/// the plain summary + the default `["canonical_runner"]` tag set
+/// (pre-A4 behaviour). Always-safe: A4 never blocks the run.
 async fn write_outcome_memory_if_enabled(
     memory_store: Option<&std::sync::Mutex<cel_store::CelStore>>,
     embedder: Option<&Arc<dyn cel_llm::Embedder>>,
+    enricher: Option<&Arc<dyn cel_llm::MemoryEnricher>>,
     limits: &RunLimits,
     goal: &str,
     outcome: &GoalOutcome,
@@ -825,11 +965,67 @@ async fn write_outcome_memory_if_enabled(
         }
     };
 
-    // WK2: embed the summary text once when an embedder is wired.
-    // Falls back to None on embed failure (logged); falls through to
-    // None when no embedder is wired at all (no per-call cost).
+    // Tier A4: enrich the summary + tags via the LLM enricher when one
+    // is wired. Falls through to (plain summary, ["canonical_runner"]
+    // tag set) on enricher absence or failure — pre-A4 behaviour
+    // preserved exactly. The enrichment runs BEFORE the embedding step
+    // so that WK2 embeds the *enriched* summary (richer text → more
+    // semantic signal in the cosine boost).
+    let kind_str = kind.as_str();
+    let content_json = serde_json::to_string(&content).unwrap_or_default();
+    let (final_summary, mut final_tags) = match enricher {
+        Some(enr) => {
+            let input = cel_llm::MemoryEnrichmentInput {
+                plain_summary: &summary,
+                kind: kind_str,
+                content_json: &content_json,
+                goal,
+            };
+            match enr.enrich(&input).await {
+                Ok(out) if !out.enriched_summary.is_empty() => {
+                    let mut tags = vec!["canonical_runner".into()];
+                    // Cap merged tag count at 16 to bound storage growth.
+                    for t in out.tags.into_iter().take(15) {
+                        if !tags.iter().any(|existing: &String| existing == &t) {
+                            tags.push(t);
+                        }
+                    }
+                    (out.enriched_summary, tags)
+                }
+                Ok(_) => {
+                    // Enricher returned empty summary — defensive
+                    // fallback (treat same as failure).
+                    tracing::warn!(
+                        workflow_id,
+                        "A4 outcome memory: enricher returned empty summary; using plain",
+                    );
+                    (summary.clone(), vec!["canonical_runner".into()])
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        workflow_id,
+                        error = %e,
+                        "A4 outcome memory: enrich failed; using plain summary + default tags",
+                    );
+                    (summary.clone(), vec!["canonical_runner".into()])
+                }
+            }
+        }
+        None => (summary.clone(), vec!["canonical_runner".into()]),
+    };
+    // The enriched summary is what gets embedded — richer text gives
+    // WK2's cosine boost more semantic signal to work with.
+    let summary_for_embedding = final_summary.clone();
+    let _ = &mut final_tags; // silence "unused mut" if A4 fallback only path runs
+
+    // WK2: embed the (possibly enriched) summary text when an embedder
+    // is wired. Falls back to None on embed failure (logged); falls
+    // through to None when no embedder is wired at all (no per-call
+    // cost). Drops the original summary binding so the borrow checker
+    // is happy.
+    drop(summary);
     let embedding = match embedder {
-        Some(emb) => match emb.embed(&summary).await {
+        Some(emb) => match emb.embed(&summary_for_embedding).await {
             Ok(v) => Some(v.to_bytes()),
             Err(e) => {
                 tracing::warn!(
@@ -847,8 +1043,8 @@ async fn write_outcome_memory_if_enabled(
         workflow_id: workflow_id.to_string(),
         kind,
         content,
-        summary: Some(summary),
-        tags: vec!["canonical_runner".into()],
+        summary: Some(final_summary),
+        tags: final_tags,
         source_ref: Some(format!(
             "canonical_runner:duration_ms={}",
             duration.as_millis()
@@ -1890,6 +2086,408 @@ mod tests {
             memories[0].kind,
             cel_store::cortex_memory::MemoryKind::Outcome
         );
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    // ─── Tier A4: memory enrichment infrastructure ──────────────────────────
+
+    use async_trait::async_trait;
+
+    /// Stub enricher: prefixes summary, adds two tags. Used to verify
+    /// the runner actually invokes + persists enriched output.
+    struct StubEnricherTagger;
+    #[async_trait]
+    impl cel_llm::MemoryEnricher for StubEnricherTagger {
+        async fn enrich(
+            &self,
+            input: &cel_llm::MemoryEnrichmentInput<'_>,
+        ) -> Result<cel_llm::MemoryEnrichmentOutput, cel_llm::LlmError> {
+            Ok(cel_llm::MemoryEnrichmentOutput {
+                enriched_summary: format!("[A4-rich] {}", input.plain_summary),
+                tags: vec!["concur".into(), "submit".into(), input.kind.to_string()],
+            })
+        }
+    }
+
+    /// Always-error stub: verifies the fallback path actually fires.
+    struct AlwaysFailEnricher;
+    #[async_trait]
+    impl cel_llm::MemoryEnricher for AlwaysFailEnricher {
+        async fn enrich(
+            &self,
+            _: &cel_llm::MemoryEnrichmentInput<'_>,
+        ) -> Result<cel_llm::MemoryEnrichmentOutput, cel_llm::LlmError> {
+            Err(cel_llm::LlmError::RequestFailed("simulated".into()))
+        }
+    }
+
+    /// Empty-output stub: enricher returns success but with empty
+    /// summary. Runner must defensively fall back to plain (we don't
+    /// want to persist a memory with summary == "").
+    struct EmptyOutputEnricher;
+    #[async_trait]
+    impl cel_llm::MemoryEnricher for EmptyOutputEnricher {
+        async fn enrich(
+            &self,
+            _: &cel_llm::MemoryEnrichmentInput<'_>,
+        ) -> Result<cel_llm::MemoryEnrichmentOutput, cel_llm::LlmError> {
+            Ok(cel_llm::MemoryEnrichmentOutput {
+                enriched_summary: String::new(),
+                tags: vec!["should_be_dropped".into()],
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn a4_no_enricher_writes_plain_summary_and_default_tags() {
+        // Pre-A4 behaviour preserved when no enricher is wired.
+        let db_path = pr2_temp_db("a4_none");
+        let planner = ScriptedPlanner::new(vec![NextMove::Done {
+            summary: "did the thing".into(),
+            extracted_data: serde_json::Value::Null,
+        }]);
+        let runner = CanonicalGoalRunner::new(planner, ScriptedExecutor::new());
+        let limits = RunLimits {
+            max_steps: 5,
+            timeout_ms: 10_000,
+            max_step_retries: 3,
+            terminal_app: None,
+            workflow_id_for_memory: Some("a4-none".into()),
+            memory_db_path: Some(db_path.clone()),
+        };
+        let _ = runner.run("submit invoice", limits).await;
+
+        let store = cel_store::CelStore::open(&db_path).expect("re-open");
+        let memories = store.list_cortex_memories("a4-none", None, 10).unwrap();
+        assert_eq!(memories.len(), 1);
+        // Plain summary preserved verbatim (no [A4-rich] prefix).
+        assert_eq!(memories[0].summary.as_deref(), Some("did the thing"));
+        // Default tag set only.
+        assert_eq!(memories[0].tags, vec!["canonical_runner".to_string()]);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[tokio::test]
+    async fn a4_enricher_success_persists_enriched_summary_and_merged_tags() {
+        let db_path = pr2_temp_db("a4_success");
+        let planner = ScriptedPlanner::new(vec![NextMove::Done {
+            summary: "Submitted invoice via Concur".into(),
+            extracted_data: serde_json::Value::Null,
+        }]);
+        let runner = CanonicalGoalRunner::new(planner, ScriptedExecutor::new())
+            .with_memory_enricher(Arc::new(StubEnricherTagger));
+        let limits = RunLimits {
+            max_steps: 5,
+            timeout_ms: 10_000,
+            max_step_retries: 3,
+            terminal_app: None,
+            workflow_id_for_memory: Some("a4-success".into()),
+            memory_db_path: Some(db_path.clone()),
+        };
+        let _ = runner.run("submit invoice in Concur", limits).await;
+
+        let store = cel_store::CelStore::open(&db_path).expect("re-open");
+        let memories = store.list_cortex_memories("a4-success", None, 10).unwrap();
+        assert_eq!(memories.len(), 1);
+        assert_eq!(
+            memories[0].summary.as_deref(),
+            Some("[A4-rich] Submitted invoice via Concur")
+        );
+        // Default tag merged with stub tags. Order: default first, then
+        // enricher tags in their original order.
+        assert_eq!(
+            memories[0].tags,
+            vec![
+                "canonical_runner".to_string(),
+                "concur".into(),
+                "submit".into(),
+                "outcome".into()
+            ]
+        );
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[tokio::test]
+    async fn a4_enricher_error_falls_back_to_plain_path() {
+        // Critical contract: enricher failure NEVER blocks the run
+        // and NEVER prevents the memory from landing. The plain
+        // summary + default tags persist, identical to the no-enricher
+        // case.
+        let db_path = pr2_temp_db("a4_fallback");
+        let planner = ScriptedPlanner::new(vec![NextMove::Done {
+            summary: "fallback test summary".into(),
+            extracted_data: serde_json::Value::Null,
+        }]);
+        let runner = CanonicalGoalRunner::new(planner, ScriptedExecutor::new())
+            .with_memory_enricher(Arc::new(AlwaysFailEnricher));
+        let limits = RunLimits {
+            max_steps: 5,
+            timeout_ms: 10_000,
+            max_step_retries: 3,
+            terminal_app: None,
+            workflow_id_for_memory: Some("a4-fallback".into()),
+            memory_db_path: Some(db_path.clone()),
+        };
+        let outcome = runner.run("g", limits).await;
+        assert!(matches!(outcome, GoalOutcome::Succeeded { .. }));
+
+        let store = cel_store::CelStore::open(&db_path).expect("re-open");
+        let memories = store.list_cortex_memories("a4-fallback", None, 10).unwrap();
+        assert_eq!(memories.len(), 1, "memory must land even on enrich failure");
+        assert_eq!(
+            memories[0].summary.as_deref(),
+            Some("fallback test summary"),
+            "plain summary persisted on enricher error"
+        );
+        assert_eq!(
+            memories[0].tags,
+            vec!["canonical_runner".to_string()],
+            "default tags only on enricher error"
+        );
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    // ─── Tier B1: LLM memory selector re-rank ───────────────────────────────
+
+    /// Reverse-order selector: lets us assert the runner actually
+    /// applied the selector by checking memory ordering after a turn.
+    struct ReverseRerank;
+    #[async_trait]
+    impl cel_llm::MemorySelector for ReverseRerank {
+        async fn rerank(
+            &self,
+            ctx: &cel_llm::MemoryRerankContext<'_>,
+        ) -> Result<Vec<i64>, cel_llm::LlmError> {
+            Ok(ctx.candidates.iter().rev().map(|c| c.id).collect())
+        }
+    }
+
+    /// Always-error selector: verifies fallback path.
+    struct AlwaysFailRerank;
+    #[async_trait]
+    impl cel_llm::MemorySelector for AlwaysFailRerank {
+        async fn rerank(
+            &self,
+            _: &cel_llm::MemoryRerankContext<'_>,
+        ) -> Result<Vec<i64>, cel_llm::LlmError> {
+            Err(cel_llm::LlmError::RequestFailed("simulated".into()))
+        }
+    }
+
+    /// Selector that returns ids guaranteed not in the candidate set.
+    /// Verifies the runner's defensive "drop unknown ids" behaviour.
+    struct InventsIdsRerank;
+    #[async_trait]
+    impl cel_llm::MemorySelector for InventsIdsRerank {
+        async fn rerank(
+            &self,
+            _: &cel_llm::MemoryRerankContext<'_>,
+        ) -> Result<Vec<i64>, cel_llm::LlmError> {
+            Ok(vec![999_001, 999_002, 999_003])
+        }
+    }
+
+    /// Helper: seed N memories under a workflow + run with the given
+    /// selector wired (or none), return the resulting view.memories
+    /// id ordering captured from a single planner turn. Uses the
+    /// happy-path Done planner so we get exactly one turn before
+    /// outcome write.
+    async fn b1_capture_memory_order(
+        selector: Option<Arc<dyn cel_llm::MemorySelector>>,
+        seeded_summaries: &[&str],
+    ) -> Vec<i64> {
+        let db_path = pr2_temp_db("b1_order");
+        // Seed memories DIRECTLY in the store (bypass runner) so we
+        // control the workflow_id state before the run.
+        let store = cel_store::CelStore::open(&db_path).expect("open seed store");
+        let mut seeded_ids = Vec::new();
+        for (i, summary) in seeded_summaries.iter().enumerate() {
+            let id = store
+                .insert_cortex_memory(&cel_store::cortex_memory::NewCortexMemory {
+                    workflow_id: "b1-test".into(),
+                    kind: cel_store::cortex_memory::MemoryKind::Outcome,
+                    content: serde_json::json!({"i": i, "goal": "submit invoice"}),
+                    summary: Some(summary.to_string()),
+                    tags: vec![],
+                    source_ref: None,
+                    embedding: None,
+                })
+                .expect("seed insert");
+            seeded_ids.push(id);
+        }
+        drop(store);
+
+        // Capture-planner: reads view.memories on its first call,
+        // returns Done. We can inspect what memories the runner
+        // surfaced.
+        let captured: Arc<std::sync::Mutex<Vec<i64>>> = Arc::new(std::sync::Mutex::new(vec![]));
+        let captured_clone = captured.clone();
+        struct CapturePlanner {
+            captured: Arc<std::sync::Mutex<Vec<i64>>>,
+        }
+        #[async_trait]
+        impl PlanProducer for CapturePlanner {
+            async fn decide_next(
+                &self,
+                _goal: &str,
+                _history: &[AttemptRecord],
+                _shared: &serde_json::Value,
+                view: &cel_contracts::PlanningView,
+                _shot: Option<&[u8]>,
+            ) -> Result<NextMove, String> {
+                *self.captured.lock().unwrap() = view.memories.iter().map(|m| m.id).collect();
+                Ok(NextMove::Done {
+                    summary: "captured".into(),
+                    extracted_data: serde_json::Value::Null,
+                })
+            }
+        }
+        let planner = CapturePlanner {
+            captured: captured_clone,
+        };
+        let mut runner = CanonicalGoalRunner::new(planner, ScriptedExecutor::new());
+        if let Some(s) = selector {
+            runner = runner.with_memory_selector(s);
+        }
+        let limits = RunLimits {
+            max_steps: 5,
+            timeout_ms: 10_000,
+            max_step_retries: 3,
+            terminal_app: None,
+            workflow_id_for_memory: Some("b1-test".into()),
+            memory_db_path: Some(db_path.clone()),
+        };
+        let _ = runner.run("submit invoice", limits).await;
+        let order = captured.lock().unwrap().clone();
+        let _ = std::fs::remove_file(&db_path);
+        order
+    }
+
+    #[tokio::test]
+    async fn b1_no_selector_preserves_wk1_ordering() {
+        // Pre-B1 behaviour: WK1 deterministic order stands.
+        let order = b1_capture_memory_order(
+            None,
+            &[
+                "Submitted invoice attempt one",
+                "Submitted invoice attempt two",
+                "Submitted invoice attempt three",
+            ],
+        )
+        .await;
+        // 3 memories should surface; we don't pin specific WK1 order
+        // (it's bm25 + decay-dependent and could shift if WK1 internals
+        // change), only that all 3 are present and the count matches.
+        assert_eq!(order.len(), 3, "all 3 keyword-matching memories surface");
+    }
+
+    #[tokio::test]
+    async fn b1_selector_success_replaces_wk1_ordering() {
+        // ReverseRerank: whatever WK1 ordered, we'll see reversed.
+        let no_sel_order = b1_capture_memory_order(
+            None,
+            &[
+                "Submitted invoice attempt alpha",
+                "Submitted invoice attempt beta",
+                "Submitted invoice attempt gamma",
+            ],
+        )
+        .await;
+        let with_sel_order = b1_capture_memory_order(
+            Some(Arc::new(ReverseRerank)),
+            &[
+                "Submitted invoice attempt alpha",
+                "Submitted invoice attempt beta",
+                "Submitted invoice attempt gamma",
+            ],
+        )
+        .await;
+        assert_eq!(no_sel_order.len(), 3);
+        assert_eq!(with_sel_order.len(), 3);
+        // Reverse: with-selector order is no-selector reversed.
+        let mut expected_reversed = no_sel_order.clone();
+        expected_reversed.reverse();
+        assert_eq!(
+            with_sel_order, expected_reversed,
+            "selector must reverse WK1 order"
+        );
+    }
+
+    #[tokio::test]
+    async fn b1_selector_error_falls_back_to_wk1_ordering() {
+        // Critical: selector failure must not change ordering.
+        let no_sel_order = b1_capture_memory_order(
+            None,
+            &[
+                "Submitted invoice attempt one",
+                "Submitted invoice attempt two",
+            ],
+        )
+        .await;
+        let failed_sel_order = b1_capture_memory_order(
+            Some(Arc::new(AlwaysFailRerank)),
+            &[
+                "Submitted invoice attempt one",
+                "Submitted invoice attempt two",
+            ],
+        )
+        .await;
+        assert_eq!(
+            no_sel_order, failed_sel_order,
+            "selector failure must leave WK1 ordering intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn b1_selector_inventing_unknown_ids_drops_them_safely() {
+        // Selector returns ids that don't exist in the candidate
+        // pool. Defensive filter: empty memories result. NOT a panic,
+        // NOT a fall-back to WK1 (the selector was "successful" — it
+        // just said "none of these"). The runner trusts the LLM's
+        // filter intent.
+        let order = b1_capture_memory_order(
+            Some(Arc::new(InventsIdsRerank)),
+            &[
+                "Submitted invoice attempt one",
+                "Submitted invoice attempt two",
+            ],
+        )
+        .await;
+        assert!(
+            order.is_empty(),
+            "inventing-ids selector → empty memories (defensive filter); got {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a4_enricher_empty_summary_treated_as_failure() {
+        // Defensive check: an enricher that returns Ok but with an
+        // empty summary string would otherwise persist a useless
+        // memory. Runner must treat this as failure → plain fallback.
+        let db_path = pr2_temp_db("a4_empty");
+        let planner = ScriptedPlanner::new(vec![NextMove::Done {
+            summary: "real text".into(),
+            extracted_data: serde_json::Value::Null,
+        }]);
+        let runner = CanonicalGoalRunner::new(planner, ScriptedExecutor::new())
+            .with_memory_enricher(Arc::new(EmptyOutputEnricher));
+        let limits = RunLimits {
+            max_steps: 5,
+            timeout_ms: 10_000,
+            max_step_retries: 3,
+            terminal_app: None,
+            workflow_id_for_memory: Some("a4-empty".into()),
+            memory_db_path: Some(db_path.clone()),
+        };
+        let _ = runner.run("g", limits).await;
+
+        let store = cel_store::CelStore::open(&db_path).expect("re-open");
+        let memories = store.list_cortex_memories("a4-empty", None, 10).unwrap();
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0].summary.as_deref(), Some("real text"));
+        // The "should_be_dropped" tag should NOT have leaked through —
+        // we treated the empty summary as failure and used defaults.
+        assert_eq!(memories[0].tags, vec!["canonical_runner".to_string()]);
         let _ = std::fs::remove_file(&db_path);
     }
 }

--- a/cel/cel-llm/src/enricher.rs
+++ b/cel/cel-llm/src/enricher.rs
@@ -1,0 +1,197 @@
+//! Tier A4: memory enrichment infrastructure.
+//!
+//! Ships the **seam** for LLM-driven enrichment of cortex memories at
+//! write time: a trait, the input/output shapes, and a no-op default
+//! pattern. No bundled LLM call; production callers wire one.
+//!
+//! ## Why write-time, not read-time?
+//!
+//! Enrichment costs an LLM call per memory write. With write-time
+//! enrichment, that cost is amortized across all future reads of the
+//! memory — one call vs hundreds. Read-time enrichment (per-turn
+//! re-summarization) has the opposite economics and would multiply
+//! latency on the hot path. We never want a hot-path LLM call we
+//! can't avoid.
+//!
+//! ## What enrichment does
+//!
+//! Given a memory's raw content + the runner's plain summary, the
+//! enricher produces:
+//!
+//! - A **richer summary** — multi-sentence if useful, mentions
+//!   keywords / entities the planner will want to match against.
+//! - A **set of tags** — short keywords (one or two words each) that
+//!   describe the memory's domain, action, and outcome. Tags
+//!   complement the summary in the FTS5 index (WK1 indexes summary +
+//!   content + tags).
+//!
+//! ## Fallback contract
+//!
+//! Enrichment is **opt-in**:
+//!
+//! - No enricher wired → `canonical_runner` writes the plain summary
+//!   + the `["canonical_runner"]` tag (current pre-A4 behaviour).
+//! - Enricher wired AND succeeds → the LLM-produced summary + the
+//!   merged `["canonical_runner", ...llm_tags]` tag set.
+//! - Enricher wired AND fails (LLM error / timeout) → log WARN, fall
+//!   through to the plain-summary path. Memory still lands; just less
+//!   richly. Never blocks the run.
+
+use async_trait::async_trait;
+
+use crate::LlmError;
+
+/// Input to one enrichment call.
+///
+/// Borrowed-data — the runner has these strings already and the
+/// enricher implementation is expected to hand them to its prompt
+/// without copying.
+#[derive(Debug, Clone)]
+pub struct MemoryEnrichmentInput<'a> {
+    /// The plain one-line summary the runner produced (e.g.
+    /// `"Submitted invoice via Concur successfully"`). Always present.
+    pub plain_summary: &'a str,
+    /// Discriminator for the structured payload. Mirrors
+    /// `cel_store::cortex_memory::MemoryKind::as_str()` — `"outcome"`
+    /// / `"prior"` / `"failure"` / `"preference"`.
+    pub kind: &'a str,
+    /// The structured content payload as JSON text. Lets the enricher
+    /// see action targets, extracted data, etc. without forcing the
+    /// runner to re-parse and pass them as separate fields.
+    pub content_json: &'a str,
+    /// The goal text that produced this memory. Helps the enricher
+    /// align tags + summary phrasing with planner-side keywords.
+    pub goal: &'a str,
+}
+
+/// Output of one enrichment call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryEnrichmentOutput {
+    /// Replaces the plain summary on the memory record. Must be
+    /// non-empty — implementations that have nothing useful to add
+    /// should return `Ok(MemoryEnrichmentOutput::passthrough(input))`
+    /// or simply return Err so the runner falls through.
+    pub enriched_summary: String,
+    /// Tags to **merge** with the runner's default tag set
+    /// (`["canonical_runner"]`). Implementations should produce 1–6
+    /// short tokens (one or two words each); the runner caps the
+    /// final tag count at 16 to bound storage growth.
+    pub tags: Vec<String>,
+}
+
+impl MemoryEnrichmentOutput {
+    /// Convenience constructor for an enricher that just wants to
+    /// pass the plain summary through with no added tags. Useful as a
+    /// safe default for implementations that don't yet know what to
+    /// add.
+    pub fn passthrough(input: &MemoryEnrichmentInput<'_>) -> Self {
+        Self {
+            enriched_summary: input.plain_summary.to_string(),
+            tags: Vec::new(),
+        }
+    }
+}
+
+/// The contract `cel-goal-runner` calls once per memory write when
+/// the caller has wired an enricher via `with_memory_enricher`.
+///
+/// Keep the surface minimal — one async call per memory. If you need
+/// batching (enrich many memories at once), wrap one of these at a
+/// higher layer rather than expanding the trait.
+#[async_trait]
+pub trait MemoryEnricher: Send + Sync {
+    /// Enrich one memory. On success, the runner uses the enriched
+    /// summary + merges the tags with `"canonical_runner"`. On error,
+    /// the runner logs WARN and writes the plain summary unchanged
+    /// (always-safe fallback — A4 never blocks the run).
+    async fn enrich(
+        &self,
+        input: &MemoryEnrichmentInput<'_>,
+    ) -> Result<MemoryEnrichmentOutput, LlmError>;
+
+    /// Optional model identifier (e.g. `"openai:gpt-4o-mini"` or
+    /// `"local-onnx:enricher-v1"`). When stable, the runner can stamp
+    /// it on writes for later observability. Returns `None` for test
+    /// stubs and impls without meaningful identity.
+    fn model_id(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic stub for downstream tests (cel-goal-runner). Adds
+    /// a fixed tag set and prefixes the summary so we can assert that
+    /// enrichment fired vs not. Sync internally; the async signature
+    /// is just trait conformance.
+    pub struct StubEnricher;
+
+    #[async_trait]
+    impl MemoryEnricher for StubEnricher {
+        async fn enrich(
+            &self,
+            input: &MemoryEnrichmentInput<'_>,
+        ) -> Result<MemoryEnrichmentOutput, LlmError> {
+            Ok(MemoryEnrichmentOutput {
+                enriched_summary: format!("[enriched] {}", input.plain_summary),
+                tags: vec!["stub_tag".into(), input.kind.to_string()],
+            })
+        }
+        fn model_id(&self) -> Option<&str> {
+            Some("stub:test")
+        }
+    }
+
+    /// Deterministic always-error stub — used to verify the runner's
+    /// fallback path actually fires.
+    pub struct AlwaysErrEnricher;
+
+    #[async_trait]
+    impl MemoryEnricher for AlwaysErrEnricher {
+        async fn enrich(
+            &self,
+            _input: &MemoryEnrichmentInput<'_>,
+        ) -> Result<MemoryEnrichmentOutput, LlmError> {
+            Err(LlmError::RequestFailed("simulated enricher failure".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn stub_enricher_returns_prefixed_summary_and_tags() {
+        let input = MemoryEnrichmentInput {
+            plain_summary: "Submitted invoice",
+            kind: "outcome",
+            content_json: "{}",
+            goal: "submit invoice in Concur",
+        };
+        let out = StubEnricher.enrich(&input).await.unwrap();
+        assert_eq!(out.enriched_summary, "[enriched] Submitted invoice");
+        assert_eq!(out.tags, vec!["stub_tag", "outcome"]);
+    }
+
+    #[tokio::test]
+    async fn always_err_enricher_returns_err_for_fallback_test() {
+        let input = MemoryEnrichmentInput {
+            plain_summary: "x",
+            kind: "outcome",
+            content_json: "{}",
+            goal: "g",
+        };
+        assert!(AlwaysErrEnricher.enrich(&input).await.is_err());
+    }
+
+    #[test]
+    fn passthrough_output_uses_plain_summary_and_no_tags() {
+        let input = MemoryEnrichmentInput {
+            plain_summary: "the original",
+            kind: "outcome",
+            content_json: "{}",
+            goal: "g",
+        };
+        let out = MemoryEnrichmentOutput::passthrough(&input);
+        assert_eq!(out.enriched_summary, "the original");
+        assert!(out.tags.is_empty());
+    }
+}

--- a/cel/cel-llm/src/lib.rs
+++ b/cel/cel-llm/src/lib.rs
@@ -6,12 +6,16 @@
 mod client;
 mod config;
 mod embedder;
+mod enricher;
 mod error;
+mod selector;
 
 pub use client::LlmClient;
 pub use config::{LlmProviderConfig, LlmRole, ModelProfile, ModelTier, ProviderKind};
 pub use embedder::{cosine_similarity, Embedder, EmbeddingVector};
+pub use enricher::{MemoryEnricher, MemoryEnrichmentInput, MemoryEnrichmentOutput};
 pub use error::LlmError;
+pub use selector::{MemoryRerankContext, MemoryRerankItem, MemorySelector};
 
 /// Content part in a chat message (text or image).
 #[derive(Debug, Clone, serde::Serialize)]

--- a/cel/cel-llm/src/selector.rs
+++ b/cel/cel-llm/src/selector.rs
@@ -1,0 +1,200 @@
+//! Tier B1: LLM-based memory selector infrastructure.
+//!
+//! Ships the **seam** for LLM-driven re-ranking of cortex memories at
+//! read time: a trait, the input/output shapes, and the always-safe
+//! fallback contract. No bundled LLM impl — production callers wire one.
+//!
+//! ## Why re-rank, not re-select?
+//!
+//! WK1's deterministic selector (FTS5 + decay + cosine boost) already
+//! produces a reasonable shortlist + ranking. The LLM selector's job
+//! is to **re-order** the shortlist using semantic understanding the
+//! deterministic scorer can't capture (e.g. "this failure memory
+//! actually answers the question even though its keywords don't
+//! overlap as well").
+//!
+//! Re-ranking is cheaper than re-selecting because:
+//! - Input tokens scale with shortlist size (~20-30 candidates), not
+//!   the full workflow memory pool (potentially 10K+).
+//! - The LLM never has to do retrieval — just ordering.
+//! - Failure cleanly falls back to WK1's existing order (already
+//!   computed); no expensive recompute.
+//!
+//! ## Fallback contract
+//!
+//! Selection is **opt-in**:
+//!
+//! - No selector wired → `canonical_runner` uses WK1 ordering
+//!   directly (pre-B1 behaviour).
+//! - Selector wired AND succeeds → memories reordered per the LLM's
+//!   priority list; ids the LLM omitted are dropped (the LLM is
+//!   trusted to filter, not just sort).
+//! - Selector wired AND fails (LLM error / timeout / parse error /
+//!   returns ids not in input) → log WARN, fall through to WK1
+//!   ordering. Memory hydration always lands; just less smartly
+//!   ranked. Never blocks the run.
+//!
+//! ## Why operate on hydrated MemoryRefs, not raw store rows?
+//!
+//! Two reasons:
+//! 1. **No store access in the LLM impl.** The LLM only needs id +
+//!    kind + summary to rank. Keeping the trait shape away from
+//!    `cel-store` types avoids a dependency cycle (cel-llm depends on
+//!    cel-cortex would close one, since cel-cortex depends on cel-llm
+//!    for the embedder + enricher traits).
+//! 2. **Caller-controlled hydration.** The runner has already paid the
+//!    cost to hydrate WK1's shortlist into the planning view; the
+//!    selector just re-orders the result. Read-time LLM cost stays
+//!    bounded.
+
+use async_trait::async_trait;
+
+use crate::LlmError;
+
+/// One candidate memory in the rerank request — minimal shape the
+/// LLM needs to reason about relevance. Mirrors the LLM-facing parts
+/// of `cel_contracts::MemoryRef` without dragging in the contract crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryRerankItem {
+    /// Stable cortex memory id. Used as the LLM's reference token in
+    /// its response — the runner re-orders the original `MemoryRef`
+    /// list by matching these ids.
+    pub id: i64,
+    /// `"outcome"` / `"prior"` / `"failure"` / `"preference"`. Lets the
+    /// LLM weight by kind (e.g. failures > outcomes when the goal
+    /// looks like a likely-to-fail attempt).
+    pub kind: String,
+    /// Caller-provided summary text. Comes from `MemoryRef.summary`
+    /// (which is the runner's plain summary in the pre-A4 path or
+    /// the LLM-enriched summary in the post-A4 path). The richer this
+    /// text, the better the LLM's re-ranking.
+    pub summary: String,
+}
+
+/// Borrowed context passed to the selector on each call.
+#[derive(Debug, Clone)]
+pub struct MemoryRerankContext<'a> {
+    pub goal: &'a str,
+    /// WK1's shortlist, in WK1's deterministic priority order. The
+    /// selector should treat this as the **complete candidate set** —
+    /// it must not invent ids that aren't in this list.
+    pub candidates: &'a [MemoryRerankItem],
+    /// Maximum number of ids the selector may return. Implementations
+    /// should respect this cap; the runner enforces it defensively
+    /// (extra ids beyond `max_to_keep` are dropped).
+    pub max_to_keep: usize,
+}
+
+/// The contract `cel-goal-runner` calls once per planner turn (when
+/// memory hydration is enabled AND a selector is wired) to re-rank
+/// WK1's shortlist.
+#[async_trait]
+pub trait MemorySelector: Send + Sync {
+    /// Re-rank `ctx.candidates` for `ctx.goal`. Returns the ids of the
+    /// memories to keep, in priority order. Implementations:
+    ///
+    /// - MUST only return ids present in `ctx.candidates` (the runner
+    ///   silently drops unknown ids; the LLM doesn't get to invent
+    ///   memories).
+    /// - SHOULD return at most `ctx.max_to_keep` ids (the runner
+    ///   defensively truncates if more are returned).
+    /// - MAY return fewer than `ctx.max_to_keep` ids — the LLM is
+    ///   trusted to filter as well as sort.
+    /// - MAY return an empty Vec if no candidate is relevant — the
+    ///   runner persists this as "no relevant memories for this goal."
+    /// - On error: the runner logs WARN and falls through to WK1's
+    ///   original ordering. Implementations should error rather than
+    ///   return garbage.
+    async fn rerank(&self, ctx: &MemoryRerankContext<'_>) -> Result<Vec<i64>, LlmError>;
+
+    /// Optional model identifier (e.g. `"openai:gpt-4o-mini"`). When
+    /// stable, lets the runner stamp it on observability traces.
+    /// Returns `None` for stubs and impls without meaningful identity.
+    fn model_id(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: i64, kind: &str, summary: &str) -> MemoryRerankItem {
+        MemoryRerankItem {
+            id,
+            kind: kind.into(),
+            summary: summary.into(),
+        }
+    }
+
+    /// Stub selector: reverses the input order. Lets downstream tests
+    /// verify "selector actually fired" by asserting the rev-order
+    /// outcome.
+    pub struct ReverseSelector;
+    #[async_trait]
+    impl MemorySelector for ReverseSelector {
+        async fn rerank(&self, ctx: &MemoryRerankContext<'_>) -> Result<Vec<i64>, LlmError> {
+            Ok(ctx.candidates.iter().rev().map(|c| c.id).collect())
+        }
+    }
+
+    /// Stub selector: always errors. Verifies the fallback path.
+    pub struct AlwaysErrSelector;
+    #[async_trait]
+    impl MemorySelector for AlwaysErrSelector {
+        async fn rerank(&self, _: &MemoryRerankContext<'_>) -> Result<Vec<i64>, LlmError> {
+            Err(LlmError::RequestFailed("simulated".into()))
+        }
+    }
+
+    /// Stub selector: returns ids the runner can't possibly know
+    /// about (1, 2, 3 — guaranteed not in the candidate pool the
+    /// downstream tests use). Verifies the runner's defensive
+    /// "unknown id → drop" behaviour.
+    pub struct InventsIdsSelector;
+    #[async_trait]
+    impl MemorySelector for InventsIdsSelector {
+        async fn rerank(&self, _: &MemoryRerankContext<'_>) -> Result<Vec<i64>, LlmError> {
+            Ok(vec![999_991, 999_992, 999_993])
+        }
+    }
+
+    #[tokio::test]
+    async fn reverse_selector_returns_input_in_reverse() {
+        let candidates = vec![
+            item(10, "outcome", "a"),
+            item(20, "prior", "b"),
+            item(30, "failure", "c"),
+        ];
+        let ctx = MemoryRerankContext {
+            goal: "any",
+            candidates: &candidates,
+            max_to_keep: 5,
+        };
+        let out = ReverseSelector.rerank(&ctx).await.unwrap();
+        assert_eq!(out, vec![30, 20, 10]);
+    }
+
+    #[tokio::test]
+    async fn always_err_selector_returns_err_for_fallback_test() {
+        let candidates = vec![item(1, "outcome", "x")];
+        let ctx = MemoryRerankContext {
+            goal: "g",
+            candidates: &candidates,
+            max_to_keep: 1,
+        };
+        assert!(AlwaysErrSelector.rerank(&ctx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn invents_ids_selector_returns_unknown_ids_for_filter_test() {
+        let candidates = vec![item(10, "outcome", "real")];
+        let ctx = MemoryRerankContext {
+            goal: "g",
+            candidates: &candidates,
+            max_to_keep: 5,
+        };
+        let out = InventsIdsSelector.rerank(&ctx).await.unwrap();
+        assert!(out.iter().all(|id| !candidates.iter().any(|c| c.id == *id)));
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3820,7 +3820,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.10.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4196,7 +4196,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0)))(ws@8.19.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.19.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
## Summary

Syncs PRs #41 (A4) + #42 (B1) from private. Both ship the same infrastructure shape as WK2 (embedder seam): trait + opt-in builder on canonical_runner + always-safe fallback. No bundled LLM impls.

**6 files changed** (4 modified + 2 new: \`cel-llm/src/enricher.rs\`, \`cel-llm/src/selector.rs\`)

## A4 — write-time memory enrichment
\`MemoryEnricher\` trait + \`with_memory_enricher\` builder + write-time hook in \`write_outcome_memory_if_enabled\`. Falls through to plain summary on absence/failure/empty-output.

## B1 — read-time LLM memory selector
\`MemorySelector\` trait + \`with_memory_selector\` builder + per-turn hook in \`run_inner\` after \`build_planning_view\`. Defensive (drops unknown ids, truncates to budget) + falls back to WK1 order on failure.

## Plan reframe (2026-05-09)
A4 + B1 reframed from "eval-gated" to "planned, fallback-default" — earlier framing was over-conservative. Only B3 remains as a true deferral (privacy boundary).

## Closes originally-planned cognition-layer infrastructure
With B1 + A4 alongside everything before, every infrastructure item that doesn't need an external decision is shipped. Only B3 (cross-workflow priors, gated on a privacy product call) remains.

## Test plan
- [x] \`pnpm install\` + \`pnpm -r build\` clean
- [x] \`cargo check --workspace\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)