### PR TITLE
sync: backport private main — Receipt-Backed Run Timeline + daemon-hosted Cortex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ name = "cel-act-gateway"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cel-contracts",
  "cel-memory",
  "cellar-types",
  "chrono",
@@ -814,6 +815,24 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "cel-boot"
+version = "0.1.0"
+dependencies = [
+ "cel-accessibility",
+ "cel-adapters",
+ "cel-audio",
+ "cel-cdp",
+ "cel-context",
+ "cel-cortex",
+ "cel-display",
+ "cel-network",
+ "cel-signals",
+ "cel-vision",
+ "tokio",
  "tracing",
 ]
 
@@ -911,7 +930,10 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cel-act-gateway",
+ "cel-boot",
  "cel-brief",
+ "cel-contracts",
+ "cel-cortex",
  "cel-memory",
  "cel-memory-sqlite",
  "cel-signals",
@@ -1058,6 +1080,7 @@ dependencies = [
  "cel-accessibility",
  "cel-adapters",
  "cel-audio",
+ "cel-boot",
  "cel-cdp",
  "cel-context",
  "cel-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "cel/cel-cortex",
     "cel/cel-adapter-sdk",
     "cel/cel-adapters",
+    "cel/cel-boot",
     "cel/cel-goal-runner",
     "cel/cel-memory",
     "cel/cel-memory-sqlite",
@@ -89,6 +90,7 @@ cel-planner = { path = "cel/cel-planner" }
 cel-cortex = { path = "cel/cel-cortex" }
 cel-adapter-sdk = { path = "cel/cel-adapter-sdk" }
 cel-adapters = { path = "cel/cel-adapters" }
+cel-boot = { path = "cel/cel-boot" }
 cel-goal-runner = { path = "cel/cel-goal-runner" }
 cel-cdp = { path = "cel/cel-cdp" }
 cel-memory = { path = "cel/cel-memory" }

--- a/agent/src/cel-bindings.ts
+++ b/agent/src/cel-bindings.ts
@@ -275,6 +275,8 @@ export interface CelNative {
   stopWatchdog(): void;
   // Cortex (Rust perception engine)
   bootCortex(): void;
+  cortexSetRunId?(runId?: string | null): void;
+  cortexClearRunId?(): void;
   readCortexModel(): string;
   notifyCortexAction(action: string): void;
   reportCortexActionFailure(): void;
@@ -1509,6 +1511,20 @@ export class Cel implements
   /** Boot the Rust Cortex — starts the 200ms perception tick loop. */
   bootCortex(): void {
     this.native?.bootCortex();
+  }
+
+  /**
+   * Scope subsequent cortex execution receipts to a run id (e.g. an MCP
+   * perceive session) so they group together in the run timeline. Pass null to
+   * clear. No-op on older native builds without the binding.
+   */
+  cortexSetRunId(runId: string | null): void {
+    this.native?.cortexSetRunId?.(runId);
+  }
+
+  /** Clear the cortex run scope (run ended). */
+  cortexClearRunId(): void {
+    this.native?.cortexClearRunId?.();
   }
 
   /**

--- a/cel-act-gateway/Cargo.toml
+++ b/cel-act-gateway/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 async-trait.workspace = true
 cel-memory = { path = "../cel/cel-memory" }
+cel-contracts = { path = "../cel/cel-contracts" }
 cellar-types = { path = "../cellar-types" }
 chrono = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/cel-act-gateway/src/gateway.rs
+++ b/cel-act-gateway/src/gateway.rs
@@ -392,6 +392,12 @@ where
                 )
             }
         };
+        // Receipt-Backed Run Timeline: emit a canonical ExecutionReceipt for
+        // this governed dispatch (the gateway is the daemon's chokepoint) →
+        // run timeline file + the memory chunk below.
+        let receipt = crate::receipt::build_receipt(action, outcome);
+        crate::receipt::record_receipt(&receipt);
+
         let chunk = NewMemoryChunk {
             kind: ChunkKind::Action,
             source: ChunkSource::Gateway,
@@ -404,6 +410,7 @@ where
                 "action_args": action.action_args,
                 "outcome": serde_json::to_value(outcome)
                     .unwrap_or(Value::Null),
+                "receipt": serde_json::to_value(&receipt).unwrap_or(Value::Null),
             }),
             importance: Some(if outcome.executed() { 0.5 } else { 0.7 }),
             shareable: false,

--- a/cel-act-gateway/src/lib.rs
+++ b/cel-act-gateway/src/lib.rs
@@ -34,6 +34,7 @@ pub mod cooldown;
 pub mod decision;
 pub mod error;
 pub mod gateway;
+mod receipt;
 pub mod test_support;
 pub mod traits;
 

--- a/cel-act-gateway/src/receipt.rs
+++ b/cel-act-gateway/src/receipt.rs
@@ -1,0 +1,200 @@
+//! Gateway-side [`ExecutionReceipt`] emission for governed actions.
+//!
+//! The gateway is the daemon's dispatch chokepoint: every governed action (and,
+//! once the daemon hosts a Cortex, every UI action too) flows through
+//! [`crate::gateway::Gateway::intercept`]. This module turns each `(action,
+//! outcome)` into a canonical [`ExecutionReceipt`] and appends it to the run
+//! timeline (`~/.cellar/runs/<run_id>.jsonl`, Receipt-Backed Run Timeline) so
+//! `cellar timeline` and the cel-brief `ReceiptSource` surface the daemon
+//! agent's actions. Best-effort: no run id (agent_session_id) → no timeline
+//! write; I/O errors are swallowed so persistence never breaks dispatch.
+
+use cel_contracts::{DispatchRoute, ExecutionReceipt, ObservedEffect, ReceiptStatus};
+use serde_json::Value;
+
+use crate::action::{ActionOutcome, ProposedAction};
+
+/// Build a receipt for a governed-action dispatch. The governance verdict maps
+/// onto [`ReceiptStatus`] (which carries `Vetoed` / `Denied` / `TimedOut` for
+/// exactly this); the route is `Other { detail: "gateway" }` because governed
+/// system actions are not a UI dispatch. Native-path observed-effect
+/// verification doesn't apply, so `observed_effect` is `NotChecked`.
+pub(crate) fn build_receipt(action: &ProposedAction, outcome: &ActionOutcome) -> ExecutionReceipt {
+    let (status, error) = match outcome {
+        ActionOutcome::Executed { .. } => (ReceiptStatus::Ok, None),
+        ActionOutcome::Vetoed {
+            rule_name,
+            soft_block,
+            ..
+        } => (
+            ReceiptStatus::Vetoed,
+            Some(format!(
+                "vetoed by rule '{rule_name}'{}",
+                if *soft_block { " (soft_block)" } else { "" }
+            )),
+        ),
+        ActionOutcome::ConfirmationDenied { rule_name, .. } => (
+            ReceiptStatus::Denied,
+            Some(format!("denied via rule '{rule_name}'")),
+        ),
+        ActionOutcome::ConfirmationTimedOut {
+            rule_name,
+            timeout_s,
+            ..
+        } => (
+            ReceiptStatus::TimedOut,
+            Some(format!(
+                "confirmation timed out after {timeout_s}s (rule '{rule_name}')"
+            )),
+        ),
+    };
+    let now = now_ms();
+    ExecutionReceipt {
+        receipt_id: new_receipt_id(),
+        run_id: action.agent_session_id.clone(),
+        trace_id: None,
+        action_kind: action.action_type.clone(),
+        target: target_of(&action.action_args),
+        route: DispatchRoute::Other {
+            detail: "gateway".to_string(),
+        },
+        observed_effect: ObservedEffect::not_checked(),
+        evidence: Vec::new(),
+        requested_at_ms: now,
+        completed_at_ms: now,
+        // Gateway v1 records a coarse receipt; per-dispatch timing is a follow-up.
+        duration_ms: 0,
+        status,
+        error,
+    }
+}
+
+/// Append a run-scoped receipt to `~/.cellar/runs/<run_id>.jsonl`. No-op when
+/// the action has no run scope (agent_session_id).
+pub(crate) fn record_receipt(receipt: &ExecutionReceipt) {
+    let Some(run_id) = receipt.run_id.as_deref() else {
+        return;
+    };
+    let Some(dir) = runs_dir() else {
+        return;
+    };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join(format!("{}.jsonl", sanitize_run_id(run_id)));
+    let Ok(line) = serde_json::to_string(receipt) else {
+        return;
+    };
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+/// Best-effort target extraction from the action args (for the timeline view).
+fn target_of(args: &Value) -> Option<String> {
+    for key in ["target_id", "path", "target", "app", "url"] {
+        if let Some(s) = args.get(key).and_then(|v| v.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn runs_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".cellar").join("runs"))
+}
+
+/// Mirror the cortex writer + CLI reader sanitization.
+fn sanitize_run_id(run_id: &str) -> String {
+    run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn new_receipt_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "rcpt_gw_{}_{}",
+        now_ms(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn action() -> ProposedAction {
+        ProposedAction {
+            caller: "embedded".into(),
+            action_type: "shell.run".into(),
+            action_args: serde_json::json!({ "path": "/tmp/x" }),
+            agent_session_id: Some("sess-1".into()),
+            project_root: None,
+        }
+    }
+
+    #[test]
+    fn executed_maps_to_ok() {
+        let r = build_receipt(
+            &action(),
+            &ActionOutcome::Executed {
+                result: Value::Null,
+            },
+        );
+        assert_eq!(r.status, ReceiptStatus::Ok);
+        assert_eq!(r.action_kind, "shell.run");
+        assert_eq!(r.run_id.as_deref(), Some("sess-1"));
+        assert_eq!(r.target.as_deref(), Some("/tmp/x"));
+        assert!(matches!(r.route, DispatchRoute::Other { .. }));
+        assert!(r.error.is_none());
+    }
+
+    #[test]
+    fn vetoed_maps_to_vetoed_with_reason() {
+        let r = build_receipt(
+            &action(),
+            &ActionOutcome::Vetoed {
+                rule_id: "r1".into(),
+                rule_name: "no-shell".into(),
+                soft_block: false,
+            },
+        );
+        assert_eq!(r.status, ReceiptStatus::Vetoed);
+        assert!(r.error.as_deref().unwrap().contains("no-shell"));
+    }
+
+    #[test]
+    fn timed_out_maps_to_timed_out() {
+        let r = build_receipt(
+            &action(),
+            &ActionOutcome::ConfirmationTimedOut {
+                rule_id: "r2".into(),
+                rule_name: "confirm-delete".into(),
+                timeout_s: 60,
+            },
+        );
+        assert_eq!(r.status, ReceiptStatus::TimedOut);
+    }
+}

--- a/cel-cortex-daemon/Cargo.toml
+++ b/cel-cortex-daemon/Cargo.toml
@@ -11,7 +11,10 @@ path = "src/main.rs"
 
 [dependencies]
 cel-act-gateway = { path = "../cel-act-gateway" }
-cel-brief = { path = "../cel/cel-brief", features = ["memory"] }
+cel-cortex = { path = "../cel/cel-cortex" }
+cel-boot = { path = "../cel/cel-boot" }
+cel-contracts = { path = "../cel/cel-contracts" }
+cel-brief = { path = "../cel/cel-brief", features = ["memory", "perception"] }
 cel-memory = { path = "../cel/cel-memory" }
 cel-memory-sqlite = { path = "../cel/cel-memory-sqlite" }
 cel-summarizer = { path = "../cel/cel-summarizer" }

--- a/cel-cortex-daemon/src/agent_runtime.rs
+++ b/cel-cortex-daemon/src/agent_runtime.rs
@@ -39,7 +39,8 @@ use std::sync::{Arc, Mutex};
 use cel_act_gateway::{ActionOutcome, AgentGateway, ProposedAction};
 use cel_brief::{
     BriefBuilder, BriefContext, BriefMessage, HistoryEntry, HistorySource, MemorySource,
-    Role as BriefRole, SystemPromptSource, TokenBudget, UserMessageSource,
+    PerceptionSource, ReceiptSource, Role as BriefRole, SystemPromptSource, TokenBudget,
+    UserMessageSource,
 };
 use cel_memory::{
     CallerScope, ChunkKind, ChunkSource, MemoryProvider, MemoryQuery, NewMemoryChunk,
@@ -353,9 +354,13 @@ impl AgentRuntime {
         //                                      right before the user message so the
         //                                      model attends to it with the question.
         //                                      Disabled when `memory_recall_k == 0`.
+        //   - ReceiptSource      (Normal)   → this session's recent execution
+        //                                      receipts from the run timeline
+        //                                      (~/.cellar/runs/<session>.jsonl)
+        //   - PerceptionSource   (Normal)   → live screen snapshot, only when
+        //                                      this daemon hosts the Cortex
+        //                                      (cellar-daemon-cortex.md Phase D)
         //   - UserMessageSource  (Critical) → the current user turn (always last)
-        // `PerceptionSource` (live Cortex snapshot) remains a follow-up — see
-        // cel-brief plan §10.1.
         let mut ordered: Vec<_> = context.into_iter().collect();
         ordered.sort_by_key(|c| c.created_at);
         let history: Vec<HistoryEntry> = ordered
@@ -391,6 +396,23 @@ impl AgentRuntime {
                         ChunkKind::Context,
                     ])),
             ));
+        }
+        // Receipt-Backed Run Timeline continuity: surface this session's recent
+        // execution receipts. The gateway stamps every governed dispatch with
+        // run_id = agent_session_id and appends it to
+        // ~/.cellar/runs/<session>.jsonl; a daemon-hosted Cortex adds UI-action
+        // receipts to the same run — so the next turn is grounded in what just
+        // happened and whether it worked.
+        if let Some(receipts) = ReceiptSource::for_run(session_id, 8) {
+            builder = builder.source(Arc::new(receipts));
+        }
+        // Live screen snapshot — only when this daemon hosts the single Cortex
+        // (cellar-daemon-cortex.md Phase D). The FocusOnly default keeps the
+        // budget impact small.
+        if let Some(cortex) = crate::daemon_cortex() {
+            builder = builder.source(Arc::new(PerceptionSource::new(Arc::new(
+                DaemonCortexPerception::new(cortex),
+            ))));
         }
         // UserMessageSource is registered last so the user's current turn is the
         // final message — `brief_message_to_llm` and the loop below depend on it.
@@ -820,6 +842,138 @@ fn summarize_brief_receipt(receipt: &cel_brief::BriefReceipt) -> Value {
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// [`cel_brief::PerceptionSnapshot`] over the daemon-hosted Cortex
+/// (`cellar-daemon-cortex.md` Phase D).
+///
+/// cel-brief stays cortex-free by design; this adapter lives daemon-side and
+/// projects the live mental model into the three brief-sized views. All three
+/// read the shared model — no perception tick is forced, so a stale-but-recent
+/// snapshot is returned instantly.
+pub struct DaemonCortexPerception {
+    cortex: Arc<cel_cortex::Cortex>,
+}
+
+impl DaemonCortexPerception {
+    /// Wrap a (typically daemon-hosted) Cortex for brief perception.
+    pub fn new(cortex: Arc<cel_cortex::Cortex>) -> Self {
+        Self { cortex }
+    }
+
+    fn or_none(s: &str) -> &str {
+        if s.is_empty() {
+            "(none)"
+        } else {
+            s
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl cel_brief::PerceptionSnapshot for DaemonCortexPerception {
+    async fn as_ax_tree(&self) -> Result<String, cel_brief::PerceptionError> {
+        let model = self.cortex.model();
+        let guard = model.read().await;
+        let ctx = &guard.current_context;
+        let mut out = format!(
+            "App: {} · window: {} · {} elements",
+            Self::or_none(&ctx.app),
+            Self::or_none(&ctx.window),
+            ctx.elements.len()
+        );
+        // Bounded dense dump — one line per element, capped so a busy page
+        // can't blow the brief budget.
+        const MAX_ELEMENTS: usize = 200;
+        for el in ctx.elements.iter().take(MAX_ELEMENTS) {
+            out.push('\n');
+            out.push_str(&format!(
+                "- [{}] {}{}{}",
+                el.element_type,
+                el.id,
+                el.label
+                    .as_deref()
+                    .map(|l| format!(" \"{l}\""))
+                    .unwrap_or_default(),
+                el.value
+                    .as_deref()
+                    .map(|v| format!(" = {v}"))
+                    .unwrap_or_default(),
+            ));
+        }
+        if ctx.elements.len() > MAX_ELEMENTS {
+            out.push_str(&format!(
+                "\n… {} more elements omitted",
+                ctx.elements.len() - MAX_ELEMENTS
+            ));
+        }
+        Ok(out)
+    }
+
+    async fn as_focus_only(&self) -> Result<String, cel_brief::PerceptionError> {
+        let model = self.cortex.model();
+        let guard = model.read().await;
+        let ctx = &guard.current_context;
+        let mut out = format!(
+            "App: {} · window: {}",
+            Self::or_none(&ctx.app),
+            Self::or_none(&ctx.window)
+        );
+        match &guard.focused_element {
+            Some(f) => out.push_str(&format!(
+                "\nFocused: {} ({})",
+                f.label.as_deref().unwrap_or("(unlabelled)"),
+                f.id
+            )),
+            None => out.push_str("\nFocused: (none)"),
+        }
+        // A short actionable sample so the model can target without the full
+        // tree.
+        const MAX_ACTIONABLE: usize = 12;
+        let actionable: Vec<_> = ctx
+            .elements
+            .iter()
+            .filter(|el| !el.actions.is_empty())
+            .take(MAX_ACTIONABLE)
+            .collect();
+        if !actionable.is_empty() {
+            out.push_str("\nActionable:");
+            for el in actionable {
+                out.push_str(&format!(
+                    "\n- {} {}",
+                    el.id,
+                    el.label.as_deref().unwrap_or("")
+                ));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn as_screen_summary(&self) -> Result<String, cel_brief::PerceptionError> {
+        let model = self.cortex.model();
+        let guard = model.read().await;
+        let ctx = &guard.current_context;
+        let actionable = ctx
+            .elements
+            .iter()
+            .filter(|el| !el.actions.is_empty())
+            .count();
+        Ok(format!(
+            "App: {} · window: {} · {} elements ({} actionable){}",
+            Self::or_none(&ctx.app),
+            Self::or_none(&ctx.window),
+            ctx.elements.len(),
+            actionable,
+            guard
+                .focused_element
+                .as_ref()
+                .map(|f| format!(
+                    " · focused: {}",
+                    f.label.as_deref().unwrap_or(f.id.as_str())
+                ))
+                .unwrap_or_default(),
+        ))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/cel-cortex-daemon/src/ipc.rs
+++ b/cel-cortex-daemon/src/ipc.rs
@@ -19,15 +19,16 @@ use async_trait::async_trait;
 use cellar_ipc::error::{IpcError, IpcResult};
 use cellar_ipc::handler::FrameSink;
 use cellar_ipc::params::{
-    agent as agent_params, confirmation as cf_params, events as ev_params, fires as fi_params,
-    memory as mem_params, rules as rules_params, system, watchlists as wl_params,
-    webhooks as wh_params,
+    agent as agent_params, confirmation as cf_params, cortex as cortex_params, events as ev_params,
+    fires as fi_params, memory as mem_params, rules as rules_params, system,
+    watchlists as wl_params, webhooks as wh_params,
 };
 use cellar_ipc::results::agent::{
     AgentMessage, AgentMessageResult, AgentRunResult, AgentSessionMetadata,
     AgentSessionsCreateResult, AgentSessionsGetResult, AgentSessionsListResult,
 };
 use cellar_ipc::results::confirmation::{ConfirmationListPendingResult, ConfirmationResolveResult};
+use cellar_ipc::results::cortex::{CortexActResult, CortexPerceiveReadResult, CortexSeeResult};
 use cellar_ipc::results::daemon::{
     DaemonStatusResult, MemoryCorpusStats, RuleStats, WatchlistStats,
 };
@@ -591,7 +592,84 @@ impl Handler for DaemonIpcHandler {
             memory_mb,
             cpu_pct,
             memory: memory_corpus,
+            cortex_running: crate::cortex_running(),
         })
+    }
+
+    // ───── cortex.* ─────
+    //
+    // Drive the daemon-hosted Cortex (Phase B of `cellar-daemon-cortex.md`).
+    // Every method returns the typed `CortexUnavailable` error when the
+    // daemon was started without `CELLAR_DAEMON_CORTEX`.
+
+    async fn cortex_see(&self) -> IpcResult<CortexSeeResult> {
+        let cortex = crate::daemon_cortex().ok_or(IpcError::CortexUnavailable("cortex.see"))?;
+        let context = {
+            let model = cortex.model();
+            let guard = model.read().await;
+            guard.current_context.clone()
+        };
+        let context = serde_json::to_value(&context)
+            .map_err(|e| IpcError::Internal(format!("context serialization failed: {e}")))?;
+        Ok(CortexSeeResult { context })
+    }
+
+    async fn cortex_act(
+        &self,
+        params: cortex_params::CortexActParams,
+    ) -> IpcResult<CortexActResult> {
+        let cortex = crate::daemon_cortex().ok_or(IpcError::CortexUnavailable("cortex.act"))?;
+        let action: cel_contracts::PlannedAction = serde_json::from_value(params.action)
+            .map_err(|e| IpcError::InvalidParams(format!("not a canonical action: {e}")))?;
+        // Execute against the cortex's current fused context — same shape the
+        // in-process canonical executor uses. The core-emitted ExecutionReceipt
+        // rides back on `data._cel_receipt`.
+        let context = {
+            let model = cortex.model();
+            let guard = model.read().await;
+            guard.current_context.clone()
+        };
+        let result = cortex
+            .execute(&action, &context)
+            .await
+            .map_err(|e| IpcError::Internal(format!("cortex execute failed: {e}")))?;
+        Ok(CortexActResult {
+            success: result.success,
+            error: result.error,
+            data: result.data,
+        })
+    }
+
+    async fn cortex_perceive_start(
+        &self,
+        params: cortex_params::CortexPerceiveStartParams,
+    ) -> IpcResult<OkResult> {
+        if crate::daemon_cortex().is_none() {
+            return Err(IpcError::CortexUnavailable("cortex.perceive.start"));
+        }
+        cel_cortex::set_run_id(Some(params.run_id));
+        Ok(OkResult {})
+    }
+
+    async fn cortex_perceive_read(&self) -> IpcResult<CortexPerceiveReadResult> {
+        let cortex =
+            crate::daemon_cortex().ok_or(IpcError::CortexUnavailable("cortex.perceive.read"))?;
+        let model = {
+            let handle = cortex.model();
+            let guard = handle.read().await;
+            guard.clone()
+        };
+        let model = serde_json::to_value(&model)
+            .map_err(|e| IpcError::Internal(format!("model serialization failed: {e}")))?;
+        Ok(CortexPerceiveReadResult { model })
+    }
+
+    async fn cortex_perceive_stop(&self) -> IpcResult<OkResult> {
+        if crate::daemon_cortex().is_none() {
+            return Err(IpcError::CortexUnavailable("cortex.perceive.stop"));
+        }
+        cel_cortex::clear_run_id();
+        Ok(OkResult {})
     }
 
     // ───── rules.* ─────
@@ -2009,6 +2087,42 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, IpcError::WatchlistNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn cortex_methods_without_hosted_cortex_yield_typed_error() {
+        // The lib test binary never sets the process-global daemon cortex
+        // (the hosted-cortex happy path lives in tests/cortex_ipc.rs, its own
+        // process), so every cortex.* method must return CortexUnavailable.
+        let h = handler();
+        assert!(matches!(
+            h.cortex_see().await.unwrap_err(),
+            IpcError::CortexUnavailable(_)
+        ));
+        assert!(matches!(
+            h.cortex_act(cellar_ipc::params::cortex::CortexActParams {
+                action: json!({"type": "wait", "ms": 1}),
+            })
+            .await
+            .unwrap_err(),
+            IpcError::CortexUnavailable(_)
+        ));
+        assert!(matches!(
+            h.cortex_perceive_start(cellar_ipc::params::cortex::CortexPerceiveStartParams {
+                run_id: "r".into(),
+            })
+            .await
+            .unwrap_err(),
+            IpcError::CortexUnavailable(_)
+        ));
+        assert!(matches!(
+            h.cortex_perceive_read().await.unwrap_err(),
+            IpcError::CortexUnavailable(_)
+        ));
+        assert!(matches!(
+            h.cortex_perceive_stop().await.unwrap_err(),
+            IpcError::CortexUnavailable(_)
+        ));
     }
 
     #[tokio::test]

--- a/cel-cortex-daemon/src/lib.rs
+++ b/cel-cortex-daemon/src/lib.rs
@@ -45,7 +45,31 @@ pub mod subscriptions;
 pub mod sweeper;
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+/// The daemon's single live Cortex (perception + execution), when hosted.
+///
+/// One daemon process = one Cortex — two would fight over the macOS AX tree and
+/// input focus (see `cellar-daemon-cortex.md`). Set once at boot when
+/// `CELLAR_DAEMON_CORTEX` is enabled; `None` otherwise (the default), in which
+/// case the daemon runs exactly as before. Later phases drive this Cortex from
+/// the app / CLI / MCP over IPC.
+static DAEMON_CORTEX: OnceLock<Arc<cel_cortex::Cortex>> = OnceLock::new();
+
+/// Store the daemon's hosted Cortex (first set wins).
+pub fn set_daemon_cortex(cortex: Arc<cel_cortex::Cortex>) {
+    let _ = DAEMON_CORTEX.set(cortex);
+}
+
+/// The daemon's Cortex handle, if one has been hosted.
+pub fn daemon_cortex() -> Option<Arc<cel_cortex::Cortex>> {
+    DAEMON_CORTEX.get().cloned()
+}
+
+/// Whether the daemon is currently hosting a live Cortex.
+pub fn cortex_running() -> bool {
+    DAEMON_CORTEX.get().is_some()
+}
 
 use cel_act_gateway::test_support::RecordingActuator;
 use cel_act_gateway::{

--- a/cel-cortex-daemon/src/main.rs
+++ b/cel-cortex-daemon/src/main.rs
@@ -71,6 +71,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&memory),
     );
 
+    // Phase A1 (cellar-daemon-cortex.md): optionally host the single live Cortex
+    // in the daemon, via the shared cel-boot helper. Gated + default OFF, so the
+    // daemon is byte-for-byte unchanged unless explicitly enabled. Native input
+    // is separately gated (off by default). Later phases drive this Cortex from
+    // the app / CLI / MCP over IPC.
+    if std::env::var("CELLAR_DAEMON_CORTEX")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    {
+        let native_input = std::env::var("CELLAR_DAEMON_NATIVE_INPUT")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+        let mut opts = cel_boot::BootOpts::new("daemon");
+        opts.native_input = native_input;
+        match cel_boot::boot_default_cortex(opts).await {
+            Ok(cortex) => {
+                cel_cortex_daemon::set_daemon_cortex(cortex);
+                tracing::info!(native_input, "daemon Cortex hosted (CELLAR_DAEMON_CORTEX)");
+            }
+            Err(e) => tracing::error!(error = %e, "daemon Cortex boot failed"),
+        }
+    }
+
     let stats = daemon.memory.stats().await?;
     tracing::info!(?stats, "memory subsystem wired");
     let initial_rules = daemon.rules_store.list_rules().len();

--- a/cel-cortex-daemon/tests/cortex_ipc.rs
+++ b/cel-cortex-daemon/tests/cortex_ipc.rs
@@ -1,0 +1,65 @@
+//! `cortex.*` IPC methods against a daemon-hosted Cortex.
+//!
+//! Lives in its own integration-test binary (own process) because hosting
+//! sets the process-global daemon cortex (`OnceLock`) — the lib test binary
+//! relies on it staying unset to exercise the `CortexUnavailable` path.
+//!
+//! The Cortex here is constructed but NOT booted: no perception tick, no
+//! AX / display / input access, so the test runs headless anywhere. `wait`
+//! is a pure control action that dispatches without device IO.
+
+use std::sync::Arc;
+
+use cel_cortex_daemon::ipc::DaemonIpcHandler;
+use cellar_ipc::error::IpcError;
+use cellar_ipc::params::cortex::{CortexActParams, CortexPerceiveStartParams};
+use cellar_ipc::Handler;
+use cellar_rules_store::SqliteRulesStore;
+use serde_json::json;
+
+#[tokio::test]
+async fn cortex_methods_drive_the_hosted_cortex() {
+    cel_cortex_daemon::set_daemon_cortex(Arc::new(cel_cortex::Cortex::new("itest".into())));
+    let store = SqliteRulesStore::in_memory().unwrap();
+    let h = DaemonIpcHandler::new("test", store);
+
+    // see → the (empty, unbooted) fused context serialises as an object.
+    let see = h.cortex_see().await.unwrap();
+    assert!(see.context.is_object());
+
+    // act → a pure control action executes and reports success.
+    let act = h
+        .cortex_act(CortexActParams {
+            action: json!({"type": "wait", "ms": 1}),
+        })
+        .await
+        .unwrap();
+    assert!(act.success, "wait should succeed: {:?}", act.error);
+
+    // A payload that isn't a canonical action → typed InvalidParams.
+    let err = h
+        .cortex_act(CortexActParams {
+            action: json!({"type": "not_a_real_action"}),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, IpcError::InvalidParams(_)));
+
+    // perceive.start/stop scope the receipt run id (Receipt-Backed Run
+    // Timeline) — receipts emitted while active group under this id.
+    h.cortex_perceive_start(CortexPerceiveStartParams {
+        run_id: "ipc-itest-run".into(),
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        cel_cortex::current_run_id().as_deref(),
+        Some("ipc-itest-run")
+    );
+
+    let read = h.cortex_perceive_read().await.unwrap();
+    assert!(read.model.is_object());
+
+    h.cortex_perceive_stop().await.unwrap();
+    assert!(cel_cortex::current_run_id().is_none());
+}

--- a/cel-cortex-daemon/tests/perception_snapshot.rs
+++ b/cel-cortex-daemon/tests/perception_snapshot.rs
@@ -1,0 +1,27 @@
+//! `DaemonCortexPerception` — the daemon-side [`cel_brief::PerceptionSnapshot`]
+//! adapter over a hosted Cortex (`cellar-daemon-cortex.md` Phase D).
+//!
+//! Uses an unbooted Cortex (default empty mental model): no perception tick,
+//! no AX / display access, so the test runs headless anywhere. The point is
+//! the projection plumbing, not live perception content.
+
+use std::sync::Arc;
+
+use cel_brief::PerceptionSnapshot;
+use cel_cortex_daemon::agent_runtime::DaemonCortexPerception;
+
+#[tokio::test]
+async fn projections_render_from_an_unbooted_cortex() {
+    let cortex = Arc::new(cel_cortex::Cortex::new("perception-test".into()));
+    let p = DaemonCortexPerception::new(cortex);
+
+    let summary = p.as_screen_summary().await.unwrap();
+    assert!(summary.contains("0 elements"), "summary: {summary}");
+    assert!(summary.contains("App: (none)"), "summary: {summary}");
+
+    let focus = p.as_focus_only().await.unwrap();
+    assert!(focus.contains("Focused: (none)"), "focus: {focus}");
+
+    let tree = p.as_ax_tree().await.unwrap();
+    assert!(tree.contains("0 elements"), "tree: {tree}");
+}

--- a/cel/cel-boot/Cargo.toml
+++ b/cel/cel-boot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cel-boot"
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+description = "Shared 'boot a default Cortex' helper — builds the standard perception merger (AX + display + network + signals, optional vision/audio) + the default adapter set and starts the Cortex tick loop. One boot path for every host (cel-napi/MCP, cel-eval/benchmarks, the daemon) instead of per-host copies."
+
+[dependencies]
+cel-cortex = { workspace = true }
+cel-adapters = { workspace = true }
+cel-cdp = { workspace = true }
+cel-accessibility = { workspace = true }
+cel-display = { workspace = true }
+cel-network = { workspace = true }
+cel-signals = { workspace = true }
+cel-context = { workspace = true }
+cel-vision = { workspace = true }
+cel-audio = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/cel/cel-boot/src/lib.rs
+++ b/cel/cel-boot/src/lib.rs
@@ -1,0 +1,133 @@
+//! Shared "boot a default Cortex" helper.
+//!
+//! The Cortex boot sequence — build the standard perception [`ContextMerger`]
+//! (AX + display + network + signals, optional vision/audio) → [`Cortex::new`]
+//! → [`cel_adapters::register_default_adapters`] → `cortex.boot(...)` (which
+//! starts the background perception tick loop) — was historically inlined in
+//! both `cel-napi` (the MCP host) and `cel-eval` (benchmarks). This crate is the
+//! single owner of that path, parameterised by [`BootOpts`], so every host
+//! (MCP, eval, the daemon) boots the same way — no per-host divergence.
+//!
+//! [`ContextMerger`]: cel_context::ContextMerger
+
+use std::sync::Arc;
+
+use cel_cortex::Cortex;
+
+/// A host-built audio capture + its config (from `cel-audio`). The host owns
+/// device selection; the helper just wires it into the Cortex when present.
+pub type AudioSource = (Box<dyn cel_audio::AudioCapture>, cel_audio::AudioConfig);
+
+/// Options for [`boot_default_cortex`].
+///
+/// Defaults ([`BootOpts::new`]) are the safe/headless choice: no native input,
+/// ambient CDP discovery, no vision/audio. Hosts opt into more:
+/// - **MCP** (`cel-napi`): `native_input = true`, `vision = true` + `runtime`,
+///   `audio = default_audio_capture()`, ambient CDP.
+/// - **eval** (`cel-eval`): pinned `cdp_client`, `native_input` only behind the
+///   foreground-leak flag, no vision/audio.
+pub struct BootOpts {
+    /// Cortex id (`"mcp-default"`, `"cel-eval"`, `"daemon"`, …).
+    pub id: String,
+    /// Enable native input (CGEvent mouse/keyboard/AX/app-activation). Off in
+    /// eval/CI; on for the MCP host and the app daemon.
+    pub native_input: bool,
+    /// Pinned CDP client — eval targets a specific headless browser. `None` =
+    /// ambient discovery (`connect_to_focused_app`), used by MCP/daemon.
+    pub cdp_client: Option<Arc<cel_cdp::CdpClient>>,
+    /// Attach a vision provider from env (`cel_vision::create_provider_from_env`).
+    /// Requires [`BootOpts::runtime`]; a missing/erroring provider is skipped.
+    pub vision: bool,
+    /// Tokio runtime handle for the vision provider's background work.
+    pub runtime: Option<tokio::runtime::Handle>,
+    /// Host-built audio capture, when audio perception is wanted.
+    pub audio: Option<AudioSource>,
+}
+
+impl BootOpts {
+    /// Safe defaults: no native input, ambient CDP, no vision/audio.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            native_input: false,
+            cdp_client: None,
+            vision: false,
+            runtime: None,
+            audio: None,
+        }
+    }
+}
+
+/// Build the standard perception merger + default adapters and boot the Cortex
+/// tick loop. Returns the booted `Arc<Cortex>`, with `model.stream_status`
+/// reflecting which perception streams are live.
+pub async fn boot_default_cortex(opts: BootOpts) -> Result<Arc<Cortex>, String> {
+    let BootOpts {
+        id,
+        native_input,
+        cdp_client,
+        vision,
+        runtime,
+        audio,
+    } = opts;
+
+    // One-shot AX-trust check — surface the missing-permission failure once,
+    // with the fix path, instead of one WARN per tick.
+    #[cfg(target_os = "macos")]
+    if !cel_accessibility::ax_is_process_trusted() {
+        tracing::warn!(
+            target: "cel_boot",
+            "macOS Accessibility permission missing for this process. AX-element \
+             observations will be empty until granted: System Settings → Privacy & \
+             Security → Accessibility, then enable the host and restart it. CDP \
+             browser perception and adapter-driven app truth (Numbers, Excel, …) \
+             work without AX trust."
+        );
+    }
+
+    // Perception sources → merger.
+    let a11y = cel_accessibility::create_tree();
+    let display = cel_display::create_capture();
+    let network = cel_network::create_monitor();
+    let signals = cel_signals::create_signal_bus();
+    let mut merger =
+        cel_context::ContextMerger::with_all(a11y, display, network).with_signals(signals);
+    if vision {
+        if let (Ok(provider), Some(rt)) = (cel_vision::create_provider_from_env(), runtime) {
+            merger = merger.with_vision(provider).with_runtime(rt);
+        }
+    }
+    let mut stream_status = merger.stream_status();
+    let observer = cel_accessibility::create_tree();
+
+    // Cortex + execution config.
+    let mut cortex = Cortex::new(id);
+    if native_input {
+        cortex = cortex.with_native_input_unsafe();
+    }
+    if let Some(client) = cdp_client.clone() {
+        cortex = cortex.with_cdp_client(client);
+    }
+    if let Some((capture, config)) = audio {
+        cortex = cortex.with_audio(capture, config);
+        stream_status.audio_capture = true;
+    }
+
+    // Default adapter set (in-process Numbers/Notes/Browser + process-driver
+    // discovery). `cdp_client` here is the same Option: `Some` pins the browser
+    // adapter to the eval browser, `None` lets it self-activate via ambient CDP.
+    cel_adapters::register_default_adapters(&mut cortex, cdp_client);
+
+    cortex
+        .boot(merger, observer)
+        .await
+        .map_err(|e| format!("cortex boot failed: {e}"))?;
+
+    let cortex = Arc::new(cortex);
+    {
+        let model_handle = cortex.model();
+        let mut model = model_handle.write().await;
+        model.stream_status = stream_status;
+    }
+    Ok(cortex)
+}

--- a/cel/cel-brief/src/lib.rs
+++ b/cel/cel-brief/src/lib.rs
@@ -81,8 +81,8 @@ pub use receipt::{
 };
 pub use source::{Contribution, ContributionContent, Source, SourceError};
 pub use sources::{
-    HistoryEntry, HistorySource, HistoryStore, SystemPromptSource, ToolCatalogSource,
-    UserMessageSource,
+    HistoryEntry, HistorySource, HistoryStore, ReceiptSource, SystemPromptSource,
+    ToolCatalogSource, UserMessageSource,
 };
 #[cfg(feature = "memory")]
 pub use sources::{MemoryQueryStrategy, MemorySource};

--- a/cel/cel-brief/src/sources/mod.rs
+++ b/cel/cel-brief/src/sources/mod.rs
@@ -17,6 +17,7 @@
 //! [`crate::governance`] / [`crate::receipt`]; this module is sources only.
 
 pub mod history;
+pub mod receipt;
 pub mod system_prompt;
 pub mod tool_catalog;
 pub mod user_message;
@@ -28,6 +29,7 @@ pub mod memory;
 pub mod perception;
 
 pub use history::{HistoryEntry, HistorySource, HistoryStore};
+pub use receipt::ReceiptSource;
 pub use system_prompt::SystemPromptSource;
 pub use tool_catalog::ToolCatalogSource;
 pub use user_message::UserMessageSource;

--- a/cel/cel-brief/src/sources/receipt.rs
+++ b/cel/cel-brief/src/sources/receipt.rs
@@ -1,0 +1,205 @@
+//! [`ReceiptSource`] — surfaces a run's recent execution receipts into the brief.
+//!
+//! The cortex appends each run-scoped execution receipt to
+//! `<runs_dir>/<run_id>.jsonl` (Receipt-Backed Run Timeline). This source reads
+//! the last `limit` for a given run and contributes a compact "recent actions"
+//! summary, so the next turn's brief reflects what the agent just did and
+//! whether the effects were observed — the `… → evidence → brief` half of the
+//! loop.
+//!
+//! cel-brief stays decoupled from cel-cortex: the receipt is read as untyped
+//! JSON from the shared file, never via a cortex dependency.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::source::{Contribution, ContributionContent, Source, SourceError};
+use crate::types::{BriefContext, Priority, SourceId};
+
+/// Contributes a run's recent execution receipts as a compact System summary.
+pub struct ReceiptSource {
+    id: SourceId,
+    runs_dir: PathBuf,
+    run_id: String,
+    limit: usize,
+}
+
+impl ReceiptSource {
+    /// Read receipts for `run_id` from `runs_dir` (`<runs_dir>/<run_id>.jsonl`),
+    /// surfacing the last `limit`.
+    pub fn new(runs_dir: impl Into<PathBuf>, run_id: impl Into<String>, limit: usize) -> Self {
+        Self {
+            id: SourceId::new("receipts"),
+            runs_dir: runs_dir.into(),
+            run_id: run_id.into(),
+            limit,
+        }
+    }
+
+    /// Convenience constructor pointing at the default `~/.cellar/runs` dir.
+    /// Returns `None` when `$HOME` is unset.
+    pub fn for_run(run_id: impl Into<String>, limit: usize) -> Option<Self> {
+        default_runs_dir().map(|dir| Self::new(dir, run_id, limit))
+    }
+}
+
+#[async_trait]
+impl Source for ReceiptSource {
+    fn id(&self) -> SourceId {
+        self.id.clone()
+    }
+
+    fn priority(&self) -> Priority {
+        Priority::Normal
+    }
+
+    async fn contribute(&self, _ctx: &BriefContext) -> Result<Vec<Contribution>, SourceError> {
+        let receipts = read_recent(&self.runs_dir, &self.run_id, self.limit);
+        if receipts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut text = format!("Recent actions this run ({}):", self.run_id);
+        for r in &receipts {
+            text.push('\n');
+            text.push_str(&format_receipt(r));
+        }
+        let estimated_tokens = text.len() / 4;
+        Ok(vec![Contribution {
+            content: ContributionContent::System { text },
+            estimated_tokens,
+            importance: 0.6,
+            redactable: true,
+            tags: vec!["receipts".to_string(), "recent".to_string()],
+        }])
+    }
+}
+
+fn read_recent(runs_dir: &Path, run_id: &str, limit: usize) -> Vec<serde_json::Value> {
+    let path = runs_dir.join(format!("{}.jsonl", sanitize_run_id(run_id)));
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let mut all: Vec<serde_json::Value> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    if all.len() > limit {
+        all = all.split_off(all.len() - limit);
+    }
+    all
+}
+
+fn format_receipt(r: &serde_json::Value) -> String {
+    let s = |k: &str| r.get(k).and_then(|v| v.as_str()).unwrap_or("?");
+    let route = r
+        .get("route")
+        .and_then(|v| v.get("route"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let effect = r
+        .get("observed_effect")
+        .and_then(|v| v.get("status"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("-");
+    let dur = r.get("duration_ms").and_then(|v| v.as_u64()).unwrap_or(0);
+    let target = r.get("target").and_then(|v| v.as_str()).unwrap_or("");
+    format!(
+        "- {} via {} → {} (effect: {}, {}ms) {}",
+        s("action_kind"),
+        route,
+        s("status"),
+        effect,
+        dur,
+        target
+    )
+}
+
+fn default_runs_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cellar").join("runs"))
+}
+
+/// Must match the cortex writer (`cel-cortex` `receipt.rs`) and the CLI reader.
+fn sanitize_run_id(run_id: &str) -> String {
+    run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BriefContext, TokenBudget};
+
+    fn ctx() -> BriefContext {
+        BriefContext::new(TokenBudget::new(1000, 0))
+    }
+
+    fn write_run(dir: &Path, run_id: &str, lines: &[&str]) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{run_id}.jsonl")), lines.join("\n")).unwrap();
+    }
+
+    #[tokio::test]
+    async fn surfaces_recent_receipts() {
+        let dir = std::env::temp_dir().join("cel_brief_receipt_src_a");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_run(
+            &dir,
+            "run1",
+            &[
+                r#"{"receipt_id":"r1","action_kind":"set_value","route":{"route":"cdp"},"observed_effect":{"status":"observed"},"status":"ok","duration_ms":42,"target":"dom:input:x"}"#,
+                r#"{"receipt_id":"r2","action_kind":"click","route":{"route":"cdp"},"observed_effect":{"status":"timed_out"},"status":"timed_out","duration_ms":2000,"target":"dom:button:y"}"#,
+            ],
+        );
+        let src = ReceiptSource::new(&dir, "run1", 8);
+        let out = src.contribute(&ctx()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        let ContributionContent::System { text } = &out[0].content else {
+            panic!("expected a system contribution");
+        };
+        assert!(text.contains("set_value via cdp → ok"));
+        assert!(text.contains("click via cdp → timed_out"));
+        assert!(text.contains("effect: observed"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn empty_when_no_file() {
+        let dir = std::env::temp_dir().join("cel_brief_receipt_src_missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        let src = ReceiptSource::new(&dir, "nope", 8);
+        assert!(src.contribute(&ctx()).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn respects_limit() {
+        let dir = std::env::temp_dir().join("cel_brief_receipt_src_limit");
+        let _ = std::fs::remove_dir_all(&dir);
+        let lines: Vec<String> = (0..10)
+            .map(|i| {
+                format!(
+                    r#"{{"action_kind":"click","route":{{"route":"cdp"}},"status":"ok","duration_ms":{i}}}"#
+                )
+            })
+            .collect();
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_run(&dir, "run2", &refs);
+        let src = ReceiptSource::new(&dir, "run2", 3);
+        let out = src.contribute(&ctx()).await.unwrap();
+        let ContributionContent::System { text } = &out[0].content else {
+            panic!("expected a system contribution");
+        };
+        // 1 header line + 3 receipt lines.
+        assert_eq!(text.lines().count(), 4);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/cel/cel-contracts/src/lib.rs
+++ b/cel/cel-contracts/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod actions;
 pub mod canonical;
 pub mod producer;
+pub mod receipt;
 pub mod view;
 
 pub use actions::{CellWrite, EffectExpectation, PlannedAction};
@@ -20,6 +21,9 @@ pub use canonical::{
     StepResult,
 };
 pub use producer::{DoneVerdict, NextActionHint, PlanProducer};
+pub use receipt::{
+    DispatchRoute, ExecutionReceipt, ObservedEffect, ObservedKind, ObservedStatus, ReceiptStatus,
+};
 pub use view::{
     AdapterActionRef, AdapterFactRef, AnomalyRef, Blocker, CapabilityRef, EventRef, EvidenceRef,
     KnowledgeRef, MemoryRef, OmittedCounts, PlanningBudget, PlanningElement, PlanningElementState,

--- a/cel/cel-contracts/src/receipt.rs
+++ b/cel/cel-contracts/src/receipt.rs
@@ -1,0 +1,236 @@
+//! Execution receipt — the canonical, core-emitted record of one dispatched
+//! action: `intent → dispatch route → observed effect → evidence`.
+//!
+//! This is the spine of CEL's trust loop. The cortex dispatch path builds an
+//! [`ExecutionReceipt`] for every canonical action it executes; surfaces
+//! (MCP / CLI / IPC / N-API) propagate it unflattened; the run timeline
+//! appends it; the next brief + memory consume it.
+//!
+//! Before this type, the only "receipt" with route/verification detail was the
+//! MCP `ActionReceipt`, *reconstructed at the surface* from a static switch on
+//! the action kind — so it mislabels e.g. a DOM `click` routed via CDP as
+//! `native_input`. The point of this contract is that the route and the
+//! observed-effect verdict are recorded by the code that actually did the work.
+//!
+//! **Contracts policy:** types + serde only. Id / timestamp generation is a
+//! runtime concern and lives at the emission site (cortex), not here.
+
+use crate::actions::EffectExpectation;
+use crate::view::EvidenceRef;
+use serde::{Deserialize, Serialize};
+
+/// The route the runtime *actually* took to dispatch an action — observed
+/// truth, not a guess from the action kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "route", rename_all = "snake_case")]
+pub enum DispatchRoute {
+    /// Chrome DevTools Protocol (browser DOM).
+    Cdp,
+    /// macOS Accessibility action.
+    Accessibility,
+    /// Synthesized native input (CGEvent key / mouse).
+    NativeInput,
+    /// A registered adapter's typed action.
+    Adapter { name: String, op: String },
+    /// App focus / lifecycle (activate / launch / quit / focus lock).
+    Focus,
+    /// Not yet classified.
+    Other { detail: String },
+}
+
+/// Whether the post-dispatch effect was confirmed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedStatus {
+    /// The expected effect was observed.
+    Observed,
+    /// An effect was expected but did not materialise before timeout.
+    TimedOut,
+    /// No effect verification was requested for this action.
+    NotChecked,
+    /// The observed state contradicted the expectation.
+    Contradicted,
+}
+
+/// How the effect was (or would be) verified. Generalised beyond the browser
+/// [`EffectExpectation`] so native / adapter routes fit the same model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ObservedKind {
+    /// Browser DOM predicate (CDP `wait_for_effect`).
+    SelectorEffect { expectation: EffectExpectation },
+    /// An adapter's declared readback action.
+    AdapterReadback { action: String },
+    /// A native accessibility re-read.
+    AxReread,
+    /// No verification mechanism applies.
+    None,
+}
+
+/// The post-dispatch observation: did the expected effect happen?
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedEffect {
+    pub status: ObservedStatus,
+    pub kind: ObservedKind,
+    /// Human-readable detail (what was observed / why it timed out).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl ObservedEffect {
+    /// No verification was requested for this action.
+    pub fn not_checked() -> Self {
+        Self {
+            status: ObservedStatus::NotChecked,
+            kind: ObservedKind::None,
+            detail: None,
+        }
+    }
+
+    /// A browser [`EffectExpectation`] was confirmed.
+    pub fn selector_observed(expectation: EffectExpectation) -> Self {
+        Self {
+            status: ObservedStatus::Observed,
+            kind: ObservedKind::SelectorEffect { expectation },
+            detail: None,
+        }
+    }
+
+    /// A browser [`EffectExpectation`] timed out; `detail` names what we saw
+    /// instead (the diagnostic `wait_for_effect` produced).
+    pub fn selector_timed_out(expectation: EffectExpectation, detail: impl Into<String>) -> Self {
+        Self {
+            status: ObservedStatus::TimedOut,
+            kind: ObservedKind::SelectorEffect { expectation },
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+/// Terminal status of a dispatched action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptStatus {
+    Ok,
+    Failed,
+    Vetoed,
+    Denied,
+    TimedOut,
+}
+
+/// Canonical, core-emitted record of one dispatched action.
+///
+/// One receipt per canonical action the cortex executes. Carries the intent
+/// (action kind + target), the ACTUAL dispatch route, the observed effect,
+/// evidence references, timing, and terminal status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionReceipt {
+    /// Process-unique id, assigned at the emission site.
+    pub receipt_id: String,
+    /// Run / session scope, when the caller or session provides one. `None`
+    /// until run-scoping lands (see plan Phase 1 / open decision #1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    /// Per-request trace id (reuses the IPC `trace_id` when present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Action kind, e.g. `"click"`, `"set_value"`, `"type"`.
+    pub action_kind: String,
+    /// Target identifier (element id / app / url) when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// The route the runtime actually took.
+    pub route: DispatchRoute,
+    /// The post-dispatch observation.
+    pub observed_effect: ObservedEffect,
+    /// Post-execution evidence references (observations / readbacks). Empty in
+    /// the first slice; populated by reference in a later phase.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<EvidenceRef>,
+    pub requested_at_ms: u64,
+    pub completed_at_ms: u64,
+    pub duration_ms: u64,
+    pub status: ReceiptStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::EffectExpectation;
+
+    fn sample() -> ExecutionReceipt {
+        ExecutionReceipt {
+            receipt_id: "rcpt_1".into(),
+            run_id: None,
+            trace_id: Some("trace-abc".into()),
+            action_kind: "click".into(),
+            target: Some("dom:button:submit".into()),
+            route: DispatchRoute::Cdp,
+            observed_effect: ObservedEffect::selector_observed(
+                EffectExpectation::SelectorAppears {
+                    selector: ".success".into(),
+                    timeout_ms: 2_000,
+                },
+            ),
+            evidence: Vec::new(),
+            requested_at_ms: 100,
+            completed_at_ms: 250,
+            duration_ms: 150,
+            status: ReceiptStatus::Ok,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn execution_receipt_round_trips() {
+        let r = sample();
+        let json = serde_json::to_string(&r).unwrap();
+        let back: ExecutionReceipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, back);
+        assert_eq!(back.route, DispatchRoute::Cdp);
+        assert_eq!(back.observed_effect.status, ObservedStatus::Observed);
+        assert_eq!(back.duration_ms, 150);
+    }
+
+    #[test]
+    fn empty_optionals_are_omitted_from_json() {
+        // run_id / error / evidence default away so the wire stays compact and
+        // older readers that never saw them keep working.
+        let json = serde_json::to_string(&sample()).unwrap();
+        assert!(!json.contains("run_id"));
+        assert!(!json.contains("\"error\""));
+        assert!(!json.contains("evidence"));
+        assert!(json.contains("trace-abc"));
+    }
+
+    #[test]
+    fn not_checked_effect_defaults() {
+        let e = ObservedEffect::not_checked();
+        assert_eq!(e.status, ObservedStatus::NotChecked);
+        assert!(matches!(e.kind, ObservedKind::None));
+    }
+
+    #[test]
+    fn timed_out_effect_carries_detail() {
+        let e = ObservedEffect::selector_timed_out(
+            EffectExpectation::DomChanged { timeout_ms: 2_000 },
+            "no DOM change observed",
+        );
+        assert_eq!(e.status, ObservedStatus::TimedOut);
+        assert_eq!(e.detail.as_deref(), Some("no DOM change observed"));
+    }
+
+    #[test]
+    fn adapter_route_serializes_with_fields() {
+        let route = DispatchRoute::Adapter {
+            name: "numbers".into(),
+            op: "write_cells".into(),
+        };
+        let json = serde_json::to_string(&route).unwrap();
+        assert!(json.contains("\"route\":\"adapter\""));
+        let back: DispatchRoute = serde_json::from_str(&json).unwrap();
+        assert_eq!(route, back);
+    }
+}

--- a/cel/cel-contracts/src/view.rs
+++ b/cel/cel-contracts/src/view.rs
@@ -353,7 +353,7 @@ pub struct EventRef {
 ///
 /// Lets a planner trace a memory or fact back to its source record without
 /// inflating the view itself.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EvidenceRef {
     /// Where this evidence came from: "memory", "knowledge", "transcript",
     /// "adapter_fact".

--- a/cel/cel-cortex/src/cortex.rs
+++ b/cel/cel-cortex/src/cortex.rs
@@ -47,6 +47,8 @@ mod cdp;
 mod dispatch;
 mod focus;
 mod numbers;
+mod receipt;
+pub use receipt::{clear_run_id, current_run_id, set_run_id};
 mod targets;
 #[cfg(test)]
 mod tests;

--- a/cel/cel-cortex/src/cortex/cdp.rs
+++ b/cel/cel-cortex/src/cortex/cdp.rs
@@ -6,8 +6,12 @@
 //! set-value JS builders, extraction expressions, and the injected JS constants
 //! (overlay dismissal, DOM snapshot, `<select>` patch).
 
-use super::dispatch::{action_dom_target, action_expect_after, wait_for_effect};
+use super::dispatch::{action_dom_target, action_expect_after, action_type_str, wait_for_effect};
+use super::receipt::{attach_receipt, current_run_id, new_receipt_id, now_ms, record_receipt};
 use super::*;
+use cel_contracts::{
+    DispatchRoute, ExecutionReceipt, ObservedEffect, ObservedStatus, ReceiptStatus,
+};
 
 /// Detect whether a selector-string entry is a raw JS expression
 /// (common prefixes the LLM uses) vs a bare CSS selector, and wrap
@@ -200,6 +204,10 @@ pub(crate) async fn try_cdp_dispatch(
         _ => return Ok(None),
     };
 
+    // Stamp the receipt clock here so timing covers the full CDP handling
+    // window (pre-dispatch snapshot + dispatch + effect wait).
+    let requested_at_ms = now_ms();
+
     // Capture a "before" page snapshot when `expect_after` is the
     // diff-based DomChanged variant. Has to happen BEFORE dispatch
     // because dispatch will mutate the very state we're comparing
@@ -275,17 +283,51 @@ pub(crate) async fn try_cdp_dispatch(
     // planner sees that immediately in next-turn history and can
     // retry / pivot without going through verify_done's screenshot
     // grader.
-    if !dispatch_result.success {
-        return Ok(Some(dispatch_result));
-    }
-    if let Some(expectation) = action_expect_after(action) {
+    let (result, observed) = if !dispatch_result.success {
+        // Dispatch itself failed — no effect verification was attempted.
+        (dispatch_result, ObservedEffect::not_checked())
+    } else if let Some(expectation) = action_expect_after(action) {
         match wait_for_effect(client, expectation, before_snapshot.as_deref()).await {
-            Ok(()) => Ok(Some(dispatch_result)),
-            Err(reason) => Ok(Some(crate::adapter::ActionResult::fail(reason))),
+            Ok(()) => (
+                dispatch_result,
+                ObservedEffect::selector_observed(expectation.clone()),
+            ),
+            Err(reason) => (
+                crate::adapter::ActionResult::fail(reason.clone()),
+                ObservedEffect::selector_timed_out(expectation.clone(), reason),
+            ),
         }
     } else {
-        Ok(Some(dispatch_result))
-    }
+        (dispatch_result, ObservedEffect::not_checked())
+    };
+
+    // Build the canonical execution receipt for this CDP-routed action. Read
+    // the Copy `status` before moving `observed` into the receipt.
+    let status = if result.success {
+        ReceiptStatus::Ok
+    } else if observed.status == ObservedStatus::TimedOut {
+        ReceiptStatus::TimedOut
+    } else {
+        ReceiptStatus::Failed
+    };
+    let completed_at_ms = now_ms();
+    let receipt = ExecutionReceipt {
+        receipt_id: new_receipt_id(),
+        run_id: current_run_id(),
+        trace_id: None,
+        action_kind: action_type_str(action).to_string(),
+        target: Some(target.to_string()),
+        route: DispatchRoute::Cdp,
+        observed_effect: observed,
+        evidence: Vec::new(),
+        requested_at_ms,
+        completed_at_ms,
+        duration_ms: completed_at_ms.saturating_sub(requested_at_ms),
+        status,
+        error: result.error.clone(),
+    };
+    record_receipt(&receipt);
+    Ok(Some(attach_receipt(result, receipt)))
 }
 
 pub(crate) fn check_cdp_ok(

--- a/cel/cel-cortex/src/cortex/dispatch.rs
+++ b/cel/cel-cortex/src/cortex/dispatch.rs
@@ -252,7 +252,7 @@ fn action_requires_native_input(action: &PlannedAction) -> bool {
     }
 }
 
-fn action_type_str(action: &PlannedAction) -> &str {
+pub(crate) fn action_type_str(action: &PlannedAction) -> &str {
     match action {
         PlannedAction::Click { .. } => "click",
         PlannedAction::Type { .. } => "type",
@@ -602,7 +602,39 @@ impl Cortex {
     ///
     /// This is the first migration slice: native/non-browser actions are owned
     /// by Rust. Adapter-dispatched execution can be layered in afterward.
+    /// Public dispatch entry. Runs the action, then stamps a canonical
+    /// [`cel_contracts::ExecutionReceipt`] onto the result when one isn't
+    /// already present: the CDP path (`try_cdp_dispatch`) stamps its own;
+    /// native / AX / adapter / focus dispatches get theirs here. Control and
+    /// data actions (Wait, Done, Extract, Batch, …) are not device dispatches
+    /// and carry no receipt. Additive: the receipt rides in `ActionResult.data`
+    /// under `_cel_receipt` (see `super::receipt`).
     pub async fn execute(
+        &self,
+        action: &PlannedAction,
+        context: &ScreenContext,
+    ) -> Result<crate::adapter::ActionResult, CortexError> {
+        let requested_at_ms = super::receipt::now_ms();
+        let result = self.execute_inner(action, context).await?;
+        if super::receipt::has_receipt(&result) {
+            return Ok(result);
+        }
+        let Some(route) = super::receipt::native_route_for(action) else {
+            return Ok(result);
+        };
+        let completed_at_ms = super::receipt::now_ms();
+        let receipt = super::receipt::build_native_receipt(
+            action,
+            route,
+            requested_at_ms,
+            completed_at_ms,
+            &result,
+        );
+        super::receipt::record_receipt(&receipt);
+        Ok(super::receipt::attach_receipt(result, receipt))
+    }
+
+    async fn execute_inner(
         &self,
         action: &PlannedAction,
         context: &ScreenContext,

--- a/cel/cel-cortex/src/cortex/receipt.rs
+++ b/cel/cel-cortex/src/cortex/receipt.rs
@@ -1,0 +1,223 @@
+//! Shared execution-receipt assembly for the cortex dispatch paths.
+//!
+//! PR1 emitted receipts from the CDP path (`cdp.rs`); this module hoists the
+//! timing / id / transport helpers so the native `execute` path reuses them,
+//! and adds route classification for non-CDP dispatch. See
+//! `~/.claude/plans/cellar-receipt-timeline.md` (Receipt-Backed Run Timeline).
+
+use super::dispatch::{action_dom_target, action_type_str};
+use cel_contracts::{
+    DispatchRoute, ExecutionReceipt, ObservedEffect, PlannedAction, ReceiptStatus,
+};
+
+/// Reserved `ActionResult.data` key the receipt is transported under (PR1
+/// rides in `data` rather than a first-class field — see `attach_receipt`).
+pub(crate) const RECEIPT_DATA_KEY: &str = "_cel_receipt";
+
+/// Process-global "current run" id. Set by the run owner (e.g. an MCP
+/// `cel_perceive` session) so the receipts emitted during a run group under one
+/// id in the timeline. `None` for one-off actions outside a run.
+///
+/// v1 assumes a single active run per process — the warm Cortex is
+/// one-per-process and the MCP perceive session is the run scope. A per-action
+/// `run_id` override and a finer `trace_id` are follow-ups (plan Open Decision #1).
+static CURRENT_RUN_ID: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Set (or replace) the current run id. Pass `None` to clear.
+pub fn set_run_id(run_id: Option<String>) {
+    if let Ok(mut guard) = CURRENT_RUN_ID.lock() {
+        *guard = run_id;
+    }
+}
+
+/// Clear the current run id (run ended).
+pub fn clear_run_id() {
+    set_run_id(None);
+}
+
+/// The current run id, stamped onto every receipt the cortex emits.
+pub fn current_run_id() -> Option<String> {
+    CURRENT_RUN_ID.lock().ok().and_then(|g| g.clone())
+}
+
+/// Milliseconds since the Unix epoch (receipt timing).
+pub(crate) fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Process-unique receipt id: monotonic counter + wall-clock ms. Good enough
+/// for in-process correlation until run/trace scoping lands (plan Phase 1).
+pub(crate) fn new_receipt_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("rcpt_{}_{}", now_ms(), n)
+}
+
+/// Whether a result already carries a receipt — the CDP path stamps its own,
+/// so the native `execute` wrapper must not double-attach.
+pub(crate) fn has_receipt(result: &crate::adapter::ActionResult) -> bool {
+    result
+        .data
+        .as_ref()
+        .and_then(|d| d.as_object())
+        .is_some_and(|m| m.contains_key(RECEIPT_DATA_KEY))
+}
+
+/// Transport the typed [`ExecutionReceipt`] on the result's `data` under the
+/// reserved key.
+///
+/// PR1 rides in `data` (additive, non-breaking) rather than a first-class
+/// `ActionResult.receipt` field: adding that field would force a mechanical
+/// edit across ~30 struct-literal construction sites in every adapter crate.
+/// The receipt TYPE is canonical (`cel-contracts`); only its transport is via
+/// `data` for now. Promoting to a field is a deliberate follow-up.
+pub(crate) fn attach_receipt(
+    mut result: crate::adapter::ActionResult,
+    receipt: ExecutionReceipt,
+) -> crate::adapter::ActionResult {
+    let Ok(rv) = serde_json::to_value(&receipt) else {
+        return result;
+    };
+    let mut map = match result.data.take() {
+        Some(serde_json::Value::Object(map)) => map,
+        Some(other) => {
+            // Preserve any prior non-object payload under a sibling key.
+            let mut m = serde_json::Map::new();
+            m.insert("result".to_string(), other);
+            m
+        }
+        None => serde_json::Map::new(),
+    };
+    map.insert(RECEIPT_DATA_KEY.to_string(), rv);
+    result.data = Some(serde_json::Value::Object(map));
+    result
+}
+
+/// Classify the dispatch route for a non-CDP action.
+///
+/// Runs AFTER the CDP fall-through, so a `click` reaching here really is native
+/// input (a `dom:*` click would have been CDP-handled and already carry its own
+/// receipt). Returns `None` for control / data / wrapper actions that are not a
+/// device dispatch (Wait, Done, Fail, Extract, Batch, Act, Custom,
+/// NotebookWrites) — those carry no receipt.
+pub(crate) fn native_route_for(action: &PlannedAction) -> Option<DispatchRoute> {
+    match action {
+        PlannedAction::Click { .. }
+        | PlannedAction::Type { .. }
+        | PlannedAction::Key { .. }
+        | PlannedAction::KeyCombo { .. }
+        | PlannedAction::Scroll { .. }
+        | PlannedAction::Drag { .. } => Some(DispatchRoute::NativeInput),
+        PlannedAction::AxAction { .. }
+        | PlannedAction::SetValue { .. }
+        | PlannedAction::Select { .. }
+        | PlannedAction::Window { .. }
+        | PlannedAction::Dialog { .. }
+        | PlannedAction::Dock { .. }
+        | PlannedAction::MenuExtra { .. } => Some(DispatchRoute::Accessibility),
+        PlannedAction::ActivateApp { .. }
+        | PlannedAction::LaunchApp { .. }
+        | PlannedAction::QuitApp { .. } => Some(DispatchRoute::Focus),
+        PlannedAction::WriteCells { .. } | PlannedAction::ReadCells { .. } => {
+            Some(DispatchRoute::Adapter {
+                name: String::new(),
+                op: action_type_str(action).to_string(),
+            })
+        }
+        // CDP-backed but not a `dom:*` target (so it fell through
+        // `try_cdp_dispatch` and is dispatched on the native path).
+        PlannedAction::CdpEval { .. } | PlannedAction::Navigate { .. } => Some(DispatchRoute::Cdp),
+        // Control / data / wrapper actions — not a device dispatch.
+        PlannedAction::Wait { .. }
+        | PlannedAction::Done { .. }
+        | PlannedAction::Fail { .. }
+        | PlannedAction::Extract { .. }
+        | PlannedAction::ExtractWithFallback { .. }
+        | PlannedAction::NotebookWrites { .. }
+        | PlannedAction::Custom { .. }
+        | PlannedAction::Act { .. }
+        | PlannedAction::Batch { .. } => None,
+    }
+}
+
+/// Build a receipt for a native-path dispatch. Observed-effect verification on
+/// the native path (adapter readback / AX re-read) is a later phase, so this
+/// records `NotChecked`.
+pub(crate) fn build_native_receipt(
+    action: &PlannedAction,
+    route: DispatchRoute,
+    requested_at_ms: u64,
+    completed_at_ms: u64,
+    result: &crate::adapter::ActionResult,
+) -> ExecutionReceipt {
+    ExecutionReceipt {
+        receipt_id: new_receipt_id(),
+        run_id: current_run_id(),
+        trace_id: None,
+        action_kind: action_type_str(action).to_string(),
+        target: action_dom_target(action).map(str::to_string),
+        route,
+        observed_effect: ObservedEffect::not_checked(),
+        evidence: Vec::new(),
+        requested_at_ms,
+        completed_at_ms,
+        duration_ms: completed_at_ms.saturating_sub(requested_at_ms),
+        status: if result.success {
+            ReceiptStatus::Ok
+        } else {
+            ReceiptStatus::Failed
+        },
+        error: result.error.clone(),
+    }
+}
+
+/// Append a run-scoped receipt to `~/.cellar/runs/<run_id>.jsonl` so
+/// `cellar timeline <run_id>` can render the run. Best-effort: receipts with no
+/// run id are skipped, and any I/O error is swallowed (persistence must never
+/// break dispatch). Mirrors the `~/.cellar/observations/` pattern.
+pub(crate) fn record_receipt(receipt: &ExecutionReceipt) {
+    let Some(run_id) = receipt.run_id.as_deref() else {
+        return;
+    };
+    let Some(dir) = runs_dir() else {
+        return;
+    };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join(format!("{}.jsonl", sanitize_run_id(run_id)));
+    let Ok(line) = serde_json::to_string(receipt) else {
+        return;
+    };
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+fn runs_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".cellar").join("runs"))
+}
+
+/// Restrict a run id to filename-safe characters (mirrored by the CLI reader).
+fn sanitize_run_id(run_id: &str) -> String {
+    run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/cel/cel-cortex/src/lib.rs
+++ b/cel/cel-cortex/src/lib.rs
@@ -71,7 +71,7 @@ pub use adapter::{
     AdapterDriver, AdapterError, AdapterManifest, AdapterState, ContextDeclaration,
     RegisteredAdapter,
 };
-pub use cortex::{Cortex, CortexError, TargetValidation};
+pub use cortex::{clear_run_id, current_run_id, set_run_id, Cortex, CortexError, TargetValidation};
 pub use manager::CortexManager;
 pub use memory::{Memory, MemoryEntry, MemoryError, MemoryLenses};
 pub use model::{

--- a/cel/cel-napi/Cargo.toml
+++ b/cel/cel-napi/Cargo.toml
@@ -35,6 +35,7 @@ adapter-common = { workspace = true }
 # are wired through the single shared `cel-adapters` registry, not registered
 # here. See `src/cortex.rs`.
 cel-adapters = { workspace = true }
+cel-boot = { workspace = true }
 cel-goal-runner = { workspace = true }
 cellar-worker = { path = "../../cellar-worker" }
 tokio = { workspace = true }

--- a/cel/cel-napi/src/cortex.rs
+++ b/cel/cel-napi/src/cortex.rs
@@ -89,6 +89,20 @@ pub(crate) fn get_cortex_handle() -> Option<Arc<cel_cortex::Cortex>> {
     state.cortex.clone()
 }
 
+/// Set the cortex's current run id so receipts emitted during the run group
+/// under it in the timeline. Pass `null` to clear. The MCP perceive session
+/// uses this to scope a run.
+#[napi]
+pub fn cortex_set_run_id(run_id: Option<String>) {
+    cel_cortex::set_run_id(run_id);
+}
+
+/// Clear the cortex's current run id (run ended).
+#[napi]
+pub fn cortex_clear_run_id() {
+    cel_cortex::clear_run_id();
+}
+
 /// Boot the Rust Cortex — starts the always-on 200ms perception tick loop.
 #[napi]
 pub fn boot_cortex() -> napi::Result<()> {
@@ -108,66 +122,21 @@ pub fn boot_cortex() -> napi::Result<()> {
         return Err(napi::Error::from_reason("Cortex already running"));
     }
 
-    // One-shot AX-trust check. Without this permission, every cortex tick
-    // emits the same `Accessibility tree unavailable` WARN — easy to drown
-    // in. Surfacing it once here, with the fix path, makes the failure
-    // diagnosable without grepping logs.
-    #[cfg(target_os = "macos")]
-    if !cel_accessibility::ax_is_process_trusted() {
-        tracing::warn!(
-            target: "cel_napi::cortex",
-            "macOS Accessibility permission missing for the host process. \
-             AX-element observations will be empty until granted. \
-             Fix: System Settings → Privacy & Security → Accessibility, \
-             then enable the host (Terminal / Claude Desktop / Claude Code / \
-             Cursor / etc.) and restart it. \
-             CDP browser perception and adapter-driven app truth (Numbers, \
-             Excel, …) work without AX trust."
-        );
-    }
-
-    let a11y = cel_accessibility::create_tree();
-    let display = cel_display::create_capture();
-    let network = cel_network::create_monitor();
-    let signals = cel_signals::create_signal_bus();
-    let mut merger =
-        cel_context::ContextMerger::with_all(a11y, display, network).with_signals(signals);
-    if let Ok(vision) = cel_vision::create_provider_from_env() {
-        merger = merger.with_vision(vision).with_runtime(handle.clone());
-    }
-    let mut stream_status = merger.stream_status();
-    let observer = cel_accessibility::create_tree();
-
-    // MCP server runs on the user's machine when they explicitly invoke it
-    // — opt into native input. Browser actions still route through CDP
-    // automatically when a CDP target is bound; this is the fallback for
-    // desktop apps.
-    let mut cortex = cel_cortex::Cortex::new("mcp-default".into()).with_native_input_unsafe();
-    if let Some((capture, config)) = default_audio_capture() {
-        cortex = cortex.with_audio(capture, config);
-        stream_status.audio_capture = true;
-    }
-
-    // Wire the default adapter set through the single shared registry:
-    // in-process Numbers / Notes (macOS) + the native Browser adapter, plus
-    // the process-driver discover scan for Mail / Calendar / Reminders /
-    // Messages and any user-installed adapter under `adapters/` or
-    // `~/.cellar/adapters/`. `None` = ambient CDP discovery: the browser
-    // adapter self-activates when `cel_cdp::connect_to_focused_app()` finds a
-    // target. Adding a new in-process adapter is a one-line change in
-    // `cel-adapters`, inherited by every host — no edits here.
-    cel_adapters::register_default_adapters(&mut cortex, None);
-
-    handle
-        .block_on(async { cortex.boot(merger, observer).await })
-        .map_err(|e| napi::Error::from_reason(format!("Cortex boot failed: {}", e)))?;
-
-    let cortex = Arc::new(cortex);
-    handle.block_on(async {
-        let model_handle = cortex.model();
-        let mut model = model_handle.write().await;
-        model.stream_status = stream_status;
-    });
+    // Boot the Cortex via the shared helper (cel-boot) — the single boot path
+    // shared with cel-eval and the daemon. MCP runs on the user's machine on
+    // explicit invocation, so native input is on; ambient CDP discovery binds
+    // the browser adapter when a target appears; vision + audio are wired when
+    // available. The helper does the AX-trust check + stream_status itself.
+    let cortex = handle
+        .block_on(cel_boot::boot_default_cortex(cel_boot::BootOpts {
+            id: "mcp-default".into(),
+            native_input: true,
+            cdp_client: None,
+            vision: true,
+            runtime: Some(handle.clone()),
+            audio: default_audio_capture(),
+        }))
+        .map_err(napi::Error::from_reason)?;
     state.model_handle = Some(cortex.model());
     state.cortex = Some(cortex);
     Ok(())

--- a/cellar-cli/src/main.rs
+++ b/cellar-cli/src/main.rs
@@ -28,6 +28,7 @@ mod doctor;
 mod eval;
 mod guide;
 mod mcp;
+mod timeline;
 mod workflow;
 
 use std::path::{Path, PathBuf};
@@ -96,6 +97,19 @@ enum Command {
     /// List CEL's surfaces: CLI verbs, native gateway actions, and MCP tools.
     /// No daemon needed (see `cellar capabilities` for daemon-advertised caps).
     Tools,
+
+    /// Render the execution-receipt timeline for a run — intent → dispatch
+    /// route → observed effect → evidence for each step. Reads
+    /// `~/.cellar/runs/<run_id>.jsonl` (written by the cortex during a
+    /// `cel_perceive` session). No daemon needed.
+    ///
+    ///   cellar timeline perceive-1718territory   # human table
+    ///   cellar timeline <run_id> --json          # raw receipts
+    Timeline {
+        /// The run id — a `cel_perceive` session's `workflow_id`, or the
+        /// auto-generated `perceive-<startTime>`.
+        run_id: String,
+    },
 
     /// Generate a shell-completion script (bash, zsh, fish, elvish,
     /// powershell) for the `cellar` CLI. Prints to stdout — no daemon needed.
@@ -803,6 +817,11 @@ async fn main() -> Result<()> {
         return guide::tools(json);
     }
 
+    // `timeline` reads a run's receipt log from disk — no daemon needed.
+    if let Command::Timeline { run_id } = &cli.cmd {
+        return timeline::show(run_id, json);
+    }
+
     // `run --dry-run` validates a workflow script and prints the plan offline —
     // no daemon, no actions dispatched. (A live `run` connects, below.)
     if let Command::Run {
@@ -986,6 +1005,7 @@ async fn main() -> Result<()> {
         Command::Completions { .. } => unreachable!("completions is handled above"),
         Command::Learn => unreachable!("learn is handled above"),
         Command::Tools => unreachable!("tools is handled above"),
+        Command::Timeline { .. } => unreachable!("timeline is handled above"),
         // `run --dry-run` is handled above (offline); a live `run` dispatches
         // each step through the gateway here.
         Command::Run {

--- a/cellar-cli/src/timeline.rs
+++ b/cellar-cli/src/timeline.rs
@@ -1,0 +1,95 @@
+//! `cellar timeline <run_id>` — render the execution-receipt timeline for a run.
+//!
+//! Receipts are appended to `~/.cellar/runs/<run_id>.jsonl` by the cortex as it
+//! dispatches actions during a run (a `cel_perceive` session scopes the run id).
+//! This command reads that file directly — no daemon needed — and renders the
+//! `intent → dispatch route → observed effect → evidence` spine for each step.
+
+use anyhow::Result;
+use std::io::BufRead;
+
+/// Read and render the timeline for `run_id`. With `json`, prints the raw
+/// receipt array instead of the human table.
+pub fn show(run_id: &str, json: bool) -> Result<()> {
+    let path = run_file(run_id);
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(_) => {
+            if json {
+                println!("[]");
+            } else {
+                println!(
+                    "No timeline for run \"{run_id}\" (looked in {}).",
+                    path.display()
+                );
+                println!("Runs are recorded while a `cel_perceive` session is active.");
+            }
+            return Ok(());
+        }
+    };
+
+    let receipts: Vec<serde_json::Value> = std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(&l).ok())
+        .collect();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&receipts)?);
+        return Ok(());
+    }
+
+    println!("Run {run_id} — {} receipt(s)", receipts.len());
+    for r in &receipts {
+        let status = field(r, "status");
+        let kind = field(r, "action_kind");
+        let route = r
+            .get("route")
+            .and_then(|v| v.get("route"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+        let effect = r
+            .get("observed_effect")
+            .and_then(|v| v.get("status"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let dur = r.get("duration_ms").and_then(|v| v.as_u64()).unwrap_or(0);
+        let target = r.get("target").and_then(|v| v.as_str()).unwrap_or("");
+        let id = r.get("receipt_id").and_then(|v| v.as_str()).unwrap_or("");
+        println!(
+            "  {status:<8} {kind:<12} route={route:<13} effect={effect:<12} {dur:>5}ms  {target}  [{id}]"
+        );
+    }
+    Ok(())
+}
+
+fn field<'a>(v: &'a serde_json::Value, key: &str) -> &'a str {
+    v.get(key).and_then(|x| x.as_str()).unwrap_or("?")
+}
+
+fn run_file(run_id: &str) -> std::path::PathBuf {
+    runs_dir().join(format!("{}.jsonl", sanitize_run_id(run_id)))
+}
+
+fn runs_dir() -> std::path::PathBuf {
+    std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_default()
+        .join(".cellar")
+        .join("runs")
+}
+
+/// Must match the cortex writer's sanitization (`cel-cortex` `receipt.rs`).
+fn sanitize_run_id(run_id: &str) -> String {
+    run_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/cellar-ipc/src/error.rs
+++ b/cellar-ipc/src/error.rs
@@ -76,6 +76,10 @@ pub enum IpcError {
     /// `-32013` — RPC requires Tauri client (some RPCs may not be CLI-safe).
     #[error("Tauri not attached")]
     TauriNotAttached,
+    /// `-32014` — the daemon is not hosting a live Cortex (boot it with
+    /// `CELLAR_DAEMON_CORTEX=1` to enable the `cortex.*` methods).
+    #[error("cortex not hosted by this daemon: {0}")]
+    CortexUnavailable(&'static str),
 
     // ───── Subsystem stubs ─────
     /// `-32099` — method is recognised but its backing subsystem isn't wired
@@ -128,6 +132,7 @@ impl IpcError {
             IpcError::LlmProviderError(_) => -32011,
             IpcError::ExternalMcpDisabled => -32012,
             IpcError::TauriNotAttached => -32013,
+            IpcError::CortexUnavailable(_) => -32014,
             IpcError::NotImplemented(_) => -32099,
             // Transport errors don't have JSON-RPC codes; they should not be
             // serialized as errors over the wire (they happen *to* the wire).
@@ -171,6 +176,7 @@ mod tests {
         assert_eq!(IpcError::Parse(String::new()).code(), -32700);
         assert_eq!(IpcError::ShuttingDown.code(), -32000);
         assert_eq!(IpcError::RuleNotFound("x".into()).code(), -32004);
+        assert_eq!(IpcError::CortexUnavailable("x").code(), -32014);
         assert_eq!(IpcError::NotImplemented("x").code(), -32099);
     }
 

--- a/cellar-ipc/src/handler.rs
+++ b/cellar-ipc/src/handler.rs
@@ -17,8 +17,8 @@ use tokio::sync::{mpsc, Notify};
 
 use crate::error::{IpcError, IpcResult};
 use crate::params::{
-    agent, agent_actions, confirmation, events, fires, gateway, memory, rules, settings, system,
-    watchlists, webhooks,
+    agent, agent_actions, confirmation, cortex, events, fires, gateway, memory, rules, settings,
+    system, watchlists, webhooks,
 };
 use crate::results;
 use crate::results::{OkResult, SubscribeResult};
@@ -467,6 +467,52 @@ pub trait Handler: Send + Sync + 'static {
         params: gateway::GatewayInterceptParams,
     ) -> IpcResult<results::gateway::GatewayInterceptResult> {
         Err(IpcError::NotImplemented("gateway.intercept"))
+    }
+
+    // ───── cortex.* ─────
+    //
+    // Drive the daemon-hosted Cortex (Phase B of `cellar-daemon-cortex.md`).
+    // Daemons not hosting one return [`IpcError::CortexUnavailable`].
+
+    /// `cortex.see` — the current fused screen context from the hosted
+    /// Cortex (`cel-context` `ScreenContext` JSON).
+    #[method("cortex.see")]
+    async fn cortex_see(&self) -> IpcResult<results::cortex::CortexSeeResult> {
+        Err(IpcError::NotImplemented("cortex.see"))
+    }
+
+    /// `cortex.act` — execute one canonical action on the hosted Cortex.
+    /// The result mirrors the engine's `ActionResult`; the core-emitted
+    /// `ExecutionReceipt` rides on `data._cel_receipt`.
+    #[method("cortex.act")]
+    async fn cortex_act(
+        &self,
+        params: cortex::CortexActParams,
+    ) -> IpcResult<results::cortex::CortexActResult> {
+        Err(IpcError::NotImplemented("cortex.act"))
+    }
+
+    /// `cortex.perceive.start` — begin a run scope: execution receipts
+    /// emitted while active carry this `run_id` (Receipt-Backed Run
+    /// Timeline).
+    #[method("cortex.perceive.start")]
+    async fn cortex_perceive_start(
+        &self,
+        params: cortex::CortexPerceiveStartParams,
+    ) -> IpcResult<OkResult> {
+        Err(IpcError::NotImplemented("cortex.perceive.start"))
+    }
+
+    /// `cortex.perceive.read` — a snapshot of the Cortex mental model.
+    #[method("cortex.perceive.read")]
+    async fn cortex_perceive_read(&self) -> IpcResult<results::cortex::CortexPerceiveReadResult> {
+        Err(IpcError::NotImplemented("cortex.perceive.read"))
+    }
+
+    /// `cortex.perceive.stop` — end the run scope.
+    #[method("cortex.perceive.stop")]
+    async fn cortex_perceive_stop(&self) -> IpcResult<OkResult> {
+        Err(IpcError::NotImplemented("cortex.perceive.stop"))
     }
 
     // ───── agent.* ─────

--- a/cellar-ipc/src/params.rs
+++ b/cellar-ipc/src/params.rs
@@ -9,6 +9,7 @@
 pub mod agent;
 pub mod agent_actions;
 pub mod confirmation;
+pub mod cortex;
 pub mod daemon;
 pub mod events;
 pub mod fires;

--- a/cellar-ipc/src/params/cortex.rs
+++ b/cellar-ipc/src/params/cortex.rs
@@ -1,0 +1,28 @@
+//! Parameter types for the `cortex.*` RPC group.
+//!
+//! These methods drive the daemon-hosted Cortex (Phase B of
+//! `cellar-daemon-cortex.md`). The action payload is carried as untyped JSON
+//! so this protocol crate stays engine-agnostic: the wire shape is
+//! `cel-contracts::PlannedAction` (`tag = "type"`, snake_case), parsed by the
+//! daemon at the boundary.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Params for `cortex.act` — execute one canonical action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CortexActParams {
+    /// The canonical action as `cel-contracts::PlannedAction` JSON,
+    /// e.g. `{"type":"wait","ms":100}` or
+    /// `{"type":"set_value","target_id":"dom:input:email","value":"x"}`.
+    pub action: Value,
+}
+
+/// Params for `cortex.perceive.start` — begin a run scope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CortexPerceiveStartParams {
+    /// Run id stamped onto every execution receipt emitted while the run is
+    /// active (Receipt-Backed Run Timeline). Renders via
+    /// `cellar timeline <run_id>`.
+    pub run_id: String,
+}

--- a/cellar-ipc/src/results.rs
+++ b/cellar-ipc/src/results.rs
@@ -2,6 +2,7 @@
 
 pub mod agent;
 pub mod confirmation;
+pub mod cortex;
 pub mod daemon;
 pub mod gateway;
 pub mod memory;

--- a/cellar-ipc/src/results/cortex.rs
+++ b/cellar-ipc/src/results/cortex.rs
@@ -1,0 +1,40 @@
+//! Result types for the `cortex.*` RPC group.
+//!
+//! Payloads are untyped JSON so this protocol crate stays engine-agnostic;
+//! the wire shapes are owned by the engine crates (`cel-context`
+//! `ScreenContext`, `cel-adapter-sdk` `ActionResult`, the cortex mental
+//! model) and already round-trip through serde.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Result of `cortex.see` — the current fused screen context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CortexSeeResult {
+    /// `cel-context::ScreenContext` JSON (app, window, elements, …).
+    pub context: Value,
+}
+
+/// Result of `cortex.act` — mirrors the engine's `ActionResult`.
+///
+/// The canonical core-emitted `ExecutionReceipt` rides on
+/// `data._cel_receipt` (Receipt-Backed Run Timeline), exactly as it does on
+/// the in-process surfaces.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CortexActResult {
+    /// Whether the dispatch succeeded.
+    pub success: bool,
+    /// Failure reason when `success` is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Action payload; carries `_cel_receipt` when the cortex emitted one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// Result of `cortex.perceive.read` — a snapshot of the Cortex mental model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CortexPerceiveReadResult {
+    /// The cortex `MentalModel` JSON (current context, diffs, freshness, …).
+    pub model: Value,
+}

--- a/cellar-ipc/src/results/daemon.rs
+++ b/cellar-ipc/src/results/daemon.rs
@@ -30,6 +30,11 @@ pub struct DaemonStatusResult {
     /// cleanly; clients should treat the absence as "unknown".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<MemoryCorpusStats>,
+    /// Whether the daemon is currently hosting a live Cortex (perception +
+    /// execution). `false` on daemons that don't host one. Optional/default so
+    /// older daemons (and clients) deserialise cleanly.
+    #[serde(default)]
+    pub cortex_running: bool,
 }
 
 /// Rule count breakdown.

--- a/cellar-ipc/src/stub.rs
+++ b/cellar-ipc/src/stub.rs
@@ -115,6 +115,7 @@ impl Handler for StubHandler {
             memory_mb: 0.0,
             cpu_pct: 0.0,
             memory: None,
+            cortex_running: false,
         })
     }
 

--- a/docs/daemon-cortex.md
+++ b/docs/daemon-cortex.md
@@ -1,0 +1,75 @@
+# Daemon-hosted Cortex
+
+The daemon (`cel-cortex-daemon`) can host the **single** live Cortex —
+perception + execution — and every surface (the Tauri app, the CLI, and the
+MCP server) drives that one Cortex over IPC. This is the execution core of
+Cellar v1.
+
+## Why one Cortex
+
+A Cortex grabs the macOS Accessibility tree, a CDP client, and input/focus.
+Two live Cortexes in two processes (e.g. the napi/MCP one *and* an app/daemon
+one) would fight over those single, machine-global resources. So there is
+exactly **one** Cortex in a running system, and it lives in the always-on
+daemon — the process the app and CLI already talk to, and the one that owns the
+governance gateway (every actuation chokepoint).
+
+## Topology
+
+```
+  app  ─IPC─┐
+  CLI  ─IPC─┤→  daemon  ──►  Cortex (the one)  ──►  AX / CDP / input
+  MCP  ─IPC─┘     │            tick loop
+                  │            └─► ExecutionReceipt ─► ~/.cellar/runs + memory
+                  └─► gateway (governance) ─► receipts (governed actions)
+                        │
+                  agent_runtime ─► BriefBuilder + ReceiptSource + PerceptionSource
+```
+
+- The daemon boots the Cortex via the shared `cel-boot::boot_default_cortex`
+  helper — the same boot path `cel-napi` (standalone MCP) and `cel-eval`
+  (benchmarks) use.
+- IPC methods `cortex.see` / `cortex.act` / `cortex.perceive.*`
+  (`cellar-ipc` `Handler` trait) drive it.
+- The MCP server proxies `cel_act` / `cel_see` / `cel_perceive` to those IPC
+  methods when the daemon hosts a Cortex; otherwise it falls back to its own
+  in-process napi Cortex (standalone / benchmark use).
+
+## Environment flags
+
+| Variable | Default | Effect |
+|---|---|---|
+| `CELLAR_DAEMON_CORTEX` | off | When truthy (`1`/`true`), the daemon hosts a live Cortex at boot. Off → the daemon runs exactly as before (no AX/input grab, no perception tick). |
+| `CELLAR_DAEMON_NATIVE_INPUT` | off | When truthy, the daemon-hosted Cortex may dispatch native input (CGEvent mouse/keyboard/AX/app-activation). Off → perceive-only. Independent of `CELLAR_DAEMON_CORTEX`. |
+| `CELLAR_MCP_DAEMON` | on | Set to `0` to force the MCP server to use its own napi Cortex and never proxy to the daemon. |
+| `CELLAR_DAEMON_SOCK` | `~/.cellar/daemon.sock` | UDS path the daemon binds and the MCP client dials. |
+
+## The one-Cortex invariant (how it's enforced)
+
+The MCP server probes `daemon.status.cortex_running` on first use:
+
+- **`cortex_running == true`** → proxy cortex operations to the daemon and
+  **never boot the napi Cortex** (the two-Cortex guard, `mcp-server/src/tools`).
+  The probe result is sticky for the server's lifetime.
+- **otherwise** → boot/use the in-process napi Cortex as before.
+
+A few in-process-only MCP operations (`cel_perceive plan_view`,
+`cel_think run_goal`, anomaly consumption) return a typed error in daemon mode
+rather than booting a second Cortex; they move onto IPC / `agent.run` in a
+later phase.
+
+## Receipts & continuity
+
+Every governed dispatch through the gateway, and every canonical action through
+the Cortex, emits a core `ExecutionReceipt` (`cel-contracts`) scoped to a
+`run_id`, appended to `~/.cellar/runs/<run_id>.jsonl`. The daemon agent's
+per-turn brief surfaces the run's recent receipts (`ReceiptSource`) plus a live
+screen snapshot (`PerceptionSource`), closing the
+`intent → dispatch → observed effect → evidence → brief` loop. See
+`cellar-receipt-timeline.md`.
+
+## Benchmarks
+
+`cel-eval` and the `benchmarks/` harness keep using the in-process napi Cortex
+(via `cel-boot`) — they don't require a running daemon. Production (app + CLI +
+MCP together) uses the daemon-hosted Cortex.

--- a/mcp-server/src/helpers/daemon.ts
+++ b/mcp-server/src/helpers/daemon.ts
@@ -1,0 +1,198 @@
+/**
+ * Daemon IPC client — drives the daemon-hosted Cortex over the UDS socket.
+ *
+ * Phase C of `cellar-daemon-cortex.md`: when the running daemon hosts the
+ * single live Cortex (`CELLAR_DAEMON_CORTEX=1`, surfaced as
+ * `daemon.status.cortex_running`), the MCP server proxies cortex-backed
+ * operations (`cortex.see` / `cortex.act` / `cortex.perceive.*`) to it
+ * instead of booting its own napi Cortex — two Cortexes would fight over
+ * one AX tree and input focus. With no daemon (or `CELLAR_MCP_DAEMON=0`),
+ * everything falls back to the existing in-process napi path.
+ *
+ * Wire protocol: newline-delimited JSON-RPC 2.0 over
+ * `$CELLAR_DAEMON_SOCK` (default `~/.cellar/daemon.sock`) — the same
+ * framing `cellar-ipc` speaks.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CONNECT_TIMEOUT_MS = 500;
+const PROBE_CALL_TIMEOUT_MS = 2_000;
+const DEFAULT_CALL_TIMEOUT_MS = 15_000;
+/** `cortex.act` can legitimately take a while (navigate waits, effect polls). */
+export const ACT_CALL_TIMEOUT_MS = 120_000;
+/** How long a failed probe is cached before the daemon is re-probed. */
+const NEGATIVE_PROBE_TTL_MS = 5_000;
+
+function socketPath(): string {
+  return process.env.CELLAR_DAEMON_SOCK ?? join(homedir(), ".cellar", "daemon.sock");
+}
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+};
+
+/**
+ * Minimal persistent JSON-RPC 2.0 client over the daemon's UDS socket.
+ * One in-flight map keyed by request id; line-buffered reads; a dead socket
+ * rejects everything in flight and the next call reconnects.
+ */
+export class DaemonClient {
+  private socket: Socket | null = null;
+  private buffer = "";
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+
+  private async connect(): Promise<Socket> {
+    if (this.socket && !this.socket.destroyed) return this.socket;
+    const socket = await new Promise<Socket>((resolve, reject) => {
+      const s = createConnection(socketPath());
+      const onError = (err: Error) => {
+        s.destroy();
+        reject(err);
+      };
+      s.setTimeout(CONNECT_TIMEOUT_MS, () => onError(new Error("daemon connect timeout")));
+      s.once("error", onError);
+      s.once("connect", () => {
+        s.setTimeout(0);
+        s.removeListener("error", onError);
+        resolve(s);
+      });
+    });
+    socket.on("data", (chunk) => this.onData(chunk));
+    const fail = (why: string) => () => this.failAll(new Error(why));
+    socket.on("error", fail("daemon socket error"));
+    socket.on("close", fail("daemon socket closed"));
+    this.socket = socket;
+    return socket;
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let nl: number;
+    while ((nl = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      let msg: { id?: unknown; result?: unknown; error?: { code?: number; message?: string } };
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue; // not addressed to us / malformed — skip
+      }
+      if (typeof msg.id !== "number") continue; // stream notification — ignore
+      const pending = this.pending.get(msg.id);
+      if (!pending) continue;
+      this.pending.delete(msg.id);
+      clearTimeout(pending.timer);
+      if (msg.error) {
+        pending.reject(
+          new Error(`daemon rpc error ${msg.error.code ?? "?"}: ${msg.error.message ?? "unknown"}`),
+        );
+      } else {
+        pending.resolve(msg.result);
+      }
+    }
+  }
+
+  private failAll(err: Error): void {
+    this.socket?.destroy();
+    this.socket = null;
+    this.buffer = "";
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  async call<T>(method: string, params?: unknown, timeoutMs = DEFAULT_CALL_TIMEOUT_MS): Promise<T> {
+    const socket = await this.connect();
+    const id = this.nextId++;
+    const line = `${JSON.stringify({ jsonrpc: "2.0", id, method, ...(params !== undefined ? { params } : {}) })}\n`;
+    return await new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`daemon rpc timeout: ${method} after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
+      socket.write(line, (err) => {
+        if (err) {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          reject(err);
+        }
+      });
+    });
+  }
+}
+
+let stickyClient: DaemonClient | null = null;
+let lastNegativeProbeAt = 0;
+let probeInFlight: Promise<DaemonClient | null> | null = null;
+
+/**
+ * The daemon-hosted-Cortex client, when one is available.
+ *
+ * Probes the daemon socket + `daemon.status.cortex_running` on first use.
+ * A positive result is sticky for the MCP server's lifetime (the daemon owns
+ * the single Cortex; flip-flopping transports mid-session would be worse than
+ * failing loudly if the daemon goes away). A negative result is re-probed
+ * after a short TTL so starting the daemon later is picked up.
+ */
+export async function daemonCortex(): Promise<DaemonClient | null> {
+  if (process.env.CELLAR_MCP_DAEMON === "0") return null;
+  if (stickyClient) return stickyClient;
+  if (Date.now() - lastNegativeProbeAt < NEGATIVE_PROBE_TTL_MS) return null;
+  if (probeInFlight) return probeInFlight;
+  probeInFlight = (async () => {
+    const client = new DaemonClient();
+    try {
+      const status = await client.call<{ cortex_running?: boolean }>(
+        "daemon.status",
+        undefined,
+        PROBE_CALL_TIMEOUT_MS,
+      );
+      if (status?.cortex_running === true) {
+        stickyClient = client;
+        return client;
+      }
+    } catch {
+      // No daemon / no socket — fall through to napi.
+    }
+    lastNegativeProbeAt = Date.now();
+    return null;
+  })();
+  try {
+    return await probeInFlight;
+  } finally {
+    probeInFlight = null;
+  }
+}
+
+/** Sticky sync accessor — non-null once a probe has succeeded. */
+export function daemonCortexKnown(): DaemonClient | null {
+  return stickyClient;
+}
+
+/** Mirror of the IPC `CortexActResult` (engine `ActionResult`). */
+export type DaemonActResult = {
+  success: boolean;
+  error?: string | null;
+  data?: unknown;
+};
+
+/** Execute one canonical action on the daemon-hosted Cortex. */
+export async function daemonAct(client: DaemonClient, action: unknown): Promise<DaemonActResult> {
+  return client.call<DaemonActResult>("cortex.act", { action }, ACT_CALL_TIMEOUT_MS);
+}
+
+/** Read the daemon Cortex's mental-model snapshot (raw JSON object). */
+export async function daemonModel(client: DaemonClient): Promise<unknown> {
+  const res = await client.call<{ model: unknown }>("cortex.perceive.read");
+  return res.model;
+}

--- a/mcp-server/src/tools/cel-act.ts
+++ b/mcp-server/src/tools/cel-act.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { Cel } from "@cellar/agent/runtime";
 import { sleep, resolveCoords, contextReferenceSchema, textResult, errorResult, axPermissionGuard } from "./shared.js";
 import { ensureFrontmost } from "../helpers/focus.js";
+import { daemonAct, daemonCortex } from "../helpers/daemon.js";
 
 const actionTypes = [
   "click",
@@ -521,6 +522,14 @@ type ActionReceipt = {
   evidence: Array<{ kind: string; value?: unknown }>;
   summary: string;
   error?: string;
+  /**
+   * The canonical, core-emitted execution receipt (cel-contracts), when the
+   * cortex dispatch path produced one. Present for canonical routes (navigate,
+   * cells, adapter, `dom:*` ax_action/set_value); absent for raw native
+   * primitives that bypass `cortex.execute`. When present, `dispatch_path`
+   * above reflects its real `route` rather than the static guess.
+   */
+  core?: CoreReceipt;
 };
 
 let receiptCounter = 0;
@@ -651,26 +660,94 @@ function evidenceForAction(action: SingleAction): ActionReceipt["evidence"] {
   return evidence;
 }
 
+/**
+ * The canonical, core-emitted ExecutionReceipt (cel-contracts), transported on
+ * `StepResult.data._cel_receipt` by the cortex dispatch path (PR #163/#164).
+ * Typed loosely here — the MCP server forwards it verbatim; the Rust crate owns
+ * the shape.
+ */
+type CoreReceipt = Record<string, unknown>;
+
+/** A dispatched action's human summary plus the core receipt when one was emitted. */
+type ActionExec = { summary: string; receipt: CoreReceipt | null };
+
+/**
+ * Pull the core receipt out of a canonical `StepResult.data`, separating it
+ * from the action's own payload so summaries that dump `data` stay clean.
+ */
+function splitReceipt(step: { data?: unknown } | null | undefined): {
+  data: unknown;
+  receipt: CoreReceipt | null;
+} {
+  const data = step?.data;
+  if (data && typeof data === "object" && "_cel_receipt" in data) {
+    const { _cel_receipt, ...rest } = data as Record<string, unknown>;
+    return { data: rest, receipt: (_cel_receipt as CoreReceipt) ?? null };
+  }
+  return { data: data ?? {}, receipt: null };
+}
+
+/** Extract just the core receipt (summary built from named fields, not a dump). */
+function receiptOf(step: { data?: unknown } | null | undefined): CoreReceipt | null {
+  return splitReceipt(step).receipt;
+}
+
+/** Map the core receipt's real `route` to the MCP dispatch-path vocabulary. */
+function coreRouteToDispatchPath(receipt: CoreReceipt | null): ActionDispatchPath | null {
+  const route = receipt?.route as { route?: string } | undefined;
+  switch (route?.route) {
+    case "cdp":
+      return "cdp";
+    case "accessibility":
+      return "accessibility";
+    case "native_input":
+      return "native_input";
+    case "adapter":
+      return "adapter";
+    case "focus":
+      return "focus";
+    default:
+      return null;
+  }
+}
+
 function buildReceipt(
   action: SingleAction,
   requestedAtMs: number,
   status: ActionReceiptStatus,
   summary: string,
   error?: string,
+  coreReceipt?: CoreReceipt | null,
 ): ActionReceipt {
+  const core = coreReceipt ?? null;
+  // When the core emitted a receipt, its `route` is the REAL dispatch path and
+  // overrides the static `dispatchPathForAction` guess (which mislabels e.g. a
+  // `dom:*` set_value, routed via CDP, as "accessibility").
+  const corePath = coreRouteToDispatchPath(core);
+  const evidence = evidenceForAction(action);
+  if (core) {
+    if (typeof core.receipt_id === "string") {
+      evidence.push({ kind: "core_receipt_id", value: core.receipt_id });
+    }
+    const observed = core.observed_effect as { status?: string } | undefined;
+    if (observed?.status) {
+      evidence.push({ kind: "observed_effect", value: observed.status });
+    }
+  }
   return {
     id: nextReceiptId(action.action),
     action: action.action,
     requested_at: new Date(requestedAtMs).toISOString(),
     completed_at: new Date().toISOString(),
     status,
-    dispatch_path: dispatchPathForAction(action),
+    dispatch_path: corePath ?? dispatchPathForAction(action),
     mutates_state: mutatesState(action),
     requires_verification: requiresVerification(action),
     verification: verificationMode(action),
-    evidence: evidenceForAction(action),
+    evidence,
     summary,
     ...(error ? { error } : {}),
+    ...(core ? { core } : {}),
   };
 }
 
@@ -867,16 +944,45 @@ function executeSingle(cel: Cel, action: SingleAction): string {
 }
 
 async function ensureCortexForCanonicalAction(cel: Cel): Promise<void> {
+  // Two-Cortex guard (cellar-daemon-cortex.md Phase C): when the daemon hosts
+  // the single live Cortex, canonical actions proxy to it over IPC and the
+  // napi Cortex must NOT boot — two Cortexes would fight over one AX tree
+  // and input focus.
+  if (await daemonCortex()) {
+    return;
+  }
   if (!cel.isCortexRunning()) {
     cel.bootCortex();
     await sleep(700);
   }
 }
 
+/**
+ * Route a canonical step to whichever Cortex owns execution: the
+ * daemon-hosted one over IPC (`cortex.act`) when available, else the
+ * in-process napi Cortex (`canonicalExecuteStep`). Both paths return the
+ * engine's `ActionResult` shape with the core-emitted `ExecutionReceipt`
+ * riding on `data._cel_receipt`, so receipt handling downstream is
+ * transport-agnostic.
+ */
+async function canonicalStep(
+  cel: Cel,
+  step: { purpose: string; kind: string; action: Record<string, unknown> },
+): Promise<{ status: string; data?: unknown; message?: string }> {
+  const daemon = await daemonCortex();
+  if (daemon) {
+    const res = await daemonAct(daemon, step.action);
+    return res.success
+      ? { status: "ok", data: res.data ?? {} }
+      : { status: "err", message: res.error ?? "cortex.act failed" };
+  }
+  return cel.canonicalExecuteStep(step as Parameters<Cel["canonicalExecuteStep"]>[0]);
+}
+
 async function executeSpreadsheetAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "write_cells" | "read_cells" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
   const canonicalAction = action.action === "write_cells"
     ? {
@@ -895,7 +1001,7 @@ async function executeSpreadsheetAction(
         cell_refs: action.cell_refs,
       };
 
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose:
       action.action === "write_cells"
         ? "Write spreadsheet cells through the deterministic Numbers backend"
@@ -907,7 +1013,8 @@ async function executeSpreadsheetAction(
   if (result.status !== "ok") {
     throw new Error(result.message);
   }
-  return JSON.stringify(result.data ?? {}, null, 2);
+  const { data, receipt } = splitReceipt(result);
+  return { summary: JSON.stringify(data, null, 2), receipt };
 }
 
 /**
@@ -923,9 +1030,9 @@ async function executeSpreadsheetAction(
 async function executeNavigateAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "navigate" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `Navigate the focused browser tab to ${action.url}`,
     kind: "deterministic",
     action: {
@@ -947,7 +1054,10 @@ async function executeNavigateAction(
   };
   const finalUrl = data.final_url ?? action.url;
   const loadMs = typeof data.load_ms === "number" ? data.load_ms : 0;
-  return `Navigated to ${action.url} (final: ${finalUrl}, ${loadMs}ms)`;
+  return {
+    summary: `Navigated to ${action.url} (final: ${finalUrl}, ${loadMs}ms)`,
+    receipt: receiptOf(result),
+  };
 }
 
 /**
@@ -958,9 +1068,9 @@ async function executeNavigateAction(
 async function executeWindowAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "window" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: action.preset ? `Window preset ${action.preset}` : `Window ${action.op ?? "op"}`,
     kind: "deterministic",
     action: {
@@ -989,11 +1099,11 @@ async function executeWindowAction(
     minimized?: boolean;
   };
   const what = action.preset ? `preset ${action.preset}` : (action.op ?? "op");
-  return (
+  const summary =
     `Window ${what} → ${Math.round(g.x ?? 0)},${Math.round(g.y ?? 0)} ` +
     `${Math.round(g.width ?? 0)}×${Math.round(g.height ?? 0)}` +
-    (g.minimized ? " (minimized)" : "")
-  );
+    (g.minimized ? " (minimized)" : "");
+  return { summary, receipt: receiptOf(result) };
 }
 
 /**
@@ -1003,9 +1113,9 @@ async function executeWindowAction(
 async function executeDialogAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "dialog" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `Dialog ${action.op}${action.button ? ` "${action.button}"` : ""}`,
     kind: "deterministic",
     action: {
@@ -1021,9 +1131,15 @@ async function executeDialogAction(
   }
   if (action.op === "list") {
     const d = (result.data ?? {}) as { buttons?: string[]; fields?: string[] };
-    return `Dialog: buttons [${(d.buttons ?? []).join(", ")}]; fields [${(d.fields ?? []).join(" | ")}]`;
+    return {
+      summary: `Dialog: buttons [${(d.buttons ?? []).join(", ")}]; fields [${(d.fields ?? []).join(" | ")}]`,
+      receipt: receiptOf(result),
+    };
   }
-  return `Dialog ${action.op}${action.button ? ` "${action.button}"` : ""} ok`;
+  return {
+    summary: `Dialog ${action.op}${action.button ? ` "${action.button}"` : ""} ok`,
+    receipt: receiptOf(result),
+  };
 }
 
 /**
@@ -1033,9 +1149,9 @@ async function executeDialogAction(
 async function executeDockAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "dock" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `Dock ${action.op}${action.name ? ` "${action.name}"` : ""}`,
     kind: "deterministic",
     action: {
@@ -1049,9 +1165,15 @@ async function executeDockAction(
   }
   if (action.op === "list") {
     const d = (result.data ?? {}) as { items?: string[] };
-    return `Dock items: [${(d.items ?? []).join(", ")}]`;
+    return {
+      summary: `Dock items: [${(d.items ?? []).join(", ")}]`,
+      receipt: receiptOf(result),
+    };
   }
-  return `Dock ${action.op}${action.name ? ` "${action.name}"` : ""} ok`;
+  return {
+    summary: `Dock ${action.op}${action.name ? ` "${action.name}"` : ""} ok`,
+    receipt: receiptOf(result),
+  };
 }
 
 /**
@@ -1061,9 +1183,9 @@ async function executeDockAction(
 async function executeMenuExtraAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "menu_extra" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `MenuExtra ${action.op}${action.name ? ` "${action.name}"` : ""}`,
     kind: "deterministic",
     action: {
@@ -1077,9 +1199,15 @@ async function executeMenuExtraAction(
   }
   if (action.op === "list") {
     const d = (result.data ?? {}) as { items?: string[] };
-    return `Menu extras: [${(d.items ?? []).join(", ")}]`;
+    return {
+      summary: `Menu extras: [${(d.items ?? []).join(", ")}]`,
+      receipt: receiptOf(result),
+    };
   }
-  return `MenuExtra ${action.op}${action.name ? ` "${action.name}"` : ""} ok`;
+  return {
+    summary: `MenuExtra ${action.op}${action.name ? ` "${action.name}"` : ""} ok`,
+    receipt: receiptOf(result),
+  };
 }
 
 /**
@@ -1095,10 +1223,10 @@ async function executeMenuExtraAction(
 async function executeAdapterAction(
   cel: Cel,
   action: Extract<SingleAction, { action: "adapter_action" }>,
-): Promise<string> {
+): Promise<ActionExec> {
   await ensureCortexForCanonicalAction(cel);
   const params = (action.params ?? {}) as Record<string, unknown>;
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `Adapter ${action.adapter}.${action.adapter_op}`,
     kind: "deterministic",
     action: {
@@ -1111,7 +1239,8 @@ async function executeAdapterAction(
   if (result.status !== "ok") {
     throw new Error(result.message);
   }
-  return JSON.stringify(result.data ?? {}, null, 2);
+  const { data, receipt } = splitReceipt(result);
+  return { summary: JSON.stringify(data, null, 2), receipt };
 }
 
 /**
@@ -1132,7 +1261,7 @@ async function executeAdapterAction(
 async function tryRouteDomViaCanonical(
   cel: Cel,
   action: SingleAction,
-): Promise<string | null> {
+): Promise<ActionExec | null> {
   if (action.action !== "ax_action" && action.action !== "set_value") {
     return null;
   }
@@ -1157,7 +1286,7 @@ async function tryRouteDomViaCanonical(
         label: null,
         role_hint: null,
       };
-  const result = await cel.canonicalExecuteStep({
+  const result = await canonicalStep(cel, {
     purpose: `${action.action} on ${action.element_id} via CDP`,
     kind: "deterministic",
     action: canonicalAction,
@@ -1165,12 +1294,13 @@ async function tryRouteDomViaCanonical(
   if (result.status !== "ok") {
     throw new Error(result.message);
   }
-  return action.action === "set_value"
+  const summary = action.action === "set_value"
     ? `Set value "${action.value}" on element ${action.element_id} (via CDP)`
     : `Performed ${action.ax_action} on element ${action.element_id} (via CDP)`;
+  return { summary, receipt: receiptOf(result) };
 }
 
-async function executeAction(cel: Cel, action: SingleAction): Promise<string> {
+async function executeAction(cel: Cel, action: SingleAction): Promise<ActionExec> {
   if (action.action === "focus_lock") {
     const focus = await ensureFrontmost(action.app_name, action.timeout_ms);
     if (!focus.matchesTarget) {
@@ -1184,19 +1314,25 @@ async function executeAction(cel: Cel, action: SingleAction): Promise<string> {
     const replacedSuffix = previous && previous !== action.app_name
       ? `, replaced previous lock on ${previous}`
       : "";
-    return focus.activated
-      ? `Focus locked to ${action.app_name} (activated in ${focus.elapsedMs}ms, was ${focus.previousFrontmost}${replacedSuffix})`
-      : `Focus locked to ${action.app_name} (was already frontmost${replacedSuffix})`;
+    return {
+      summary: focus.activated
+        ? `Focus locked to ${action.app_name} (activated in ${focus.elapsedMs}ms, was ${focus.previousFrontmost}${replacedSuffix})`
+        : `Focus locked to ${action.app_name} (was already frontmost${replacedSuffix})`,
+      receipt: null,
+    };
   }
   if (action.action === "focus_release") {
     const previous = focusLock?.appName ?? null;
     focusLock = null;
-    return previous ? `Focus released (was locked to ${previous})` : "Focus released (no active lock)";
+    return {
+      summary: previous ? `Focus released (was locked to ${previous})` : "Focus released (no active lock)",
+      receipt: null,
+    };
   }
   if (action.action === "cdp_eval") {
     const result = await cel.cdpEvaluate(action.expression);
     const resultStr = result === undefined || result === null ? "void" : JSON.stringify(result);
-    return `CDP eval result: ${resultStr}`;
+    return { summary: `CDP eval result: ${resultStr}`, receipt: null };
   }
   if (action.action === "navigate") {
     return executeNavigateAction(cel, action);
@@ -1250,7 +1386,10 @@ async function executeAction(cel: Cel, action: SingleAction): Promise<string> {
       if (pid != null) {
         const bg = executeSingleBackground(cel, action, pid);
         if (bg != null) {
-          return `${bg} (focus: background → ${effectiveTarget} pid ${pid}, not activated)`;
+          return {
+            summary: `${bg} (focus: background → ${effectiveTarget} pid ${pid}, not activated)`,
+            receipt: null,
+          };
         }
       }
       // pid unresolved or no background variant → fall through to foreground.
@@ -1261,12 +1400,18 @@ async function executeAction(cel: Cel, action: SingleAction): Promise<string> {
       const result = executeSingle(cel, action);
       const source = explicitTarget ? "target_app" : "focus_lock";
       if (focus?.activated) {
-        return `${result} (focus[${source}]: activated ${focus.frontmost} in ${focus.elapsedMs}ms, was ${focus.previousFrontmost})`;
+        return {
+          summary: `${result} (focus[${source}]: activated ${focus.frontmost} in ${focus.elapsedMs}ms, was ${focus.previousFrontmost})`,
+          receipt: null,
+        };
       }
-      return `${result} (focus[${source}]: ${focus?.frontmost} already frontmost)`;
+      return {
+        summary: `${result} (focus[${source}]: ${focus?.frontmost} already frontmost)`,
+        receipt: null,
+      };
     }
   }
-  return executeSingle(cel, action);
+  return { summary: executeSingle(cel, action), receipt: null };
 }
 
 export async function handleCelAct(cel: Cel, rawArgs: unknown) {
@@ -1287,9 +1432,9 @@ export async function handleCelAct(cel: Cel, rawArgs: unknown) {
       const action = args.actions[i];
       const requestedAtMs = Date.now();
       try {
-        const result = await executeAction(cel, action);
-        results.push(result);
-        receipts.push(buildReceipt(action, requestedAtMs, "ok", result));
+        const exec = await executeAction(cel, action);
+        results.push(exec.summary);
+        receipts.push(buildReceipt(action, requestedAtMs, "ok", exec.summary, undefined, exec.receipt));
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         receipts.push(buildReceipt(action, requestedAtMs, "error", error, error));
@@ -1305,11 +1450,11 @@ export async function handleCelAct(cel: Cel, rawArgs: unknown) {
   const action = args as SingleAction;
   const requestedAtMs = Date.now();
   try {
-    const result = await executeAction(cel, action);
+    const exec = await executeAction(cel, action);
     return textResult({
       success: true,
-      result,
-      receipt: buildReceipt(action, requestedAtMs, "ok", result),
+      result: exec.summary,
+      receipt: buildReceipt(action, requestedAtMs, "ok", exec.summary, undefined, exec.receipt),
     });
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);

--- a/mcp-server/src/tools/cel-perceive.ts
+++ b/mcp-server/src/tools/cel-perceive.ts
@@ -3,6 +3,8 @@ import type { Cel } from "@cellar/agent/runtime";
 import { normalizeCortexAnomalies, normalizeCortexModel } from "@cellar/agent/runtime";
 import { textResult, errorResult, sleep, axPermissionGuard } from "./shared.js";
 import { getFrontmost } from "../helpers/focus.js";
+import { readFileSync } from "node:fs";
+import { daemonCortex, daemonCortexKnown, daemonModel } from "../helpers/daemon.js";
 
 // ─── Schema ─────────────────────────────────────────────────────────────────
 
@@ -135,9 +137,87 @@ interface SessionState {
   totalReads: number;
   /** PR2 opt-in: when set, checkpoint + stop write a cortex memory under this workflow_id. */
   memoryWorkflowId?: string;
+  /** Run id scoping this session's execution receipts (Receipt-Backed Run
+   * Timeline). Set on start; used to surface the run's recent receipts on read. */
+  runId?: string;
 }
 
 let session: SessionState | null = null;
+
+/**
+ * Whether a Cortex is available to this session — the daemon-hosted one
+ * (Phase C proxy) or the in-process napi one.
+ */
+function cortexAvailable(cel: Cel): boolean {
+  return daemonCortexKnown() !== null || cel.isCortexRunning();
+}
+
+/**
+ * The current Cortex mental model, from whichever Cortex owns perception:
+ * the daemon-hosted one over IPC when proxying, else the in-process napi
+ * one. Returns null when neither is reachable.
+ */
+async function currentModel(cel: Cel): Promise<ReturnType<typeof normalizeCortexModel>> {
+  const daemon = daemonCortexKnown();
+  if (daemon) {
+    try {
+      return normalizeCortexModel(await daemonModel(daemon));
+    } catch {
+      return null;
+    }
+  }
+  if (!cel.isCortexRunning()) return null;
+  return normalizeCortexModel(cel.readCortexModel());
+}
+
+/**
+ * Pending anomalies, when the in-process Cortex owns perception. The daemon
+ * path doesn't expose anomaly consumption yet (Phase C limitation) — anomaly
+ * counts still surface via the model's `anomalyQueue`.
+ */
+function currentAnomalies(cel: Cel): ReturnType<typeof normalizeCortexAnomalies> {
+  if (daemonCortexKnown()) return [];
+  return normalizeCortexAnomalies(cel.consumeCortexAnomalies());
+}
+
+/**
+ * Recent execution receipts for the active run, read from the timeline file the
+ * cortex appends to (`~/.cellar/runs/<run_id>.jsonl`, Receipt-Backed Run
+ * Timeline). Returns the last `limit` as compact rows so the agent's next step
+ * is informed by its own recent actions + observed-effect verdicts. Best-effort:
+ * returns undefined when there's no file yet, so the field is simply omitted.
+ */
+function recentRunReceipts(
+  runId: string | undefined,
+  limit = 8,
+): Array<Record<string, unknown>> | undefined {
+  if (!runId) return undefined;
+  const home = process.env.HOME;
+  if (!home) return undefined;
+  // Mirror the cortex writer's filename sanitization (cel-cortex receipt.rs).
+  const safe = runId.replace(/[^A-Za-z0-9_-]/g, "_");
+  try {
+    const raw = readFileSync(`${home}/.cellar/runs/${safe}.jsonl`, "utf8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    return lines.slice(-limit).map((l) => {
+      try {
+        const r = JSON.parse(l) as Record<string, any>;
+        return {
+          action: r.action_kind,
+          route: r.route?.route ?? null,
+          status: r.status,
+          effect: r.observed_effect?.status ?? null,
+          duration_ms: r.duration_ms,
+          target: r.target ?? null,
+        };
+      } catch {
+        return { raw: l };
+      }
+    });
+  } catch {
+    return undefined;
+  }
+}
 
 // ─── Constraint helpers ─────────────────────────────────────────────────────
 
@@ -202,12 +282,16 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
   try {
     switch (args.mode) {
       case "start": {
-        if (session && cel.isCortexRunning()) {
+        // Two-Cortex guard (cellar-daemon-cortex.md Phase C): when the daemon
+        // hosts the single live Cortex, the session drives it over IPC and the
+        // napi Cortex must NOT boot.
+        const daemon = await daemonCortex();
+        if (session && (daemon !== null || cel.isCortexRunning())) {
           return errorResult("A perception session is already active. Call stop first.");
         }
 
-        // Boot the Rust Cortex if not already running
-        if (!cel.isCortexRunning()) {
+        // Boot the in-process Rust Cortex only when no daemon hosts one.
+        if (daemon === null && !cel.isCortexRunning()) {
           cel.bootCortex();
         }
 
@@ -236,7 +320,19 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           memoryWorkflowId: enableMemory ? args.workflow_id : undefined,
         };
 
-        const model = normalizeCortexModel(cel.readCortexModel());
+        // Scope execution receipts emitted during this perception session to a
+        // run id so they group in the run timeline (Receipt-Backed Run Timeline)
+        // AND so `read` can surface this run's recent receipts back to the agent.
+        // Prefer the caller's workflow_id; fall back to a per-session id.
+        const runId = args.workflow_id ?? `perceive-${session.startTime}`;
+        session.runId = runId;
+        if (daemon) {
+          await daemon.call("cortex.perceive.start", { run_id: runId });
+        } else {
+          cel.cortexSetRunId(runId);
+        }
+
+        const model = await currentModel(cel);
         return textResult({
           success: true,
           initialContext: {
@@ -251,6 +347,20 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
       case "stop": {
         if (!session) {
           return errorResult("No active perception session to stop.");
+        }
+
+        // End the run scope — one-off actions after stop won't carry this run id.
+        {
+          const daemon = daemonCortexKnown();
+          if (daemon) {
+            try {
+              await daemon.call("cortex.perceive.stop");
+            } catch {
+              // Daemon went away mid-session — nothing to clear.
+            }
+          } else {
+            cel.cortexClearRunId();
+          }
         }
 
         const successfulActions = session.actionLog.filter((a) => a.landed).length;
@@ -301,18 +411,23 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           memory_id: finalMemoryId ?? null,
         };
 
-        cel.stopCortex();
+        // The napi Cortex belongs to this session — stop it. A daemon-hosted
+        // Cortex belongs to the daemon and keeps running; the session only
+        // ends its run scope (above).
+        if (daemonCortexKnown() === null) {
+          cel.stopCortex();
+        }
         session = null;
         return textResult(summary);
       }
 
       case "read": {
-        if (!session || !cel.isCortexRunning()) {
+        if (!session || !cortexAvailable(cel)) {
           return errorResult("No active perception session. Call start first.");
         }
         session.totalReads++;
 
-        const model = normalizeCortexModel(cel.readCortexModel());
+        const model = await currentModel(cel);
         if (!model) return errorResult("Failed to read Cortex model");
 
         const ctx = model.currentContext;
@@ -320,7 +435,7 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           (el: any) => el.state?.enabled && el.state?.visible && (el.actions?.length ?? 0) > 0,
         ).length;
 
-        const anomalies = normalizeCortexAnomalies(cel.consumeCortexAnomalies());
+        const anomalies = currentAnomalies(cel);
         const recentDiffs = model.recentDiffs ?? [];
         const latestDiff = recentDiffs.length > 0 ? recentDiffs[recentDiffs.length - 1] : null;
 
@@ -393,11 +508,15 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
             ? session.constraints.map((c) => ({ text: c.text, kind: c.kind, satisfied: c.satisfied }))
             : undefined,
           checkpointSummary,
+          // Receipt-Backed Run Timeline: the agent's own recent actions this
+          // run — real dispatch route + observed-effect verdict — so its next
+          // step is informed by what just happened (and whether it worked).
+          recentReceipts: recentRunReceipts(session.runId),
         });
       }
 
       case "feed": {
-        if (!session || !cel.isCortexRunning()) {
+        if (!session || !cortexAvailable(cel)) {
           return errorResult("No active perception session. Call start first.");
         }
 
@@ -406,7 +525,7 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
         // and these two disagree, it's strong evidence the event landed in a
         // different window than the cortex was tracking — almost always a
         // focus-race symptom worth surfacing structurally.
-        const preModel = normalizeCortexModel(cel.readCortexModel());
+        const preModel = await currentModel(cel);
         const expectedApp = preModel?.currentContext?.app ?? null;
         let actualApp: string | null = null;
         try {
@@ -415,14 +534,17 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           // osascript can fail in headless test envs — degrade silently.
         }
 
-        // Notify the Rust Cortex
-        cel.notifyCortexAction(args.action);
+        // Notify the Rust Cortex (napi-local model touch; the daemon-hosted
+        // Cortex sees activity through its own tick loop).
+        if (daemonCortexKnown() === null) {
+          cel.notifyCortexAction(args.action);
+        }
 
         // Wait for 3 ticks (600ms)
         await sleep(600);
 
-        const postModel = normalizeCortexModel(cel.readCortexModel());
-        const anomalies = normalizeCortexAnomalies(cel.consumeCortexAnomalies());
+        const postModel = await currentModel(cel);
+        const anomalies = currentAnomalies(cel);
 
         const latestDiff = (postModel?.recentDiffs ?? []).slice(-1)[0] ?? null;
         const actionLanded = latestDiff
@@ -461,10 +583,12 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
           checkConstraintSatisfaction(session.constraints, args.action, obs);
         }
 
-        if (actionLanded) {
-          cel.reportCortexActionSuccess();
-        } else {
-          cel.reportCortexActionFailure();
+        if (daemonCortexKnown() === null) {
+          if (actionLanded) {
+            cel.reportCortexActionSuccess();
+          } else {
+            cel.reportCortexActionFailure();
+          }
         }
 
         return textResult({
@@ -540,11 +664,11 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
       }
 
       case "status": {
-        if (!cel.isCortexRunning()) {
+        if (!cortexAvailable(cel)) {
           return textResult({ active: false, message: "No cortex is running. Call start to boot one." });
         }
 
-        const model = normalizeCortexModel(cel.readCortexModel());
+        const model = await currentModel(cel);
         const ctx = model?.currentContext;
         const actionableCount = (ctx?.elements ?? []).filter(
           (el: any) => el.state?.enabled && el.state?.visible && (el.actions?.length ?? 0) > 0,
@@ -571,6 +695,16 @@ export async function handleCelPerceive(cel: Cel, args: Input) {
       case "plan_view": {
         // Standalone — does not require a perception session, but does
         // require a booted cortex (boot it on demand if needed).
+        if (daemonCortexKnown()) {
+          // plan_view runs in-process against the napi Cortex; booting one
+          // alongside the daemon-hosted Cortex would violate the two-Cortex
+          // guard. IPC plan_view is a later phase.
+          return errorResult(
+            "plan_view is not available while the daemon hosts the live Cortex " +
+              "(it would boot a second in-process Cortex). Use cel_perceive read for " +
+              "the current model, or run without CELLAR_DAEMON_CORTEX.",
+          );
+        }
         if (!cel.isCortexRunning()) {
           cel.bootCortex();
         }

--- a/mcp-server/src/tools/cel-see.ts
+++ b/mcp-server/src/tools/cel-see.ts
@@ -7,6 +7,7 @@ import {
   getCanonicalCdpState,
   normalizeCortexModel,
 } from "@cellar/agent/runtime";
+import { daemonCortex, daemonCortexKnown, daemonModel } from "../helpers/daemon.js";
 import {
   sleep,
   buildUrlMap,
@@ -247,7 +248,18 @@ export async function handleCelSee(cel: Cel, args: Input) {
         let cortexConfidence: number | undefined;
         let cortexModel: ReturnType<typeof normalizeCortexModel> | null = null;
 
-        if (cel.isCortexRunning()) {
+        const daemon = await daemonCortex();
+        if (daemon) {
+          // The daemon hosts the live Cortex (cellar-daemon-cortex.md Phase C)
+          // — read its model over IPC instead of the napi one.
+          try {
+            cortexModel = normalizeCortexModel(await daemonModel(daemon));
+          } catch {
+            cortexModel = null;
+          }
+          ctx = cortexModel?.currentContext ?? cel.getContext();
+          cortexConfidence = cortexModel?.confidence;
+        } else if (cel.isCortexRunning()) {
           cortexModel = normalizeCortexModel(cel.readCortexModel());
           ctx = cortexModel?.currentContext ?? cel.getContext();
           cortexConfidence = cortexModel?.confidence;
@@ -667,7 +679,7 @@ export async function handleCelSee(cel: Cel, args: Input) {
       }
 
       case "watch": {
-        if (cel.isCortexRunning()) {
+        if (daemonCortexKnown() !== null || cel.isCortexRunning()) {
           return errorResult(
             "Cortex is active. Use cel_perceive read instead of cel_see watch.",
           );

--- a/mcp-server/src/tools/cel-think.ts
+++ b/mcp-server/src/tools/cel-think.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { Cel, PlannerStepRecord, PlannedAction, ScreenContext } from "@cellar/agent/runtime";
 import { textResult, errorResult } from "./shared.js";
 import { ensureCdpChrome } from "../server.js";
+import { daemonCortexKnown } from "../helpers/daemon.js";
 
 export const celThinkSchema = z.discriminatedUnion("mode", [
   // --- plan ---
@@ -412,6 +413,17 @@ export async function handleCelThink(cel: Cel, args: Input) {
         // CanonicalGoalRunner::run. No legacy flags, no per-invocation
         // routing decisions — the canonical agent is one shape for
         // every caller. See docs/canonical-agent-plan.md.
+        if (daemonCortexKnown() !== null) {
+          // run_goal drives the in-process canonical runner against the napi
+          // Cortex; booting one alongside the daemon-hosted Cortex would
+          // violate the two-Cortex guard. Goal runs proxy to the daemon's
+          // agent in a later phase (`agent.run`).
+          return errorResult(
+            "run_goal is not available while the daemon hosts the live Cortex. " +
+              "Drive actions via cel_act (proxied to the daemon), or run without " +
+              "CELLAR_DAEMON_CORTEX.",
+          );
+        }
         if (!cel.isCortexRunning()) {
           cel.bootCortex();
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3795,7 +3795,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.39.0
       '@browserbasehq/sdk': 2.10.0
       '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0)))(ws@8.21.0(bufferutil@4.1.0))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(ws@8.21.0(bufferutil@4.1.0)))(ws@8.21.0(bufferutil@4.1.0))
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       ai: 5.0.157(zod@4.3.6)
       deepmerge: 4.3.1
@@ -4171,7 +4171,7 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0)))(ws@8.21.0(bufferutil@4.1.0))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(ws@8.21.0(bufferutil@4.1.0)))(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@langchain/core': 0.3.80(openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0))
       js-tiktoken: 1.0.21


### PR DESCRIPTION
Backports the private batch since #91: **14 PRs (#163–#176)**.

**Receipt-Backed Run Timeline (v1 spine):** canonical `ExecutionReceipt` (cel-contracts) emitted from CDP + native dispatch; MCP `cel_act` real route; run-scoping; `cellar timeline`; cel_perceive recent-receipts; cel-brief `ReceiptSource`; gateway receipts for governed actions.

**Daemon-hosted Cortex (A0–E):** `cel-boot` shared boot helper; daemon hosts the single live Cortex (gated, default off); IPC `cortex.see/act/perceive.*`; MCP proxies to the daemon (two-Cortex guard + napi fallback); `ReceiptSource`+`PerceptionSource` in the daemon brief; `docs/daemon-cortex.md`.

Generated by `sync-to-oss.sh` (exclusions + OSS transforms + secrets scan + workspace build verification green). 45 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)