### PR TITLE
ci(release): cross-compile x86_64-apple-darwin from macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,14 @@ jobs:
             os: macos-latest
             artifact: cel-napi.darwin-arm64.node
           - target: x86_64-apple-darwin
-            os: macos-13
+            # macos-13 hosted runners are being retired by GitHub —
+            # release #55 sat queued for 15+ min because no Intel-Mac
+            # runner ever picked it up. Switching to macos-latest
+            # (Apple Silicon) and cross-compiling via the existing
+            # `target: x86_64-apple-darwin` works because the macOS
+            # SDK ships the x86_64 linker by default; rustup pulls the
+            # matching Rust target a step later.
+            os: macos-latest
             artifact: cel-napi.darwin-x64.node
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest


### PR DESCRIPTION
## Summary
Release #55 in `dimpagk92/cellar` (public) was stuck for 15+ min on the `NAPI x86_64-apple-darwin` job, waiting for a `macos-13` runner that never picked it up — GitHub has been retiring those Intel-Mac hosted runners. Every other matrix entry (aarch64-darwin, Linux, Windows) completed normally.

Fix: switch the x86_64-apple-darwin job to `macos-latest` (Apple Silicon) and cross-compile via the existing `target: x86_64-apple-darwin` flag. The macOS SDK on hosted ARM runners ships the x86_64 linker by default; rustup pulls the cross Rust target via the `target` input on `dtolnay/rust-action/setup`. The artifact copy step is already target-relative (`target/x86_64-apple-darwin/release/`) so no further changes needed.

## Test plan
- [ ] After merge + sync to public cellar, the next release run should have all 5 NAPI matrix entries succeed
- [ ] Verify `cel-napi.darwin-x64.node` artifact is genuinely x86_64 (file/lipo on the downloaded artifact)
- [ ] If cross-link fails on Apple Silicon, fall back to `macos-13-large` (paid Intel runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
