### PR TITLE
ci(release): drop @semantic-release/npm to unblock v0.2.0 GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,14 @@ jobs:
             os: macos-latest
             artifact: cel-napi.darwin-arm64.node
           - target: x86_64-apple-darwin
-            os: macos-13
+            # macos-13 hosted runners are being retired by GitHub —
+            # release #55 sat queued for 15+ min because no Intel-Mac
+            # runner ever picked it up. Switching to macos-latest
+            # (Apple Silicon) and cross-compiling via the existing
+            # `target: x86_64-apple-darwin` works because the macOS
+            # SDK ships the x86_64 linker by default; rustup pulls the
+            # matching Rust target a step later.
+            os: macos-latest
             artifact: cel-napi.darwin-x64.node
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,18 +5,6 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": "mcp-server"
-      }
-    ],
-    [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": "cel/cel-napi"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": [
@@ -31,7 +19,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "mcp-server/package.json", "cel/cel-napi/package.json"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
## Summary
Every release run since v0.1.0 has failed on the npm publish step: no `NPM_TOKEN` secret + no OIDC trusted publishing on the npm packages. v0.1.0 itself shipped by hand. Drop both `@semantic-release/npm` plugins so the workflow can cut the GitHub release + tag + CHANGELOG with NAPI binaries attached. npm publish stays manual until OIDC or a static token is configured.

## Test plan
- [ ] CI green
- [ ] Release workflow then cuts v0.2.0 with 5 NAPI binaries attached
- [ ] CHANGELOG.md committed back to main with the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)